### PR TITLE
Backport "fix `dotty.tools.dotc.config.Properties` scaladoc" to LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/Properties.scala
+++ b/compiler/src/dotty/tools/dotc/config/Properties.scala
@@ -10,7 +10,7 @@ import java.io.IOException
 import java.util.jar.Attributes.{ Name => AttributeName }
 import java.nio.charset.StandardCharsets
 
-/** Loads `library.properties` from the jar. */
+/** Loads `compiler.properties` from the jar. */
 object Properties extends PropertiesTrait {
   protected def propCategory: String = "compiler"
   protected def pickJarBasedOn: Class[PropertiesTrait] = classOf[PropertiesTrait]


### PR DESCRIPTION
Backports #21691 to the 3.3.5.

PR submitted by the release tooling.
[skip ci]