### PR TITLE
Backport "Fix provablyDisjoint handling enum constants with mixins" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -3110,7 +3110,7 @@ object TypeComparer {
 
   def explaining[T](op: ExplainingTypeComparer => T, short: Boolean = false)(using Context): T =
     comparing(_.explaining(op, short))
-    
+
   def tracked[T](op: TrackingTypeComparer => T)(using Context): T =
     comparing(_.tracked(op))
 }

--- a/tests/warn/i21860.scala
+++ b/tests/warn/i21860.scala
@@ -1,0 +1,16 @@
+trait Figure
+sealed trait Corners { self: Figure => }
+
+enum Shape extends Figure:
+  case Triangle extends Shape with Corners
+  case Square   extends Shape with Corners
+  case Circle   extends Shape
+  case Ellipsis extends Shape
+
+def hasCorners(s: Shape): Boolean = s match
+  case hasCorners: Corners => true //  <--- reported as `Unreachable case`
+  case _                   => false
+
+class Test:
+  def test(): Unit =
+    println(hasCorners(Shape.Circle))

--- a/tests/warn/i21860.unenum.scala
+++ b/tests/warn/i21860.unenum.scala
@@ -1,0 +1,17 @@
+trait Figure
+sealed trait Corners { self: Figure => }
+
+sealed abstract class Shape extends Figure
+object Shape:
+  case object Triange  extends Shape with Corners
+  case object Square   extends Shape with Corners
+  case object Circle   extends Shape
+  case object Ellipsis extends Shape
+
+def hasCorners(s: Shape): Boolean = s match
+  case hasCorners: Corners => true //  <--- reported as `Unreachable case`
+  case _                   => false
+
+class Test:
+  def test(): Unit =
+    println(hasCorners(Shape.Circle))


### PR DESCRIPTION
Backports #21876 to the 3.3.6.

PR submitted by the release tooling.
[skip ci]