### PR TITLE
Backport "Filter opaque modifier from object documentation" to LTS

### DIFF
--- a/scaladoc-testcases/src/tests/opaqueTypes.scala
+++ b/scaladoc-testcases/src/tests/opaqueTypes.scala
@@ -7,3 +7,7 @@ opaque type Permissions
 opaque type PermissionChoice
  = Int
 //opaque type Permission <: Permissions & PermissionChoice = Int TODO: #112
+
+object Foo:
+  opaque type Bar
+   = Int

--- a/scaladoc/src/dotty/tools/scaladoc/tasty/ClassLikeSupport.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/ClassLikeSupport.scala
@@ -314,7 +314,7 @@ trait ClassLikeSupport:
   def parseObject(classDef: ClassDef, signatureOnly: Boolean = false): Member =
     mkClass(classDef)(
       // All objects are final so we do not need final modifier!
-      modifiers = classDef.symbol.getExtraModifiers().filter(_ != Modifier.Final),
+      modifiers = classDef.symbol.getExtraModifiers().filter(mod => mod != Modifier.Final && mod != Modifier.Opaque),
       signatureOnly = signatureOnly
     )
 


### PR DESCRIPTION
Backports #21640 to the 3.3.5.

PR submitted by the release tooling.
[skip ci]