### PR TITLE
Backport "Bump webrick from 1.8.1 to 1.8.2 in /docs/_spec" to LTS

### DIFF
--- a/docs/_spec/Gemfile.lock
+++ b/docs/_spec/Gemfile.lock
@@ -41,7 +41,7 @@ GEM
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    webrick (1.8.1)
+    webrick (1.8.2)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
Backports #21674 to the 3.3.5.

PR submitted by the release tooling.
[skip ci]