### PR TITLE
Backport "Fix ctx implicits under case unapplySeq" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1920,7 +1920,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
   /** Type a case. */
   def typedCase(tree: untpd.CaseDef, sel: Tree, wideSelType: Type, pt: Type)(using Context): CaseDef = {
     val originalCtx = ctx
-    val gadtCtx: Context = ctx.fresh.setFreshGADTBounds.setNewScope
+    val gadtCtx: Context = ctx.fresh.setFreshGADTBounds
 
     def caseRest(pat: Tree)(using Context) = {
       val pt1 = instantiateMatchTypeProto(pat, pt) match {
@@ -1950,7 +1950,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
     val pat1 = typedPattern(tree.pat, wideSelType)(using gadtCtx)
     caseRest(pat1)(
       using Nullables.caseContext(sel, pat1)(
-        using gadtCtx))
+        using gadtCtx.fresh.setNewScope))
   }
 
   def typedLabeled(tree: untpd.Labeled)(using Context): Labeled = {

--- a/tests/pos/i21742.1.scala
+++ b/tests/pos/i21742.1.scala
@@ -1,0 +1,5 @@
+case class C(n: Int, ds: Double*)
+class Test:
+  def m(using n: Int): Int = n + 1
+  def t(): Unit =
+    C(1, 2, 3, 4) match { case C(given Int, ds*) => m }

--- a/tests/pos/i21742.2.scala
+++ b/tests/pos/i21742.2.scala
@@ -1,0 +1,5 @@
+case class C(n: Int, ds: Seq[Double])
+class Test:
+  def m(using n: Int): Int = n + 1
+  def t(): Unit =
+    C(1, Seq(2, 3, 4)) match { case C(given Int, ds) => m }


### PR DESCRIPTION
Backports #21748 to the 3.3.6.

PR submitted by the release tooling.
[skip ci]