### PR TITLE
Backport "Always interpret underscores inside patterns as type bounds" to LTS

### DIFF
--- a/tests/pos/14952.scala
+++ b/tests/pos/14952.scala
@@ -1,0 +1,9 @@
+//> using options -Ykind-projector:underscores
+
+import Tuple.*
+
+type LiftP[F[_], T] <: Tuple =
+  T match {
+    case _ *: _ => F[Head[T]] *: LiftP[F, Tail[T]]
+    case _ => EmptyTuple
+  }

--- a/tests/pos/21400.scala
+++ b/tests/pos/21400.scala
@@ -1,0 +1,7 @@
+//> using options -Ykind-projector:underscores
+
+import scala.compiletime.ops.int.S
+
+type IndexOf[T <: Tuple, E] <: Int = T match
+  case E *: _  => 0
+  case _ *: es => 1 // S[IndexOf[es, E]]

--- a/tests/pos/21400b.scala
+++ b/tests/pos/21400b.scala
@@ -1,0 +1,10 @@
+//> using options -Ykind-projector:underscores
+
+import scala.quoted.Type
+import scala.quoted.Quotes
+
+def x[A](t: Type[A])(using Quotes): Boolean = t match
+  case '[_ *: _] =>
+    true
+  case _ =>
+    false


### PR DESCRIPTION
Backports #21718 to the 3.3.5.

PR submitted by the release tooling.
[skip ci]