### PR TITLE
Backport "(Re-)Drop inaccessible subclasses from refineUsingParent" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Decorators.scala
+++ b/compiler/src/dotty/tools/dotc/core/Decorators.scala
@@ -284,7 +284,7 @@ object Decorators {
       case _ => String.valueOf(x).nn
 
     /** Returns the simple class name of `x`. */
-    def className: String = x.getClass.getSimpleName.nn
+    def className: String = if x == null then "<null>" else x.getClass.getSimpleName.nn
 
   extension [T](x: T)
     def assertingErrorsReported(using Context): T = {

--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -943,7 +943,11 @@ object TypeOps:
       for tp <- mixins.reverseIterator do
         protoTp1 <:< tp
       maximizeType(protoTp1, NoSpan)
-      wildApprox(protoTp1)
+      val inst = wildApprox(protoTp1)
+      if !inst.classSymbol.exists then
+        // E.g. i21790, can't instantiate S#CA as a subtype of O.A, because O.CA isn't accessible
+        NoType
+      else inst
     }
 
     if (protoTp1 <:< tp2) instantiate()

--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -944,7 +944,7 @@ object TypeOps:
         protoTp1 <:< tp
       maximizeType(protoTp1, NoSpan)
       val inst = wildApprox(protoTp1)
-      if !inst.classSymbol.exists then
+      if inst.classSymbols.isEmpty then
         // E.g. i21790, can't instantiate S#CA as a subtype of O.A, because O.CA isn't accessible
         NoType
       else inst

--- a/tests/pos/i21790.scala
+++ b/tests/pos/i21790.scala
@@ -1,0 +1,14 @@
+package p
+
+trait S:
+  sealed trait A
+  private class CA() extends A
+
+object O extends S
+
+trait T
+
+class Test:
+  def f(e: T) = e match
+    case _: O.A =>
+    case _      =>


### PR DESCRIPTION
Backports #21930 to the 3.3.6.

PR submitted by the release tooling.
[skip ci]