### PR TITLE
Backport "Expr#show: Don't crash when the expression contains an unsupported type (like a SkolemType)" to LTS

### DIFF
--- a/compiler/src/scala/quoted/runtime/impl/printers/Extractors.scala
+++ b/compiler/src/scala/quoted/runtime/impl/printers/Extractors.scala
@@ -177,6 +177,8 @@ object Extractors {
         this += "Alternatives(" ++= patterns += ")"
       case TypedOrTest(tree, tpt) =>
         this += "TypedOrTest(" += tree += ", " += tpt += ")"
+      case tree =>
+        this += s"<Internal compiler AST $tree does not have a corresponding reflect extractor>"
     }
 
     def visitConstant(x: Constant): this.type = x match {
@@ -239,6 +241,8 @@ object Extractors {
         this += "NoPrefix()"
       case MatchCase(pat, rhs) =>
         this += "MatchCase(" += pat += ", " += rhs += ")"
+      case tp =>
+        this += s"<Internal compiler type $tp does not have a corresponding reflect extractor>"
     }
 
     def visitSignature(sig: Signature): this.type = {

--- a/compiler/src/scala/quoted/runtime/impl/printers/SourceCode.scala
+++ b/compiler/src/scala/quoted/runtime/impl/printers/SourceCode.scala
@@ -1287,7 +1287,9 @@ object SourceCode {
           val sym = annot.tpe.typeSymbol
           sym != Symbol.requiredClass("scala.forceInline") &&
           sym.maybeOwner != Symbol.requiredPackage("scala.annotation.internal")
-        case x => cannotBeShownAsSource(x.show(using Printer.TreeStructure))
+        case x =>
+          cannotBeShownAsSource(x.show(using Printer.TreeStructure))
+          false
       }
       printAnnotations(annots)
       if (annots.nonEmpty) this += " "
@@ -1462,8 +1464,8 @@ object SourceCode {
       }
     }
 
-    private def cannotBeShownAsSource(x: String): Nothing =
-      throw new Exception(s"$x does not have a source representation")
+    private def cannotBeShownAsSource(x: String): this.type =
+      this += s"<$x does not have a source representation>"
 
     private object SpecialOp {
       def unapply(arg: Tree): Option[(String, List[Term])] = arg match {

--- a/tests/pos-macros/skolem/Macro_1.scala
+++ b/tests/pos-macros/skolem/Macro_1.scala
@@ -1,0 +1,10 @@
+import scala.quoted.*
+
+object Macro {
+
+  def impl(expr: Expr[Any])(using Quotes): Expr[Unit] =
+    println(expr.show)
+    '{ () }
+
+  inline def macr(inline x: Any): Unit = ${impl('x)}
+}

--- a/tests/pos-macros/skolem/Test_2.scala
+++ b/tests/pos-macros/skolem/Test_2.scala
@@ -1,0 +1,9 @@
+trait Foo:
+  val x: Int
+  def ho(p: x.type => x.type): Unit = ()
+
+object Test {
+  var f: Foo = ???
+  Macro.macr:
+    f.ho(arg => arg)
+}

--- a/tests/run-macros/i19905.check
+++ b/tests/run-macros/i19905.check
@@ -1,3 +1,3 @@
-java.lang.Exception: NoPrefix() does not have a source representation
-java.lang.Exception: NoPrefix() does not have a source representation
+<NoPrefix() does not have a source representation>
+<NoPrefix() does not have a source representation>
 NoPrefix()


### PR DESCRIPTION
Backports #20494 to the 3.3.5.

PR submitted by the release tooling.
[skip ci]