### PR TITLE
Backport "Don't warn for deprecated Thread.getId() calls in `ChromeTrace`" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/profile/ChromeTrace.scala
+++ b/compiler/src/dotty/tools/dotc/profile/ChromeTrace.scala
@@ -45,6 +45,7 @@ final class ChromeTrace(f: Path) extends Closeable {
   private val traceWriter = FileUtils.newAsyncBufferedWriter(f)
   private val context = mutable.Stack[JsonContext](TopContext)
   private val tidCache = new ThreadLocal[String]() {
+    @annotation.nowarn("cat=deprecation")
     override def initialValue(): String = "%05d".format(Thread.currentThread().getId())
   }
   objStart()


### PR DESCRIPTION
Backports #21831 to the 3.3.6.

PR submitted by the release tooling.
[skip ci]