### PR TITLE
Backport "Fix for macro annotation that resolves macro-based implicit crashing the compiler" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
@@ -1065,6 +1065,8 @@ class Inliner(val call: tpd.Tree)(using Context):
     new TreeAccumulator[List[Symbol]] {
       override def apply(syms: List[Symbol], tree: tpd.Tree)(using Context): List[Symbol] =
         tree match {
+          case Closure(env, meth, tpt) if meth.symbol.isAnonymousFunction =>
+            this(syms, tpt :: env)
           case tree: RefTree if tree.isTerm && level == -1 && tree.symbol.isDefinedInCurrentRun && !tree.symbol.isLocal =>
             foldOver(tree.symbol :: syms, tree)
           case _: This if level == -1 && tree.symbol.isDefinedInCurrentRun =>

--- a/tests/pos-macros/i20353/Macro_1.scala
+++ b/tests/pos-macros/i20353/Macro_1.scala
@@ -1,0 +1,22 @@
+//> using options -experimental -Yno-experimental
+
+import scala.annotation.{experimental, MacroAnnotation}
+import scala.quoted.*
+
+class ImplicitValue
+
+object ImplicitValue:
+  inline given ImplicitValue =
+    ${ makeImplicitValue }
+
+  def makeImplicitValue(using Quotes) =
+    import quotes.reflect.*
+    '{ ImplicitValue() }
+end ImplicitValue
+
+@experimental
+class Test extends MacroAnnotation:
+  def transform(using Quotes)(tree: quotes.reflect.Definition) =
+    import quotes.reflect.*
+    Implicits.search(TypeRepr.of[ImplicitValue])
+    List(tree)

--- a/tests/pos-macros/i20353/Macro_1.scala
+++ b/tests/pos-macros/i20353/Macro_1.scala
@@ -16,7 +16,7 @@ end ImplicitValue
 
 @experimental
 class Test extends MacroAnnotation:
-  def transform(using Quotes)(tree: quotes.reflect.Definition) =
+  def transform(using Quotes)(definition: quotes.reflect.Definition, companion: Option[quotes.reflect.Definition]) =
     import quotes.reflect.*
     Implicits.search(TypeRepr.of[ImplicitValue])
-    List(tree)
+    List(definition)

--- a/tests/pos-macros/i20353/Macro_1.scala
+++ b/tests/pos-macros/i20353/Macro_1.scala
@@ -1,4 +1,4 @@
-//> using options -experimental -Yno-experimental
+//> using options -experimental
 
 import scala.annotation.{experimental, MacroAnnotation}
 import scala.quoted.*

--- a/tests/pos-macros/i20353/Test_2.scala
+++ b/tests/pos-macros/i20353/Test_2.scala
@@ -1,0 +1,17 @@
+//> using options -experimental -Yno-experimental
+
+class OuterClass:
+  @Test
+  class InnerClass
+
+  @Test
+  object InnerObject
+end OuterClass
+
+object OuterObject:
+  @Test
+  class InnerClass
+
+  @Test
+  object InnerObject
+end OuterObject

--- a/tests/pos-macros/i20353/Test_2.scala
+++ b/tests/pos-macros/i20353/Test_2.scala
@@ -1,4 +1,4 @@
-//> using options -experimental -Yno-experimental
+//> using options -experimental
 
 class OuterClass:
   @Test


### PR DESCRIPTION
Backports #20353 to the 3.3.6.

PR submitted by the release tooling.
[skip ci]