### PR TITLE
Backport "Fix #21914: Don't project nested wildcard patterns to nullable" to 3.3 LTS

### DIFF
--- a/tests/patmat/null.check
+++ b/tests/patmat/null.check
@@ -1,3 +1,4 @@
 6: Pattern Match
 13: Pattern Match
 20: Pattern Match
+21: Match case Unreachable

--- a/tests/patmat/null.scala
+++ b/tests/patmat/null.scala
@@ -18,5 +18,6 @@ class Test {
     case Some(null)     =>
     case None           =>
     case y              =>
+    case _              =>
   }
 }

--- a/tests/warn/i15503d.scala
+++ b/tests/warn/i15503d.scala
@@ -16,7 +16,7 @@ val a = Sum(S(S(Z)),Z) match {
   case Sum(a@S(b@S(_)), Z) => a // warn
   case Sum(a@S(b@(S(_))), Z) => Sum(a,b) // warn unreachable
   case Sum(_,_) => Z // OK
-  case _ => Z // warn unreachable
+  case _ => Z
 }
 
 // todo : This should pass in the future

--- a/tests/warn/i20121.scala
+++ b/tests/warn/i20121.scala
@@ -1,0 +1,13 @@
+sealed trait T_A[A, B]
+type X = T_A[Byte, Byte]
+
+case class CC_B[A](a: A) extends T_A[A, X]
+
+val v_a: T_A[X, X] = CC_B(null)
+val v_b = v_a match
+  case CC_B(_) => 0 // warn: unreachable
+  case _       => 1
+    // for CC_B[A] to match T_A[X, X]
+    // A := X
+    // so require X, aka T_A[Byte, Byte]
+    // which isn't instantiable, outside of null

--- a/tests/warn/i20122.scala
+++ b/tests/warn/i20122.scala
@@ -1,0 +1,17 @@
+sealed trait T_B[C, D]
+
+case class CC_A()
+case class CC_B[A, C](a: A) extends T_B[C, CC_A]
+case class CC_C[C, D](a: T_B[C, D]) extends T_B[Int, CC_A]
+case class CC_E(a: CC_C[Char, Byte])
+
+val v_a: T_B[Int, CC_A] = CC_B(CC_E(CC_C(null)))
+val v_b = v_a match
+  case CC_B(CC_E(CC_C(_))) => 0 // warn: unreachable
+  case _                   => 1
+    // for CC_B[A, C] to match T_B[C, CC_A]
+    // C <: Int, ok
+    // A <: CC_E, ok
+    // but you need a CC_C[Char, Byte]
+    // which requires a T_B[Char, Byte]
+    // which isn't instantiable, outside of null

--- a/tests/warn/i20123.scala
+++ b/tests/warn/i20123.scala
@@ -1,0 +1,16 @@
+sealed trait T_A[A, B]
+sealed trait T_B[C]
+
+case class CC_D[A, C]() extends T_A[A, C]
+case class CC_E() extends T_B[Nothing]
+case class CC_G[A, C](c: C) extends T_A[A, C]
+
+val v_a: T_A[Boolean, T_B[Boolean]] = CC_G(null)
+val v_b = v_a match {
+  case CC_D()  => 0
+  case CC_G(_) => 1 // warn: unreachable
+    // for CC_G[A, C] to match T_A[Boolean, T_B[Boolean]]
+    // A := Boolean, which is ok
+    // C := T_B[Boolean],
+    // which isn't instantiable, outside of null
+}

--- a/tests/warn/t2755.scala
+++ b/tests/warn/t2755.scala
@@ -19,7 +19,7 @@ object Test {
     case x: Array[String]   => x.size
     case x: Array[AnyRef]   => 5
     case x: Array[?]        => 6
-    case _                  => 7   // warn: only null is matched
+    case _                  => 7
   }
   def f3[T](a: Array[T]) = a match {
     case x: Array[Int]      => x(0)
@@ -28,7 +28,7 @@ object Test {
     case x: Array[String]   => x.size
     case x: Array[AnyRef]   => 5
     case x: Array[?]        => 6
-    case _                  => 7   // warn: only null is matched
+    case _                  => 7
   }
 
 


### PR DESCRIPTION
Backports #21934 to the 3.3.6.

PR submitted by the release tooling.
[skip ci]