### PR TITLE
Backport "Don't point to the compiler backlog when a compiler plugin phase crashes" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/report.scala
+++ b/compiler/src/dotty/tools/dotc/report.scala
@@ -152,13 +152,23 @@ object report:
       "compiler version"   -> dotty.tools.dotc.config.Properties.versionString,
       "settings"           -> settings.map(showSetting).mkString(" "),
     ))
+    val fileAReportMsg =
+      if ctx.phase.isInstanceOf[plugins.PluginPhase]
+      then
+        s"""|  An unhandled exception was thrown in the compiler plugin named "${ctx.phase.megaPhase}".
+            |  Please report the issue to the plugin's maintainers.
+            |  For non-enriched exceptions, compile with -Xno-enrich-error-messages.
+            |""".stripMargin
+      else
+        s"""|  An unhandled exception was thrown in the compiler.
+            |  Please file a crash report here:
+            |  https://github.com/scala/scala3/issues/new/choose
+            |  For non-enriched exceptions, compile with -Xno-enrich-error-messages.
+            |""".stripMargin
     s"""
        |  $errorMessage
        |
-       |  An unhandled exception was thrown in the compiler.
-       |  Please file a crash report here:
-       |  https://github.com/lampepfl/dotty/issues/new/choose
-       |  For non-enriched exceptions, compile with -Yno-enrich-error-messages.
+       |$fileAReportMsg
        |
        |$info1
        |""".stripMargin


### PR DESCRIPTION
Backports #21887 to the 3.3.6.

PR submitted by the release tooling.