### PR TITLE
Backport "Avoid orphan param from default arg" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -1965,6 +1965,11 @@ class Namer { typer: Typer =>
       val pt = inherited.orElse(expectedDefaultArgType).orElse(fallbackProto).widenExpr
       val tp = typedAheadRhs(pt).tpe
       if (defaultTp eq pt) && (tp frozen_<:< defaultTp) then
+        // See i21558, the default argument new A(1.0) is of type A[?T]
+        // With an uninterpolated, invariant ?T type variable.
+        // So before we return the default getter parameter type (A[? <: Double])
+        // we want to force ?T to instantiate, so it's poly is removed from the constraint
+        isFullyDefined(tp, ForceDegree.all)
         // When possible, widen to the default getter parameter type to permit a
         // larger choice of overrides (see `default-getter.scala`).
         // For justification on the use of `@uncheckedVariance`, see

--- a/tests/pos/i21558.orig.scala
+++ b/tests/pos/i21558.orig.scala
@@ -1,0 +1,10 @@
+class Base
+class A[T <: Float](val f: T) extends Base
+
+def test() = {
+  m1(new A(m2()));
+
+}
+
+def m1(x: Base) = {}
+def m2(p: A[? <: Float] = new A(1.0f)): Int = 1

--- a/tests/pos/i21558.scala
+++ b/tests/pos/i21558.scala
@@ -1,0 +1,8 @@
+class Base
+class A[T <: Double](val f: T) extends Base
+
+class Test:
+  def test() = m1(new A(m2()))
+
+  def m1(x: Base): Unit = {}
+  def m2(p: A[? <: Double] = new A(1.0)): Int = 2


### PR DESCRIPTION
Backports #21824 to the 3.3.6.

PR submitted by the release tooling.
[skip ci]