### PR TITLE
Backport "Apply implicit conversion from derived Conversion instance defined as implicit rather than given" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -1134,7 +1134,7 @@ trait Implicits:
             case _ => info.derivesFrom(defn.ConversionClass)
           def tryConversion(using Context) = {
             val untpdConv =
-              if ref.symbol.is(Given) && producesConversion(ref.symbol.info) then
+              if ref.symbol.isOneOf(GivenOrImplicit) && producesConversion(ref.symbol.info) then
                 untpd.Select(
                   untpd.TypedSplice(
                     adapt(generated,

--- a/tests/pos/i21757.scala
+++ b/tests/pos/i21757.scala
@@ -1,0 +1,33 @@
+object ConversionChain {
+
+  class X(val value: Int)
+
+  class Y(val x: X)
+
+  class Z(val y: Y)
+
+  trait Conv[A, B] extends Conversion[A, B]
+
+  given xy: Conv[X, Y] = { (x: X) => new Y(x) }
+
+  given yz: Conv[Y, Z] = { (y: Y) => new Z(y) }
+
+  object ConvUtils {
+    implicit def hypotheticalSyllogism[A, B, C]( // implicit def instead of given
+        using
+        ab: Conv[A, B],
+        bc: Conv[B, C]
+    ): Conv[A, C] = {
+
+      new Conv[A, C] {
+        def apply(a: A): C = bc(ab(a))
+      }
+    }
+  }
+  import ConvUtils.hypotheticalSyllogism
+
+  def test(): Unit = {
+    val x = new X(42)
+    val z: Z = x
+  }
+}


### PR DESCRIPTION
Backports #21785 to the 3.3.6.

PR submitted by the release tooling.
[skip ci]