### PR TITLE
Backport "Rethrow SuspendExceptions caught in CodeGen phase" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/CodeGen.scala
+++ b/compiler/src/dotty/tools/backend/jvm/CodeGen.scala
@@ -83,6 +83,7 @@ class CodeGen(val int: DottyBackendInterface, val primitives: DottyPrimitives)( 
         registerGeneratedClass(mirrorClassNode, isArtifact = true)
       catch
         case ex: InterruptedException => throw ex
+        case ex: CompilationUnit.SuspendException => throw ex
         case ex: Throwable =>
           ex.printStackTrace()
           report.error(s"Error while emitting ${unit.source}\n${ex.getMessage}", NoSourcePosition)

--- a/tests/pos-macros/i21983/Test.scala
+++ b/tests/pos-macros/i21983/Test.scala
@@ -1,0 +1,13 @@
+package example
+
+sealed trait Test
+
+object Test {
+  case object Foo extends Test
+
+  val visitorType = mkVisitorType[Test]
+
+  trait Visitor[A] {
+    type V[a] = visitorType.Out[a]
+  }
+}

--- a/tests/pos-macros/i21983/UsesTest.scala
+++ b/tests/pos-macros/i21983/UsesTest.scala
@@ -1,0 +1,3 @@
+package example
+
+val _ = Test.Foo

--- a/tests/pos-macros/i21983/VisitorMacros.scala
+++ b/tests/pos-macros/i21983/VisitorMacros.scala
@@ -1,0 +1,13 @@
+package example
+
+import scala.deriving.Mirror
+import scala.quoted.*
+
+private def mkVisitorTypeImpl[T: Type](using q: Quotes): Expr[VisitorType[T]] =
+  '{new VisitorType[T]{}}
+
+transparent inline def mkVisitorType[T]: VisitorType[T] = ${ mkVisitorTypeImpl[T] }
+
+trait VisitorType[T] {
+  type Out[A]
+}


### PR DESCRIPTION
Backports #22009 to the 3.3.6.

PR submitted by the release tooling.
[skip ci]