### PR TITLE
Backport "Fix Java parsing of annotations on qualified types" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/JavaParsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/JavaParsers.scala
@@ -292,6 +292,7 @@ object JavaParsers {
           }
           while (in.token == DOT) {
             in.nextToken()
+            annotations()
             t = typeArgs(atSpan(t.span.start, in.offset)(typeSelect(t, ident())))
           }
           convertToTypeId(t)

--- a/tests/pos/i21319/Foo.java
+++ b/tests/pos/i21319/Foo.java
@@ -1,0 +1,8 @@
+package app;
+
+import java.util.Optional;
+import lib.*;
+
+public class Foo {
+  private java.util.@lib.Valid Optional<String> userId;
+}

--- a/tests/pos/i21319/Test.scala
+++ b/tests/pos/i21319/Test.scala
@@ -1,0 +1,3 @@
+package app
+
+class Test

--- a/tests/pos/i21319/Valid.java
+++ b/tests/pos/i21319/Valid.java
@@ -1,0 +1,17 @@
+package lib;
+
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE_USE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Target({ METHOD, FIELD, CONSTRUCTOR, PARAMETER, TYPE_USE })
+@Retention(RUNTIME)
+@Documented
+public @interface Valid {}


### PR DESCRIPTION
Backports #21867 to the 3.3.6.

PR submitted by the release tooling.
[skip ci]