### PR TITLE
Backport "Allow macro annotations to recover from suspension" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/MacroAnnotations.scala
+++ b/compiler/src/dotty/tools/dotc/transform/MacroAnnotations.scala
@@ -60,6 +60,8 @@ class MacroAnnotations:
               //       Replace this case with the nested cases.
               case ex0: InvocationTargetException =>
                 ex0.getCause match
+                  case ex: CompilationUnit.SuspendException =>
+                    throw ex
                   case ex: scala.quoted.runtime.StopMacroExpansion =>
                     if !ctx.reporter.hasErrors then
                       report.error("Macro expansion was aborted by the macro without any errors reported. Macros should issue errors to end-users when aborting a macro expansion with StopMacroExpansion.", annot.tree)

--- a/tests/neg-macros/annot-crash.check
+++ b/tests/neg-macros/annot-crash.check
@@ -2,7 +2,7 @@
 -- Error: tests/neg-macros/annot-crash/Test_2.scala:1:0 ----------------------------------------------------------------
 1 |@crash // error
   |^^^^^^
-  |Failed to evaluate macro.
+  |Failed to evaluate macro annotation '@crash'.
   |  Caused by class scala.NotImplementedError: an implementation is missing
   |    scala.Predef$.$qmark$qmark$qmark(Predef.scala:344)
   |    crash.transform(Macro_1.scala:7)


### PR DESCRIPTION
Backports #21969 to the 3.3.6.

PR submitted by the release tooling.
[skip ci]