### PR TITLE
Backport "Fix incorrect caching with dependent method parameters" to LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -140,6 +140,9 @@ object Types extends TypeUtils {
               !t.isPermanentlyInstantiated || test(t.permanentInst, theAcc)
             case t: LazyRef =>
               !t.completed || test(t.ref, theAcc)
+            case t: ParamRef =>
+              (t: Type).mightBeProvisional = false // break cycles
+              test(t.underlying, theAcc)
             case _ =>
               (if theAcc != null then theAcc else ProAcc()).foldOver(false, t)
         end if

--- a/tests/pos/dep-poly-class.scala
+++ b/tests/pos/dep-poly-class.scala
@@ -1,0 +1,9 @@
+trait A:
+  type B
+
+class CCPoly[T <: A](a: T, b: a.B)
+
+object Test:
+  def test(): Unit =
+    val aa: A { type B = Int } = new A { type B = Int }
+    val x: CCPoly[aa.type] = CCPoly(aa, 1)


### PR DESCRIPTION
Backports #21699 to the 3.3.5.

PR submitted by the release tooling.
[skip ci]