### PR TITLE
Backport "Add better error reporting for inlined non-immutable paths" to LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -1797,12 +1797,24 @@ class SuperCallsNotAllowedInlineable(symbol: Symbol)(using Context)
 }
 
 class NotAPath(tp: Type, usage: String)(using Context) extends TypeMsg(NotAPathID):
-  def msg(using Context) = i"$tp is not a valid $usage, since it is not an immutable path"
+  def msg(using Context) = i"$tp is not a valid $usage, since it is not an immutable path" + inlineParamAddendum
   def explain(using Context) =
     i"""An immutable path is
         | - a reference to an immutable value, or
         | - a reference to `this`, or
         | - a selection of an immutable path with an immutable value."""
+
+  def inlineParamAddendum(using Context) =
+    val sym = tp.termSymbol
+    if sym.isAllOf(Flags.InlineParam) then
+      i"""
+         |Inline parameters are not considered immutable paths and cannot be used as
+         |singleton types. 
+         | 
+         |Hint: Removing the `inline` qualifier from the `${sym.name}` parameter
+         |may help resolve this issue."""
+    else ""
+    
 
 class WrongNumberOfParameters(tree: untpd.Tree, foundCount: Int, pt: Type, expectedCount: Int)(using Context)
   extends SyntaxMsg(WrongNumberOfParametersID) {

--- a/tests/neg/21538.check
+++ b/tests/neg/21538.check
@@ -1,0 +1,11 @@
+-- [E083] Type Error: tests/neg/21538.scala:3:45 -----------------------------------------------------------------------
+3 |inline def foo[V](inline value: V)(using Bar[value.type]) : Unit = {} // error
+  |                                             ^^^^^^^^^^
+  |                                      (value : V) is not a valid singleton type, since it is not an immutable path
+  |                                      Inline parameters are not considered immutable paths and cannot be used as
+  |                                      singleton types. 
+  |                                       
+  |                                      Hint: Removing the `inline` qualifier from the `value` parameter
+  |                                      may help resolve this issue.
+  |
+  | longer explanation available when compiling with `-explain`

--- a/tests/neg/21538.scala
+++ b/tests/neg/21538.scala
@@ -1,0 +1,3 @@
+trait Bar[T]
+given [T]: Bar[T] with {}
+inline def foo[V](inline value: V)(using Bar[value.type]) : Unit = {} // error


### PR DESCRIPTION
Backports #21639 to the 3.3.5.

PR submitted by the release tooling.
[skip ci]