### PR TITLE
Backport "Disallow open modifier on objects" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -593,6 +593,8 @@ object Checking {
     val mods = mdef.mods
     def flagSourcePos(flag: FlagSet) =
       mods.mods.find(_.flags == flag).getOrElse(mdef).srcPos
+    if mods.is(Open) then
+      report.error(ModifierNotAllowedForDefinition(Open), flagSourcePos(Open))
     if mods.is(Abstract) then
       report.error(ModifierNotAllowedForDefinition(Abstract), flagSourcePos(Abstract))
     if mods.is(Sealed) then

--- a/tests/neg/i21760.scala
+++ b/tests/neg/i21760.scala
@@ -1,0 +1,1 @@
+open object O // error


### PR DESCRIPTION
Backports #21922 to the 3.3.6.

PR submitted by the release tooling.
[skip ci]