### PR TITLE
Backport "Quotes type printing: take `infix` type modifier into account" to LTS

### DIFF
--- a/compiler/src/scala/quoted/runtime/impl/printers/SourceCode.scala
+++ b/compiler/src/scala/quoted/runtime/impl/printers/SourceCode.scala
@@ -1150,8 +1150,19 @@ object SourceCode {
           case tp: TypeRef if tp.typeSymbol == Symbol.requiredClass("scala.<repeated>") =>
             this += "_*"
           case _ =>
-            printType(tp)
-            inSquare(printTypesOrBounds(args, ", "))
+            if !fullNames && args.lengthCompare(2) == 0 && tp.typeSymbol.flags.is(Flags.Infix) then
+              val lhs = args(0)
+              val rhs = args(1)
+              this += "("
+              printType(lhs)
+              this += " "
+              printType(tp)
+              this += " "
+              printType(rhs)
+              this += ")"
+            else
+              printType(tp)
+              inSquare(printTypesOrBounds(args, ", "))
         }
 
       case AnnotatedType(tp, annot) =>

--- a/tests/run-macros/type-print.check
+++ b/tests/run-macros/type-print.check
@@ -1,0 +1,12 @@
+List[Int]
+scala.collection.immutable.List[scala.Int]
+scala.collection.[35mimmutable[0m.[35mList[0m[[35mscala[0m.[35mInt[0m]
+AppliedType(TypeRef(ThisType(TypeRef(NoPrefix(), "immutable")), "List"), List(TypeRef(TermRef(ThisType(TypeRef(NoPrefix(), "<root>")), "scala"), "Int")))
+(3 + (a * b))
+scala.compiletime.ops.int.+[3, scala.compiletime.ops.int.*[a, b]]
+[35mscala[0m.[35mcompiletime[0m.[35mops[0m.[35mint[0m.[35m+[0m[[31m3[0m, [35mscala[0m.[35mcompiletime[0m.[35mops[0m.[35mint[0m.[35m*[0m[[35ma[0m, [35mb[0m]]
+AppliedType(TypeRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix(), "<root>")), "scala"), "compiletime"), "ops"), "int"), "+"), List(ConstantType(IntConstant(3)), AppliedType(TypeRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix(), "<root>")), "scala"), "compiletime"), "ops"), "int"), "*"), List(TermRef(NoPrefix(), "a"), TermRef(NoPrefix(), "b")))))
+((3 + a) * b)
+scala.compiletime.ops.int.*[scala.compiletime.ops.int.+[3, a], b]
+[35mscala[0m.[35mcompiletime[0m.[35mops[0m.[35mint[0m.[35m*[0m[[35mscala[0m.[35mcompiletime[0m.[35mops[0m.[35mint[0m.[35m+[0m[[31m3[0m, [35ma[0m], [35mb[0m]
+AppliedType(TypeRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix(), "<root>")), "scala"), "compiletime"), "ops"), "int"), "*"), List(AppliedType(TypeRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix(), "<root>")), "scala"), "compiletime"), "ops"), "int"), "+"), List(ConstantType(IntConstant(3)), TermRef(NoPrefix(), "a"))), TermRef(NoPrefix(), "b")))

--- a/tests/run-macros/type-print.check
+++ b/tests/run-macros/type-print.check
@@ -2,11 +2,11 @@ List[Int]
 scala.collection.immutable.List[scala.Int]
 scala.collection.[35mimmutable[0m.[35mList[0m[[35mscala[0m.[35mInt[0m]
 AppliedType(TypeRef(ThisType(TypeRef(NoPrefix(), "immutable")), "List"), List(TypeRef(TermRef(ThisType(TypeRef(NoPrefix(), "<root>")), "scala"), "Int")))
-(3 + (a * b))
++[3, *[a, b]]
 scala.compiletime.ops.int.+[3, scala.compiletime.ops.int.*[a, b]]
 [35mscala[0m.[35mcompiletime[0m.[35mops[0m.[35mint[0m.[35m+[0m[[31m3[0m, [35mscala[0m.[35mcompiletime[0m.[35mops[0m.[35mint[0m.[35m*[0m[[35ma[0m, [35mb[0m]]
 AppliedType(TypeRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix(), "<root>")), "scala"), "compiletime"), "ops"), "int"), "+"), List(ConstantType(IntConstant(3)), AppliedType(TypeRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix(), "<root>")), "scala"), "compiletime"), "ops"), "int"), "*"), List(TermRef(NoPrefix(), "a"), TermRef(NoPrefix(), "b")))))
-((3 + a) * b)
+*[+[3, a], b]
 scala.compiletime.ops.int.*[scala.compiletime.ops.int.+[3, a], b]
 [35mscala[0m.[35mcompiletime[0m.[35mops[0m.[35mint[0m.[35m*[0m[[35mscala[0m.[35mcompiletime[0m.[35mops[0m.[35mint[0m.[35m+[0m[[31m3[0m, [35ma[0m], [35mb[0m]
 AppliedType(TypeRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix(), "<root>")), "scala"), "compiletime"), "ops"), "int"), "*"), List(AppliedType(TypeRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix(), "<root>")), "scala"), "compiletime"), "ops"), "int"), "+"), List(ConstantType(IntConstant(3)), TermRef(NoPrefix(), "a"))), TermRef(NoPrefix(), "b")))

--- a/tests/run-macros/type-print/Macro_1.scala
+++ b/tests/run-macros/type-print/Macro_1.scala
@@ -1,0 +1,29 @@
+import scala.quoted.*
+
+inline def printTypeShort[T]: String =
+  ${ printTypeShortImpl[T] }
+
+inline def printType[T]: String =
+  ${ printTypeImpl[T] }
+
+inline def printTypeAnsi[T]: String =
+  ${ printTypeAnsiImpl[T] }
+
+inline def printTypeStructure[T]: String =
+  ${ printTypeStructureImpl[T] }
+
+def printTypeShortImpl[T: Type](using Quotes): Expr[String] =
+  import quotes.reflect.*
+  Expr(Printer.TypeReprShortCode.show(TypeRepr.of[T]))
+
+def printTypeImpl[T: Type](using Quotes): Expr[String] =
+  import quotes.reflect.*
+  Expr(Printer.TypeReprCode.show(TypeRepr.of[T]))
+
+def printTypeAnsiImpl[T: Type](using Quotes): Expr[String] =
+  import quotes.reflect.*
+  Expr(Printer.TypeReprAnsiCode.show(TypeRepr.of[T]))
+
+def printTypeStructureImpl[T: Type](using Quotes): Expr[String] =
+  import quotes.reflect.*
+  Expr(Printer.TypeReprStructure.show(TypeRepr.of[T]))

--- a/tests/run-macros/type-print/Test_2.scala
+++ b/tests/run-macros/type-print/Test_2.scala
@@ -1,0 +1,15 @@
+import scala.compiletime.ops.int.*
+
+inline def printAll[T]: Unit =
+  println(printTypeShort[T])
+  println(printType[T])
+  println(printTypeAnsi[T])
+  println(printTypeStructure[T])
+
+@main
+def Test: Unit =
+  printAll[List[Int]]
+  val a = 1
+  val b = 2
+  printAll[3 + a.type * b.type]
+  printAll[(3 + a.type) * b.type]


### PR DESCRIPTION
Backports #21726 to the 3.3.5.

PR submitted by the release tooling.
[skip ci]