### PR TITLE
Backport "Do not crash when typing a closure with unknown type, since it can occur for erroneous input" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -1111,7 +1111,7 @@ class Namer { typer: Typer =>
     private def exportForwarders(exp: Export, pathMethod: Symbol)(using Context): List[tpd.MemberDef] =
       val buf = new mutable.ListBuffer[tpd.MemberDef]
       val Export(expr, selectors) = exp
-      if expr.isEmpty then
+      if expr.isEmpty || selectors.exists(_.imported.name == nme.ERROR) then
         report.error(em"Export selector must have prefix and `.`", exp.srcPos)
         return Nil
 

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -1111,7 +1111,7 @@ class Namer { typer: Typer =>
     private def exportForwarders(exp: Export, pathMethod: Symbol)(using Context): List[tpd.MemberDef] =
       val buf = new mutable.ListBuffer[tpd.MemberDef]
       val Export(expr, selectors) = exp
-      if expr.isEmpty || selectors.exists(_.imported.name == nme.ERROR) then
+      if expr.isEmpty then
         report.error(em"Export selector must have prefix and `.`", exp.srcPos)
         return Nil
 

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1722,8 +1722,6 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
                   EmptyTree
             }
           case tp =>
-            if !tp.isErroneous then
-              throw new java.lang.Error(i"internal error: closing over non-method $tp, pos = ${tree.span}")
             TypeTree(defn.AnyType)
         }
       else typed(tree.tpt)

--- a/tests/neg/i20511-1.check
+++ b/tests/neg/i20511-1.check
@@ -1,0 +1,32 @@
+-- [E083] Type Error: tests/neg/i20511-1.scala:7:7 ---------------------------------------------------------------------
+7 |export toppingPrice.apply, crustPrice.apply, crustPrice.unlift // error // error // error // error // error
+  |       ^^^^^^^^^^^^
+  |       Int => Double is not a valid export prefix, since it is not an immutable path
+  |
+  | longer explanation available when compiling with `-explain`
+-- [E083] Type Error: tests/neg/i20511-1.scala:7:27 --------------------------------------------------------------------
+7 |export toppingPrice.apply, crustPrice.apply, crustPrice.unlift // error // error // error // error // error
+  |                           ^^^^^^^^^^
+  |                           Any is not a valid export prefix, since it is not an immutable path
+  |
+  | longer explanation available when compiling with `-explain`
+-- Error: tests/neg/i20511-1.scala:7:38 --------------------------------------------------------------------------------
+7 |export toppingPrice.apply, crustPrice.apply, crustPrice.unlift // error // error // error // error // error
+  |                                      ^^^^^
+  |                                      no eligible member apply at {
+  |                                        def $anonfun(crustType: Double): Double = pakiet.crustPrice(crustType)
+  |                                        closure(pakiet.$anonfun:Any)
+  |                                      }
+-- [E083] Type Error: tests/neg/i20511-1.scala:7:45 --------------------------------------------------------------------
+7 |export toppingPrice.apply, crustPrice.apply, crustPrice.unlift // error // error // error // error // error
+  |                                             ^^^^^^^^^^
+  |                                             Any is not a valid export prefix, since it is not an immutable path
+  |
+  | longer explanation available when compiling with `-explain`
+-- Error: tests/neg/i20511-1.scala:7:56 --------------------------------------------------------------------------------
+7 |export toppingPrice.apply, crustPrice.apply, crustPrice.unlift // error // error // error // error // error
+  |                                                        ^^^^^^
+  |                                          no eligible member unlift at {
+  |                                            def $anonfun(crustType: Double): Double = pakiet.crustPrice(crustType)
+  |                                            closure(pakiet.$anonfun:Any)
+  |                                          }

--- a/tests/neg/i20511-1.scala
+++ b/tests/neg/i20511-1.scala
@@ -4,4 +4,4 @@ def toppingPrice(size: Int): Double = ???
 
 def crustPrice(crustType: Double): Double = ???
 
-export toppingPrice.apply, crustPrice.unlift // error // error // error
+export toppingPrice.apply, crustPrice.apply, crustPrice.unlift // error // error // error // error // error

--- a/tests/neg/i20511-1.scala
+++ b/tests/neg/i20511-1.scala
@@ -1,0 +1,7 @@
+package pakiet
+
+def toppingPrice(size: Int): Double = ???
+
+def crustPrice(crustType: Double): Double = ???
+
+export toppingPrice.apply, crustPrice.unlift // error // error // error

--- a/tests/neg/i20511.check
+++ b/tests/neg/i20511.check
@@ -1,0 +1,12 @@
+-- [E040] Syntax Error: tests/neg/i20511.scala:7:19 --------------------------------------------------------------------
+7 |export toppingPrice, crustPrice // error // error
+  |                   ^
+  |                   '.' expected, but ',' found
+-- [E040] Syntax Error: tests/neg/i20511.scala:8:0 ---------------------------------------------------------------------
+8 |val i = 1 // error
+  |^^^
+  |'.' expected, but 'end of statement' found
+-- Error: tests/neg/i20511.scala:7:21 ----------------------------------------------------------------------------------
+7 |export toppingPrice, crustPrice // error // error
+  |                     ^^^^^^^^^^
+  |                     Export selector must have prefix and `.`

--- a/tests/neg/i20511.check
+++ b/tests/neg/i20511.check
@@ -6,7 +6,9 @@
 8 |val i = 1 // error
   |^^^
   |'.' expected, but 'end of statement' found
--- Error: tests/neg/i20511.scala:7:21 ----------------------------------------------------------------------------------
+-- [E083] Type Error: tests/neg/i20511.scala:7:21 ----------------------------------------------------------------------
 7 |export toppingPrice, crustPrice // error // error
   |                     ^^^^^^^^^^
-  |                     Export selector must have prefix and `.`
+  |                     Any is not a valid export prefix, since it is not an immutable path
+  |
+  | longer explanation available when compiling with `-explain`

--- a/tests/neg/i20511.scala
+++ b/tests/neg/i20511.scala
@@ -1,0 +1,8 @@
+package pakiet
+
+def toppingPrice(size: Int): Double = ???
+
+def crustPrice(crustType: Double): Double = ???
+
+export toppingPrice, crustPrice // error // error
+val i = 1 // error


### PR DESCRIPTION
Backports #21178 to the 3.3.6.

PR submitted by the release tooling.
[skip ci]