### PR TITLE
Backport "Fix typo in `allTermArguments`" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
@@ -136,9 +136,9 @@ trait TreeInfo[T <: Untyped] { self: Trees.Instance[T] =>
 
   /** All term arguments of an application in a single flattened list */
   def allTermArguments(tree: Tree): List[Tree] = unsplice(tree) match {
-    case Apply(fn, args) => allArguments(fn) ::: args
-    case TypeApply(fn, args) => allArguments(fn)
-    case Block(_, expr) => allArguments(expr)
+    case Apply(fn, args) => allTermArguments(fn) ::: args
+    case TypeApply(fn, args) => allTermArguments(fn)
+    case Block(_, expr) => allTermArguments(expr)
     case _ => Nil
   }
 

--- a/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
@@ -206,7 +206,7 @@ object TreeChecker {
   private[TreeChecker] def isValidJVMMethodName(name: Name): Boolean = name.toString.forall(isValidJVMMethodChar)
 
 
-  class Checker(phasesToCheck: Seq[Phase]) extends ReTyper with Checking {
+  class Checker(phasesToCheck: Seq[Phase]) extends ReTyper {
     import ast.tpd.*
 
     protected val nowDefinedSyms = util.HashSet[Symbol]()


### PR DESCRIPTION
Backports #21836 to the 3.3.6.

PR submitted by the release tooling.
[skip ci]