### PR TITLE
Backport "Make sure definition tree has the defined symbol" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -11,6 +11,7 @@ import Symbols.*, StdNames.*, Annotations.*, Trees.*, Symbols.*
 import Decorators.*, DenotTransformers.*
 import collection.{immutable, mutable}
 import util.{Property, SourceFile}
+import config.Printers.typr
 import NameKinds.{TempResultName, OuterSelectName}
 import typer.ConstFold
 
@@ -1154,6 +1155,21 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
       if (sym.exists) sym.defTree = tree
       tree
     }
+
+    /** Make sure tree has given symbol. This is called when typing or unpickling
+     *  a ValDef or DefDef. It turns out that under very rare circumstances the symbol
+     *  computed for a tree is not correct. The only known test case is i21755.scala.
+     *  Here we have a self type that mentions a supertype as well as a type parameter
+     *  upper-bounded by the current class and it turns out that we compute the symbol
+     *  for a member method (named `root` in this case) in a subclass to be the
+     *  corresponding symbol in the superclass. It is not known what are the precise
+     *  conditions where this happens, but my guess would be that it's connected to the
+     *  recursion in the self type.
+     */
+    def ensureHasSym(sym: Symbol)(using Context): Unit =
+      if sym.exists && sym != tree.symbol then
+        typr.println(i"correcting definition symbol from ${tree.symbol.showLocated} to ${sym.showLocated}")
+        tree.overwriteType(NamedType(sym.owner.thisType, sym.asTerm.name, sym.denot))
 
     def etaExpandCFT(using Context): Tree =
       def expand(target: Tree, tp: Type)(using Context): Tree = tp match

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -960,6 +960,7 @@ class TreeUnpickler(reader: TastyReader,
         }
       }
 
+      tree.ensureHasSym(sym)
       tree.setDefTree
     }
 

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2610,19 +2610,23 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
 
     val ddef2 = assignType(cpy.DefDef(ddef)(name, paramss1, tpt1, rhs1), sym)
 
-    postProcessInfo(sym)
-    ddef2.setDefTree
-      //todo: make sure dependent method types do not depend on implicits or by-name params
+    postProcessInfo(ddef2, sym)
+    //todo: make sure dependent method types do not depend on implicits or by-name params
   }
 
   /** (1) Check that the signature of the class member does not return a repeated parameter type
    *  (2) If info is an erased class, set erased flag of member
+   *  (3) Check that erased classes are not parameters of polymorphic functions.
+   *  (4) Make sure the definition's symbol is `sym`.
+   *  (5) Set the `defTree` of `sym` to be `mdef`.
    */
-  private def postProcessInfo(sym: Symbol)(using Context): Unit =
+  private def postProcessInfo(mdef: MemberDef, sym: Symbol)(using Context): MemberDef =
     if (!sym.isOneOf(Synthetic | InlineProxy | Param) && sym.info.finalResultType.isRepeatedParam)
       report.error(em"Cannot return repeated parameter type ${sym.info.finalResultType}", sym.srcPos)
     if !sym.is(Module) && !sym.isConstructor && sym.info.finalResultType.isErasedClass then
       sym.setFlag(Erased)
+    mdef.ensureHasSym(sym)
+    mdef.setDefTree
 
   def typedTypeDef(tdef: untpd.TypeDef, sym: Symbol)(using Context): Tree = ctx.profiler.onTypedDef(sym) {
     val TypeDef(name, rhs) = tdef

--- a/tests/pos/i21755.scala
+++ b/tests/pos/i21755.scala
@@ -1,0 +1,11 @@
+trait GraphTraversal  {
+  type NodeT
+
+  protected trait Properties {
+    def root: NodeT
+  }
+
+  abstract protected class TraverserMethods[A, +CC <: TraverserMethods[A, CC]]  { this: CC with Properties =>
+    def root: NodeT
+  }
+}


### PR DESCRIPTION
Backports #21851 to the 3.3.6.

PR submitted by the release tooling.
[skip ci]