### PR TITLE
Backport "Drop support for old experimental in community-build" to 3.3 LTS

### DIFF
--- a/community-build/src/scala/dotty/communitybuild/CommunityBuildRunner.scala
+++ b/community-build/src/scala/dotty/communitybuild/CommunityBuildRunner.scala
@@ -16,13 +16,12 @@ object CommunityBuildRunner:
    *  and avoid network overhead. See https://github.com/lampepfl/dotty-drone
    *  for more infrastructural details.
    */
-  extension (self: CommunityProject) def run()(using suite: CommunityBuildRunner): Unit =
-    if self.requiresExperimental && !compilerSupportExperimental then
-      log(s"Skipping ${self.project} - it needs experimental features unsupported in this build.")
-      return
-    self.dependencies.foreach(_.publish())
-    self.testOnlyDependencies().foreach(_.publish())
-    suite.runProject(self)
+  extension (self: CommunityProject) 
+    def run()(using suite: CommunityBuildRunner): Unit =
+      self.dependencies.foreach(_.publish())
+      self.testOnlyDependencies().foreach(_.publish())
+      suite.runProject(self)
+  end extension
 
 trait CommunityBuildRunner:
 

--- a/community-build/src/scala/dotty/communitybuild/Main.scala
+++ b/community-build/src/scala/dotty/communitybuild/Main.scala
@@ -55,10 +55,7 @@ object Main:
         Seq("rm", "-rf", destStr).!
         Files.createDirectory(dest)
         val (toRun, ignored) =
-          allProjects.partition( p =>
-            p.docCommand != null
-            && (!p.requiresExperimental || compilerSupportExperimental)
-          )
+          allProjects.partition(_.docCommand != null)
 
         val paths = toRun.map { project =>
           val name = project.project


### PR DESCRIPTION
Backports #21729 to the 3.3.6.

PR submitted by the release tooling.
[skip ci]