### PR TITLE
Backport "Fix #9879: allow top-level opaque type definitions in REPL" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -4389,6 +4389,8 @@ object Parsers {
           stats += closure(in.offset, Location.InBlock, modifiers(BitSet(IMPLICIT)))
         else if isIdent(nme.extension) && followingIsExtension() then
           stats += extension()
+        else if ctx.mode.is(Mode.Interactive) && isDefIntro(localModifierTokens) then
+          stats +++= localDef(in.offset)
         else if isDefIntro(localModifierTokens, excludedSoftModifiers = Set(nme.`opaque`)) then
           stats +++= localDef(in.offset)
         else

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -4389,9 +4389,11 @@ object Parsers {
           stats += closure(in.offset, Location.InBlock, modifiers(BitSet(IMPLICIT)))
         else if isIdent(nme.extension) && followingIsExtension() then
           stats += extension()
-        else if outermost && ctx.mode.is(Mode.Interactive) && isDefIntro(localModifierTokens) then
-          stats +++= localDef(in.offset)
-        else if isDefIntro(localModifierTokens, excludedSoftModifiers = Set(nme.`opaque`)) then
+        else if isDefIntro(localModifierTokens,
+            excludedSoftModifiers =
+              // Allow opaque definitions at outermost level in REPL.
+              if outermost && ctx.mode.is(Mode.Interactive)
+              then Set.empty else Set(nme.`opaque`)) then
           stats +++= localDef(in.offset)
         else
           empty = true

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -4377,7 +4377,7 @@ object Parsers {
      *                 | Expr1
      *                 |
      */
-    def blockStatSeq(): List[Tree] = checkNoEscapingPlaceholders {
+    def blockStatSeq(outermost: Boolean = false): List[Tree] = checkNoEscapingPlaceholders {
       val stats = new ListBuffer[Tree]
       while
         var empty = false
@@ -4389,7 +4389,7 @@ object Parsers {
           stats += closure(in.offset, Location.InBlock, modifiers(BitSet(IMPLICIT)))
         else if isIdent(nme.extension) && followingIsExtension() then
           stats += extension()
-        else if ctx.mode.is(Mode.Interactive) && isDefIntro(localModifierTokens) then
+        else if outermost && ctx.mode.is(Mode.Interactive) && isDefIntro(localModifierTokens) then
           stats +++= localDef(in.offset)
         else if isDefIntro(localModifierTokens, excludedSoftModifiers = Set(nme.`opaque`)) then
           stats +++= localDef(in.offset)

--- a/compiler/src/dotty/tools/repl/ParseResult.scala
+++ b/compiler/src/dotty/tools/repl/ParseResult.scala
@@ -122,7 +122,7 @@ object ParseResult {
 
   private def parseStats(using Context): List[untpd.Tree] = {
     val parser = new Parser(ctx.source)
-    val stats = parser.blockStatSeq()
+    val stats = parser.blockStatSeq(outermost = true)
     parser.accept(Tokens.EOF)
     stats
   }

--- a/compiler/test/dotty/tools/repl/ReplCompilerTests.scala
+++ b/compiler/test/dotty/tools/repl/ReplCompilerTests.scala
@@ -372,6 +372,34 @@ class ReplCompilerTests extends ReplTest:
       assertTrue(last, last.startsWith("val res0: tpolecat.type = null"))
       assertTrue(last, last.endsWith("""// result of "res0.toString" is null"""))
 
+  @Test def `i9879`: Unit = initially:
+    run {
+      """|opaque type A = Int; def getA: A = 0
+         |object Wrapper { opaque type A = Int; def getA: A = 1 }
+         |val x = getA
+         |val y = Wrapper.getA""".stripMargin
+    }
+    val expected = List(
+      "def getA: A",
+      "// defined object Wrapper",
+      "val x: A = 0",
+      "val y: Wrapper.A = 1"
+    )
+    assertEquals(expected, lines())
+
+  @Test def `i9879b`: Unit = initially:
+    run {
+      """|def test =
+         |  type A = Int
+         |  opaque type B = String
+         |  object Wrapper { opaque type C = Int }
+         |  ()""".stripMargin
+    }
+    val all = lines()
+    assertEquals(6, all.length)
+    assertTrue(all.head.startsWith("-- [E103] Syntax Error"))
+    assertTrue(all.exists(_.trim().startsWith("|  Illegal start of statement: this modifier is not allowed here")))
+
 object ReplCompilerTests:
 
   private val pattern = Pattern.compile("\\r[\\n]?|\\n");


### PR DESCRIPTION
Backports #21753 to the 3.3.6.

PR submitted by the release tooling.
[skip ci]