### PR TITLE
Backport "Fix typos" to 3.3 LTS

### DIFF
--- a/docs/_docs/contributing/architecture/types.md
+++ b/docs/_docs/contributing/architecture/types.md
@@ -108,7 +108,7 @@ Ground Type has no meaningful underlying type, typically it is the type of metho
 definitions, but also union types and intersection types, along with utility types of the
 compiler.
 
-Here's a diagram, serving as the mental model of the most important and distinct types available after the `typer` phase, derived from [dotty/tools/dotc/core/Types.scala][1]:
+Here's a diagram, serving as the mental model of the most important and distinct types available after the `typer` phase, derived from [Types.scala]:
 
 ```
 Type -+- proxy_type --+- NamedType --------+- TypeRef

--- a/docs/_docs/internals/gadts.md
+++ b/docs/_docs/internals/gadts.md
@@ -70,7 +70,7 @@ Right now, we record GADT constraints for:
 -   function/method type parameters
 -   class type parameters
 
-There is a branch on the way which will also record them for type members (so path-dependent types) and singleton types. It has a paper associated: "Implementing path-depepdent GADTs for Scala 3".
+There is a branch on the way which will also record them for type members (so path-dependent types) and singleton types. It has a paper associated: "Implementing path-dependent GADTs for Scala 3".
 
 ### What are necessary relationships? Any examples?
 


### PR DESCRIPTION
Backports #21913 to the 3.3.6.

PR submitted by the release tooling.
[skip ci]