### PR TITLE
Backport "Handle old given syntax where identifier and type are seperated by new line" to 3.3 LTS

### DIFF
--- a/tests/patmat/null.check
+++ b/tests/patmat/null.check
@@ -1,4 +1,4 @@
 6: Pattern Match
 13: Pattern Match
-20: Pattern Match
-21: Match case Unreachable
+20: Match case Unreachable
+21: Pattern Match

--- a/tests/pos/i21768.scala
+++ b/tests/pos/i21768.scala
@@ -1,0 +1,12 @@
+
+trait Foo[T]:
+  def foo(v: T): Unit
+
+given myFooOfInt:
+  Foo[Int] with
+  def foo(v: Int): Unit = ???
+
+given myFooOfLong:
+  Foo[Long] = new Foo[Long] {
+    def foo(v: Long): Unit = ???
+  }


### PR DESCRIPTION
Backports #21957 to the 3.3.6.

PR submitted by the release tooling.