### PR TITLE
Backport "improvement: Update mtags to 1.4.1 and backport remaining changes" to 3.3 LTS

### DIFF
--- a/presentation-compiler/src/main/dotty/tools/pc/printer/ShortenedTypePrinter.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/printer/ShortenedTypePrinter.scala
@@ -3,6 +3,7 @@ package dotty.tools.pc.printer
 import scala.collection.mutable
 import scala.meta.internal.jdk.CollectionConverters.*
 import scala.meta.internal.metals.ReportContext
+import scala.meta.internal.mtags.KeywordWrapper
 import scala.meta.pc.SymbolDocumentation
 import scala.meta.pc.SymbolSearch
 
@@ -63,6 +64,11 @@ class ShortenedTypePrinter(
     )
 
   private val foundRenames = collection.mutable.LinkedHashMap.empty[Symbol, String]
+
+  override def nameString(name: Name): String =
+    val nameStr = super.nameString(name)
+    if (nameStr.nonEmpty) KeywordWrapper.Scala3Keywords.backtickWrap(nameStr)
+    else nameStr
 
   def getUsedRenames: Map[Symbol, String] =
     foundRenames.toMap.filter { case (k, v) => k.showName != v }

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionKeywordSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionKeywordSuite.scala
@@ -437,6 +437,7 @@ class CompletionKeywordSuite extends BaseCompletionSuite:
          |given
          |extension
          |type
+         |opaque type
          |class
          |enum
          |case class

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
@@ -1135,7 +1135,7 @@ class CompletionSuite extends BaseCompletionSuite:
           |  scala@@
           |}
           |""".stripMargin,
-      """|scala <root>
+      """|scala `<root>`
          |""".stripMargin
     )
 
@@ -1725,8 +1725,8 @@ class CompletionSuite extends BaseCompletionSuite:
     check(
       """|import @@
          |""".stripMargin,
-      """|java <root>
-         |javax <root>
+      """|java `<root>`
+         |javax `<root>`
          |""".stripMargin,
       filter = _.startsWith("java")
     )
@@ -1744,8 +1744,8 @@ class CompletionSuite extends BaseCompletionSuite:
     check(
       """|export @@
          |""".stripMargin,
-      """|java <root>
-         |javax <root>
+      """|java `<root>`
+         |javax `<root>`
          |""".stripMargin,
       filter = _.startsWith("java")
     )

--- a/presentation-compiler/test/dotty/tools/pc/tests/edit/InsertInferredTypeSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/edit/InsertInferredTypeSuite.scala
@@ -597,6 +597,78 @@ class InsertInferredTypeSuite extends BaseCodeActionSuite:
          |""".stripMargin
     )
 
+  @Test def `backticks-4` =
+  checkEdit(
+    """|case class `Foo-Foo`(i: Int)
+       |object O{
+       |  val <<foo>> = `Foo-Foo`(1)
+       |}""".stripMargin,
+    """|case class `Foo-Foo`(i: Int)
+       |object O{
+       |  val foo: `Foo-Foo` = `Foo-Foo`(1)
+       |}
+       |""".stripMargin
+  )
+
+
+  @Test def `backticks-5` =
+    checkEdit(
+      """|object A{
+         |  case class `Foo-Foo`(i: Int)
+         |}
+         |object O{
+         |  val <<foo>> = A.`Foo-Foo`(1)
+         |}""".stripMargin,
+      """|import A.`Foo-Foo`
+         |object A{
+         |  case class `Foo-Foo`(i: Int)
+         |}
+         |object O{
+         |  val foo: `Foo-Foo` = A.`Foo-Foo`(1)
+         |}
+         |""".stripMargin
+    )
+
+
+  @Test def `backticks-6` =
+    checkEdit(
+      """|object A{
+         |  case class `Foo-Foo`[A](i: A)
+         |}
+         |object O{
+         |  val <<foo>> = A.`Foo-Foo`(1)
+         |}""".stripMargin,
+      """|import A.`Foo-Foo`
+         |object A{
+         |  case class `Foo-Foo`[A](i: A)
+         |}
+         |object O{
+         |  val foo: `Foo-Foo`[Int] = A.`Foo-Foo`(1)
+         |}
+         |""".stripMargin
+    )
+
+  @Test def `backticks-7` =
+    checkEdit(
+      """|object A{
+         |  class `x-x`
+         |  case class Foo[A](i: A)
+         |}
+         |object O{
+         |  val <<foo>> = A.Foo(new A.`x-x`)
+         |}""".stripMargin,
+      """|import A.Foo
+         |import A.`x-x`
+         |object A{
+         |  class `x-x`
+         |  case class Foo[A](i: A)
+         |}
+         |object O{
+         |  val foo: Foo[`x-x`] = A.Foo(new A.`x-x`)
+         |}
+         |""".stripMargin
+    )
+
   @Test def `literal-types1` =
     checkEdit(
       """|object O {

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -262,6 +262,9 @@ object Build {
       // sbt will complain if we don't exclude them here.
       Keys.scalaSource, Keys.javaSource
     ),
+
+    // This is used to download nightly builds of the Scala 2 library in `scala2-library-bootstrapped`
+    resolvers += "scala-integration" at "https://scala-ci.typesafe.com/artifactory/scala-integration/"
   )
 
   lazy val disableDocSetting =
@@ -1181,7 +1184,7 @@ object Build {
       BuildInfoPlugin.buildInfoDefaultSettings
 
   lazy val presentationCompilerSettings = {
-    val mtagsVersion = "1.3.5"
+    val mtagsVersion = "1.4.1"
     Seq(
       libraryDependencies ++= Seq(
         "org.lz4" % "lz4-java" % "1.8.0",


### PR DESCRIPTION
Backports #21859 to the 3.3.6.

PR submitted by the release tooling.
[skip ci]