### PR TITLE
Backport "Do not consider uninhabited constructors when performing exhaustive match checking" to 3.3 LTS

### DIFF
--- a/tests/init-global/pos/i18629.scala
+++ b/tests/init-global/pos/i18629.scala
@@ -1,0 +1,6 @@
+object Foo {
+  val bar = List() match {
+    case List() => ???
+    case null => ???
+  }
+}

--- a/tests/patmat/i13931.scala
+++ b/tests/patmat/i13931.scala
@@ -1,7 +1,7 @@
 class Test:
   def test = Vector() match
     case Seq() => println("empty")
-    case _ => println("non-empty")
+    case null => println("non-empty")
 
   def test2 = IndexedSeq() match { case IndexedSeq() => case null => }
   def test3 = IndexedSeq() match { case IndexedSeq(1) => case _ => }

--- a/tests/patmat/i13931.scala
+++ b/tests/patmat/i13931.scala
@@ -3,5 +3,5 @@ class Test:
     case Seq() => println("empty")
     case _ => println("non-empty")
 
-  def test2 = IndexedSeq() match { case IndexedSeq() => case _ => }
+  def test2 = IndexedSeq() match { case IndexedSeq() => case null => }
   def test3 = IndexedSeq() match { case IndexedSeq(1) => case _ => }

--- a/tests/plugins/run/scriptWrapper/LineNumberPlugin_1.scala
+++ b/tests/plugins/run/scriptWrapper/LineNumberPlugin_1.scala
@@ -12,7 +12,7 @@ class LineNumberPlugin extends StandardPlugin {
   val name: String = "linenumbers"
   val description: String = "adjusts line numbers of script files"
 
-  override def initialize(options: List[String])(using Context): List[PluginPhase] = FixLineNumbers() :: Nil
+  override def init(options: List[String]): List[PluginPhase] = FixLineNumbers() :: Nil
 }
 
 // Loosely follows Mill linenumbers plugin (scan for marker with "original" source, adjust line numbers to match)

--- a/tests/warn/patmat-nothing-exhaustive.scala
+++ b/tests/warn/patmat-nothing-exhaustive.scala
@@ -1,0 +1,10 @@
+enum TestAdt:
+  case Inhabited
+  case Uninhabited(no: Nothing)
+
+def test1(t: TestAdt): Int = t match
+  case TestAdt.Inhabited => 1
+
+def test2(o: Option[Option[Nothing]]): Int = o match
+  case Some(None) => 1
+  case None => 2


### PR DESCRIPTION
Backports #21750 to the 3.3.6.

PR submitted by the release tooling.