### PR TITLE
Backport "sbt 1.10.5 (was 1.9.9)" to 3.3 LTS

### DIFF
--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -22,5 +22,5 @@ RUN apt-get update && \
 # Install sbt
 ENV SBT_HOME /usr/local/sbt
 ENV PATH ${SBT_HOME}/bin:${PATH}
-ENV SBT_VERSION 1.9.0
+ENV SBT_VERSION 1.10.5
 RUN curl -sL "https://github.com/sbt/sbt/releases/download/v$SBT_VERSION/sbt-$SBT_VERSION.tgz" | gunzip | tar -x -C /usr/local

--- a/community-build/src/scala/dotty/communitybuild/projects.scala
+++ b/community-build/src/scala/dotty/communitybuild/projects.scala
@@ -128,7 +128,7 @@ final case class SbtCommunityProject(
       case Some(ivyHome) => List(s"-Dsbt.ivy.home=$ivyHome")
       case _ => Nil
     extraSbtArgs ++ sbtProps ++ List(
-      "-sbt-version", "1.9.7",
+      "-sbt-version", "1.10.5",
       "-Dsbt.supershell=false",
       s"-Ddotty.communitybuild.dir=$communitybuildDir",
       s"--addPluginSbtFile=$sbtPluginFilePath"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -28,5 +28,5 @@ object Dependencies {
     "com.vladsch.flexmark" % "flexmark-ext-yaml-front-matter" % flexmarkVersion,
   )
 
-  val compilerInterface = "org.scala-sbt" % "compiler-interface" % "1.9.6"
+  val compilerInterface = "org.scala-sbt" % "compiler-interface" % "1.10.4"
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.9
+sbt.version=1.10.5

--- a/tests/cmdTest-sbt-tests/sourcepath-with-inline-api-hash/project/build.properties
+++ b/tests/cmdTest-sbt-tests/sourcepath-with-inline-api-hash/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.7
+sbt.version=1.10.5

--- a/tests/cmdTest-sbt-tests/sourcepath-with-inline/project/build.properties
+++ b/tests/cmdTest-sbt-tests/sourcepath-with-inline/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.7
+sbt.version=1.10.5


### PR DESCRIPTION
Backports #20157 to the 3.3.6.

PR submitted by the release tooling.
[skip ci]