### PR TITLE
Backport "REPL: JLine 3.27.0 (was 3.25.1)" to LTS

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -582,9 +582,9 @@ object Build {
       libraryDependencies ++= Seq(
         "org.scala-lang.modules" % "scala-asm" % "9.7.0-scala-2", // used by the backend
         Dependencies.compilerInterface,
-        "org.jline" % "jline-reader" % "3.25.1",   // used by the REPL
-        "org.jline" % "jline-terminal" % "3.25.1",
-        "org.jline" % "jline-terminal-jna" % "3.25.1", // needed for Windows
+        "org.jline" % "jline-reader" % "3.27.0",   // used by the REPL
+        "org.jline" % "jline-terminal" % "3.27.0",
+        "org.jline" % "jline-terminal-jna" % "3.27.0", // needed for Windows
         ("io.get-coursier" %% "coursier" % "2.0.16" % Test).cross(CrossVersion.for3Use2_13),
       ),
 


### PR DESCRIPTION
Backports #21752 to the 3.3.5.

PR submitted by the release tooling.
[skip ci]