### PR TITLE
Backport "fix match error in keyword completions" to 3.3 LTS

### DIFF
--- a/presentation-compiler/src/main/dotty/tools/pc/completions/KeywordsCompletions.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/KeywordsCompletions.scala
@@ -216,6 +216,7 @@ object KeywordsCompletions:
       case untpd.TypeDef(_, template: Template) => checkForPossibleKeywords(template)
       case untpd.ModuleDef(_, template: Template) => checkForPossibleKeywords(template)
       case template: Template => checkForPossibleKeywords(template)
+      case _ => TemplateKeywordAvailability.default
     }.getOrElse(TemplateKeywordAvailability.default)
 
 

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
@@ -2116,3 +2116,21 @@ class CompletionSuite extends BaseCompletionSuite:
          |""".stripMargin,
       assertSingleItem = false
     )
+
+  @Test def `metals-i6861` =
+    check(
+      """|trait Builder[Alg]:
+         |  def withTraces: String
+         |
+         |trait BuilderFactory:
+         |  def transformRouter(f: [Alg] => Builder[Alg] => String): BuilderFactory
+         |  def build: Unit
+         |
+         |def demo =
+         |  (??? : BuilderFactory)
+         |    .transformRouter([Alg] => _.withTraces)
+         |    .build@@
+         |""".stripMargin,
+      """|build: Unit
+         |""".stripMargin,
+    )


### PR DESCRIPTION
Backports #22138 to the 3.3.6.

PR submitted by the release tooling.