### PR TITLE
Backport "Handle old given syntax where identifier and type are seperated by new line" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -113,7 +113,6 @@ object SpaceEngine {
   def isSubspace(a: Space, b: Space)(using Context): Boolean = a.isSubspace(b)
   def canDecompose(typ: Typ)(using Context): Boolean         = typ.canDecompose
   def decompose(typ: Typ)(using Context): List[Typ]          = typ.decompose
-  def nullSpace(using Context): Space = Typ(ConstantType(Constant(null)), decomposed = false)
 
   /** Simplify space such that a space equal to `Empty` becomes `Empty` */
   def computeSimplify(space: Space)(using Context): Space = trace(i"simplify($space)")(space match {
@@ -904,11 +903,6 @@ object SpaceEngine {
       then project(OrType(selTyp, ConstantType(Constant(null)), soft = false))
       else project(selTyp)
     )
-    def projectPat(pat: Tree): Space =
-      // Project toplevel wildcard pattern to nullable
-      if isNullable && isWildcardArg(pat) then Or(project(pat) :: nullSpace :: Nil)
-      else project(pat)
-
     var i        = 0
     val len      = cases.length
     var prevs    = List.empty[Space]
@@ -917,7 +911,7 @@ object SpaceEngine {
     while (i < len) {
       val CaseDef(pat, guard, _) = cases(i)
 
-      val curr = trace(i"project($pat)")(projectPat(pat))
+      val curr = trace(i"project($pat)")(project(pat))
 
       val covered = trace("covered")(simplify(intersect(curr, targetSpace)))
 

--- a/scaladoc/src/scala/tasty/inspector/TastyInspector.scala
+++ b/scaladoc/src/scala/tasty/inspector/TastyInspector.scala
@@ -46,7 +46,7 @@ object ScaladocInternalTastyInspector:
   private def checkFiles(tastyFiles: List[String], jars: List[String]): Unit =
     def checkFile(fileName: String, ext: String): Unit =
       val file = dotty.tools.io.Path(fileName)
-      if !file.ext.toLowerCase.equalsIgnoreCase(ext) then
+      if !file.extension.toLowerCase.equalsIgnoreCase(ext) then
         throw new IllegalArgumentException(s"File extension is not `.$ext`: $file")
       else if !file.exists then
         throw new IllegalArgumentException(s"File not found: ${file.toAbsolute}")

--- a/tests/patmat/null.check
+++ b/tests/patmat/null.check
@@ -1,4 +1,4 @@
 6: Pattern Match
 13: Pattern Match
-20: Pattern Match
-21: Match case Unreachable
+20: Match case Unreachable
+21: Pattern Match

--- a/tests/pos/i21768.scala
+++ b/tests/pos/i21768.scala
@@ -1,0 +1,12 @@
+
+trait Foo[T]:
+  def foo(v: T): Unit
+
+given myFooOfInt:
+  Foo[Int] with
+  def foo(v: Int): Unit = ???
+
+given myFooOfLong:
+  Foo[Long] = new Foo[Long] {
+    def foo(v: Long): Unit = ???
+  }

--- a/tests/warn/i15503d.scala
+++ b/tests/warn/i15503d.scala
@@ -16,7 +16,7 @@ val a = Sum(S(S(Z)),Z) match {
   case Sum(a@S(b@S(_)), Z) => a // warn
   case Sum(a@S(b@(S(_))), Z) => Sum(a,b) // warn unreachable
   case Sum(_,_) => Z // OK
-  case _ => Z
+  case _ => Z // warn unreachable
 }
 
 // todo : This should pass in the future

--- a/tests/warn/t2755.scala
+++ b/tests/warn/t2755.scala
@@ -19,7 +19,7 @@ object Test {
     case x: Array[String]   => x.size
     case x: Array[AnyRef]   => 5
     case x: Array[?]        => 6
-    case _                  => 7
+    case _                  => 7  // warn: only null is matched
   }
   def f3[T](a: Array[T]) = a match {
     case x: Array[Int]      => x(0)
@@ -28,7 +28,7 @@ object Test {
     case x: Array[String]   => x.size
     case x: Array[AnyRef]   => 5
     case x: Array[?]        => 6
-    case _                  => 7
+    case _                  => 7  // warn: only null is matched
   }
 
 


### PR DESCRIPTION
Backports #21957 to the 3.3.6.

PR submitted by the release tooling.