### PR TITLE
Backport "Do not warn about expected missing positions in quotes.reflect.Symbol" to 3.3 LTS

### DIFF
--- a/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
+++ b/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
@@ -2617,9 +2617,10 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
           if self.exists then
             val symPos = self.sourcePos
             if symPos.exists then Some(symPos)
-            else
+            else if self.source.exists then
               if xCheckMacro then report.warning(s"Missing symbol position (defaulting to position 0): $self\nThis is a compiler bug. Please report it.")
               Some(self.source.atSpan(dotc.util.Spans.Span(0)))
+            else None
           else None
 
         def docstring: Option[String] =

--- a/tests/pos-macros/i21672/Macro_1.scala
+++ b/tests/pos-macros/i21672/Macro_1.scala
@@ -1,0 +1,10 @@
+object Repro {
+  inline def apply(): Unit = ${ applyImpl }
+
+  import scala.quoted.*
+  def applyImpl(using q: Quotes): Expr[Unit] = {
+   import q.reflect.*
+   report.info(TypeRepr.of[Some[String]].typeSymbol.pos.toString)
+   '{ () }
+  }
+}

--- a/tests/pos-macros/i21672/Test_2.scala
+++ b/tests/pos-macros/i21672/Test_2.scala
@@ -1,0 +1,3 @@
+//> using options -Xfatal-warnings
+object Test:
+  Repro()


### PR DESCRIPTION
Backports #21677 to the 3.3.6.

PR submitted by the release tooling.
[skip ci]