### PR TITLE
Backport "fix: don't consider `into` as a soft-modifier" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Tokens.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Tokens.scala
@@ -294,7 +294,7 @@ object Tokens extends TokensCommon {
 
   final val closingParens = BitSet(RPAREN, RBRACKET, RBRACE)
 
-  final val softModifierNames = Set(nme.inline, nme.into, nme.opaque, nme.open, nme.transparent, nme.infix)
+  final val softModifierNames = Set(nme.inline, nme.opaque, nme.open, nme.transparent, nme.infix)
 
   def showTokenDetailed(token: Int): String = debugString(token)
 

--- a/tests/neg/i21786.check
+++ b/tests/neg/i21786.check
@@ -1,0 +1,6 @@
+-- [E103] Syntax Error: tests/neg/i21786.scala:1:0 ---------------------------------------------------------------------
+1 |into class X // error
+  |^^^^
+  |Illegal start of toplevel definition
+  |
+  | longer explanation available when compiling with `-explain`

--- a/tests/neg/i21786.scala
+++ b/tests/neg/i21786.scala
@@ -1,0 +1,1 @@
+into class X // error

--- a/tests/pos/i21635.scala
+++ b/tests/pos/i21635.scala
@@ -1,0 +1,6 @@
+class A(val into: Boolean) {
+  def m1(): Any =
+    into
+
+  def m2(): Int = 1
+}


### PR DESCRIPTION
Backports #21924 to the 3.3.6.

PR submitted by the release tooling.
[skip ci]