### PR TITLE
Backport "Fix enclosingClass from returning refinement classes" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -1154,10 +1154,10 @@ object SymDenotations {
     final def enclosingClass(using Context): Symbol = {
       def enclClass(sym: Symbol, skip: Boolean): Symbol = {
         def newSkip = sym.is(JavaStaticTerm)
-        if (!sym.exists)
+        if !sym.exists then
           NoSymbol
-        else if (sym.isClass)
-          if (skip) enclClass(sym.owner, newSkip) else sym
+        else if sym.isClass then
+          if skip || sym.isRefinementClass then enclClass(sym.owner, newSkip) else sym
         else
           enclClass(sym.owner, skip || newSkip)
       }

--- a/compiler/src/dotty/tools/dotc/transform/ProtectedAccessors.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ProtectedAccessors.scala
@@ -44,7 +44,10 @@ object ProtectedAccessors {
   /** Do we need a protected accessor for accessing sym from the current context's owner? */
   def needsAccessor(sym: Symbol)(using Context): Boolean =
     needsAccessorIfNotInSubclass(sym) &&
-    !ctx.owner.enclosingClass.derivesFrom(sym.owner)
+    !needsAccessorIsSubclass(sym)
+
+  def needsAccessorIsSubclass(sym: Symbol)(using Context): Boolean =
+    ctx.owner.enclosingClass.derivesFrom(sym.owner)
 }
 
 class ProtectedAccessors extends MiniPhase {

--- a/compiler/src/dotty/tools/dotc/transform/SuperAccessors.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SuperAccessors.scala
@@ -195,7 +195,7 @@ class SuperAccessors(thisPhase: DenotTransformer) {
          * Otherwise, we need to go through an accessor,
          * which the implementing class will provide an implementation for.
          */
-        if ctx.owner.enclosingClass.derivesFrom(sym.owner) then
+        if ProtectedAccessors.needsAccessorIsSubclass(sym) then
           if sym.is(JavaDefined) then
             report.error(em"${ctx.owner} accesses protected $sym inside a concrete trait method: use super.${sel.name} instead", sel.srcPos)
           sel

--- a/tests/pos/i20952.scala
+++ b/tests/pos/i20952.scala
@@ -1,0 +1,20 @@
+package object packer: // the super class needs to be in a different package
+  class SuperClass():
+    protected val problem: Any = ??? // needs to be protected
+
+class SuperClass():
+  protected val problem: Any = ??? // needs to be protected
+
+// type Target = SuperClass        // passes
+type Target = packer.SuperClass // error
+
+trait Child extends Target:
+
+  val aliased: problem.type = problem
+  type Alias = problem.type
+
+  val newProblem: Any {val prog: problem.type} = ???  // error
+  val newProblem2: Any {val prog: Alias} = ???         // passes
+  val newProblem3: Any {val prog: aliased.type} = ???  // passes
+
+class ChildImpl extends Target with Child // concrete implementation is needed


### PR DESCRIPTION
Backports #21411 to the 3.3.6.

PR submitted by the release tooling.
[skip ci]