### PR TITLE
Backport "Enable PC tests in test_windows_fast" to LTS

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -175,7 +175,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Test
-        run: sbt ";scala3-bootstrapped/compile; scala3-bootstrapped/testCompilation"
+        run: sbt ";scala3-bootstrapped/compile; scala3-bootstrapped/testCompilation; scala3-presentation-compiler-bootstrapped/test; scala3-language-server/test"
         shell: cmd
 
       - name: build binary


### PR DESCRIPTION
Backports #21626 to the 3.3.5.

PR submitted by the release tooling.
[skip ci]