### PR TITLE
Backport "Shade scalajs.ir under dotty.tools" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/backend/sjs/JSCodeGen.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSCodeGen.scala
@@ -25,12 +25,12 @@ import dotty.tools.dotc.transform.{Erasure, ValueClasses}
 import dotty.tools.dotc.util.SourcePosition
 import dotty.tools.dotc.report
 
-import org.scalajs.ir
-import org.scalajs.ir.{ClassKind, Position, Names => jsNames, Trees => js, Types => jstpe}
-import org.scalajs.ir.Names.{ClassName, MethodName, SimpleMethodName}
-import org.scalajs.ir.OriginalName
-import org.scalajs.ir.OriginalName.NoOriginalName
-import org.scalajs.ir.Trees.OptimizerHints
+import dotty.tools.sjs.ir
+import dotty.tools.sjs.ir.{ClassKind, Position, Names => jsNames, Trees => js, Types => jstpe}
+import dotty.tools.sjs.ir.Names.{ClassName, MethodName, SimpleMethodName}
+import dotty.tools.sjs.ir.OriginalName
+import dotty.tools.sjs.ir.OriginalName.NoOriginalName
+import dotty.tools.sjs.ir.Trees.OptimizerHints
 
 import dotty.tools.dotc.transform.sjs.JSSymUtils.*
 

--- a/compiler/src/dotty/tools/backend/sjs/JSEncoding.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSEncoding.scala
@@ -15,12 +15,12 @@ import StdNames.*
 
 import dotty.tools.dotc.transform.sjs.JSSymUtils.*
 
-import org.scalajs.ir
-import org.scalajs.ir.{Trees => js, Types => jstpe}
-import org.scalajs.ir.Names.{LocalName, LabelName, FieldName, SimpleMethodName, MethodName, ClassName}
-import org.scalajs.ir.OriginalName
-import org.scalajs.ir.OriginalName.NoOriginalName
-import org.scalajs.ir.UTF8String
+import dotty.tools.sjs.ir
+import dotty.tools.sjs.ir.{Trees => js, Types => jstpe}
+import dotty.tools.sjs.ir.Names.{LocalName, LabelName, FieldName, SimpleMethodName, MethodName, ClassName}
+import dotty.tools.sjs.ir.OriginalName
+import dotty.tools.sjs.ir.OriginalName.NoOriginalName
+import dotty.tools.sjs.ir.UTF8String
 
 import dotty.tools.backend.jvm.DottyBackendInterface.symExtensions
 

--- a/compiler/src/dotty/tools/backend/sjs/JSExportsGen.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSExportsGen.scala
@@ -22,11 +22,11 @@ import TypeErasure.ErasedValueType
 import dotty.tools.dotc.util.{SourcePosition, SrcPos}
 import dotty.tools.dotc.report
 
-import org.scalajs.ir.{Position, Names => jsNames, Trees => js, Types => jstpe}
-import org.scalajs.ir.Names.DefaultModuleID
-import org.scalajs.ir.OriginalName.NoOriginalName
-import org.scalajs.ir.Position.NoPosition
-import org.scalajs.ir.Trees.OptimizerHints
+import dotty.tools.sjs.ir.{Position, Names => jsNames, Trees => js, Types => jstpe}
+import dotty.tools.sjs.ir.Names.DefaultModuleID
+import dotty.tools.sjs.ir.OriginalName.NoOriginalName
+import dotty.tools.sjs.ir.Position.NoPosition
+import dotty.tools.sjs.ir.Trees.OptimizerHints
 
 import dotty.tools.dotc.transform.sjs.JSExportUtils.*
 import dotty.tools.dotc.transform.sjs.JSSymUtils.*
@@ -924,7 +924,7 @@ final class JSExportsGen(jsCodeGen: JSCodeGen)(using Context) {
         InstanceOfTypeTest(tpe.tycon.typeSymbol.typeRef)
 
       case _ =>
-        import org.scalajs.ir.Names
+        import dotty.tools.sjs.ir.Names
 
         (toIRType(tpe): @unchecked) match {
           case jstpe.AnyType => NoTypeTest

--- a/compiler/src/dotty/tools/backend/sjs/JSPositions.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSPositions.scala
@@ -13,7 +13,7 @@ import dotty.tools.dotc.report
 import dotty.tools.dotc.util.{SourceFile, SourcePosition}
 import dotty.tools.dotc.util.Spans.Span
 
-import org.scalajs.ir
+import dotty.tools.sjs.ir
 
 /** Conversion utilities from dotty Positions to IR Positions. */
 class JSPositions()(using Context) {

--- a/compiler/src/dotty/tools/dotc/transform/CheckReentrant.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckReentrant.scala
@@ -43,7 +43,7 @@ class CheckReentrant extends MiniPhase {
     requiredClass("scala.annotation.internal.unshared"))
 
   private val scalaJSIRPackageClass = new CtxLazy(
-    getPackageClassIfDefined("org.scalajs.ir"))
+    getPackageClassIfDefined("dotty.tools.sjs.ir"))
 
   def isIgnored(sym: Symbol)(using Context): Boolean =
     sym.hasAnnotation(sharableAnnot()) ||

--- a/compiler/src/dotty/tools/dotc/transform/sjs/JSSymUtils.scala
+++ b/compiler/src/dotty/tools/dotc/transform/sjs/JSSymUtils.scala
@@ -17,7 +17,7 @@ import Types.*
 
 import dotty.tools.backend.sjs.JSDefinitions.jsdefn
 
-import org.scalajs.ir.{Trees => js}
+import dotty.tools.sjs.ir.{Trees => js}
 
 /** Additional extensions for `Symbol`s that are only relevant for Scala.js. */
 object JSSymUtils {

--- a/compiler/src/dotty/tools/dotc/transform/sjs/PrepJSExports.scala
+++ b/compiler/src/dotty/tools/dotc/transform/sjs/PrepJSExports.scala
@@ -21,8 +21,8 @@ import dotty.tools.backend.sjs.JSDefinitions.jsdefn
 import JSExportUtils.*
 import JSSymUtils.*
 
-import org.scalajs.ir.Names.DefaultModuleID
-import org.scalajs.ir.Trees.TopLevelExportDef.isValidTopLevelExportName
+import dotty.tools.sjs.ir.Names.DefaultModuleID
+import dotty.tools.sjs.ir.Trees.TopLevelExportDef.isValidTopLevelExportName
 
 object PrepJSExports {
   import tpd.*

--- a/compiler/src/dotty/tools/dotc/transform/sjs/PrepJSInterop.scala
+++ b/compiler/src/dotty/tools/dotc/transform/sjs/PrepJSInterop.scala
@@ -23,7 +23,7 @@ import Types.*
 
 import JSSymUtils.*
 
-import org.scalajs.ir.Trees.JSGlobalRef
+import dotty.tools.sjs.ir.Trees.JSGlobalRef
 
 import dotty.tools.backend.sjs.JSDefinitions.jsdefn
 

--- a/tests/pos-with-compiler-cc/backend/sjs/JSCodeGen.scala
+++ b/tests/pos-with-compiler-cc/backend/sjs/JSCodeGen.scala
@@ -25,12 +25,12 @@ import dotty.tools.dotc.transform.SymUtils._
 import dotty.tools.dotc.util.SourcePosition
 import dotty.tools.dotc.report
 
-import org.scalajs.ir
-import org.scalajs.ir.{ClassKind, Position, Names => jsNames, Trees => js, Types => jstpe}
-import org.scalajs.ir.Names.{ClassName, MethodName, SimpleMethodName}
-import org.scalajs.ir.OriginalName
-import org.scalajs.ir.OriginalName.NoOriginalName
-import org.scalajs.ir.Trees.OptimizerHints
+import dotty.tools.sjs.ir
+import dotty.tools.sjs.ir.{ClassKind, Position, Names => jsNames, Trees => js, Types => jstpe}
+import dotty.tools.sjs.ir.Names.{ClassName, MethodName, SimpleMethodName}
+import dotty.tools.sjs.ir.OriginalName
+import dotty.tools.sjs.ir.OriginalName.NoOriginalName
+import dotty.tools.sjs.ir.Trees.OptimizerHints
 
 import dotty.tools.dotc.transform.sjs.JSSymUtils._
 

--- a/tests/pos-with-compiler-cc/backend/sjs/JSEncoding.scala
+++ b/tests/pos-with-compiler-cc/backend/sjs/JSEncoding.scala
@@ -15,12 +15,12 @@ import StdNames._
 
 import dotty.tools.dotc.transform.sjs.JSSymUtils._
 
-import org.scalajs.ir
-import org.scalajs.ir.{Trees => js, Types => jstpe}
-import org.scalajs.ir.Names.{LocalName, LabelName, FieldName, SimpleMethodName, MethodName, ClassName}
-import org.scalajs.ir.OriginalName
-import org.scalajs.ir.OriginalName.NoOriginalName
-import org.scalajs.ir.UTF8String
+import dotty.tools.sjs.ir
+import dotty.tools.sjs.ir.{Trees => js, Types => jstpe}
+import dotty.tools.sjs.ir.Names.{LocalName, LabelName, FieldName, SimpleMethodName, MethodName, ClassName}
+import dotty.tools.sjs.ir.OriginalName
+import dotty.tools.sjs.ir.OriginalName.NoOriginalName
+import dotty.tools.sjs.ir.UTF8String
 
 import dotty.tools.backend.jvm.DottyBackendInterface.symExtensions
 

--- a/tests/pos-with-compiler-cc/backend/sjs/JSExportsGen.scala
+++ b/tests/pos-with-compiler-cc/backend/sjs/JSExportsGen.scala
@@ -22,11 +22,11 @@ import TypeErasure.ErasedValueType
 import dotty.tools.dotc.util.{SourcePosition, SrcPos}
 import dotty.tools.dotc.report
 
-import org.scalajs.ir.{Position, Names => jsNames, Trees => js, Types => jstpe}
-import org.scalajs.ir.Names.DefaultModuleID
-import org.scalajs.ir.OriginalName.NoOriginalName
-import org.scalajs.ir.Position.NoPosition
-import org.scalajs.ir.Trees.OptimizerHints
+import dotty.tools.sjs.ir.{Position, Names => jsNames, Trees => js, Types => jstpe}
+import dotty.tools.sjs.ir.Names.DefaultModuleID
+import dotty.tools.sjs.ir.OriginalName.NoOriginalName
+import dotty.tools.sjs.ir.Position.NoPosition
+import dotty.tools.sjs.ir.Trees.OptimizerHints
 
 import dotty.tools.dotc.transform.sjs.JSExportUtils._
 import dotty.tools.dotc.transform.sjs.JSSymUtils._
@@ -924,7 +924,7 @@ final class JSExportsGen(jsCodeGen: JSCodeGen)(using Context) {
         InstanceOfTypeTest(tpe.tycon.typeSymbol.typeRef)
 
       case _ =>
-        import org.scalajs.ir.Names
+        import dotty.tools.sjs.ir.Names
 
         (toIRType(tpe): @unchecked) match {
           case jstpe.AnyType => NoTypeTest

--- a/tests/pos-with-compiler-cc/backend/sjs/JSPositions.scala
+++ b/tests/pos-with-compiler-cc/backend/sjs/JSPositions.scala
@@ -13,7 +13,7 @@ import dotty.tools.dotc.report
 import dotty.tools.dotc.util.{SourceFile, SourcePosition}
 import dotty.tools.dotc.util.Spans.Span
 
-import org.scalajs.ir
+import dotty.tools.sjs.ir
 
 /** Conversion utilities from dotty Positions to IR Positions. */
 class JSPositions()(using Context) {


### PR DESCRIPTION
Backports #21765 to the 3.3.6.

PR submitted by the release tooling.
[skip ci]