### PR TITLE
Backport "Add the macro type-print test to run-macros-scala2-library-tasty.blacklist" to 3.3 LTS

### DIFF
--- a/tests/plugins/run/scriptWrapper/LineNumberPlugin_1.scala
+++ b/tests/plugins/run/scriptWrapper/LineNumberPlugin_1.scala
@@ -12,7 +12,7 @@ class LineNumberPlugin extends StandardPlugin {
   val name: String = "linenumbers"
   val description: String = "adjusts line numbers of script files"
 
-  override def initialize(options: List[String])(using Context): List[PluginPhase] = FixLineNumbers() :: Nil
+  override def init(options: List[String]): List[PluginPhase] = FixLineNumbers() :: Nil
 }
 
 // Loosely follows Mill linenumbers plugin (scan for marker with "original" source, adjust line numbers to match)


### PR DESCRIPTION
Backports #21787 to the 3.3.6.

PR submitted by the release tooling.