### PR TITLE
Backport "fix: Allow `as` as an infix type in non context bound types" to 3.3 LTS

### DIFF
--- a/tests/pos/i21769.scala
+++ b/tests/pos/i21769.scala
@@ -1,0 +1,10 @@
+
+infix trait as[From, To]
+
+val conv: (String as Int) = ???
+given instance: (String as Int) = ???
+def test(ev: (String as Int)) = ???
+
+class F
+
+class K extends (F as K)


### PR DESCRIPTION
Backports #21849 to the 3.3.6.

PR submitted by the release tooling.
[skip ci]