### PR TITLE
Backport "[ISSUE-#19208] If scaladocs on file protocol don't do SPA routing." to 3.3 LTS

### DIFF
--- a/scaladoc/resources/dotty_res/scripts/ux.js
+++ b/scaladoc/resources/dotty_res/scripts/ux.js
@@ -167,6 +167,11 @@ function attachAllListeners() {
       if (url.origin !== window.location.origin) {
         return;
       }
+      // ISSUE-19208, treat as normal link when lacking HTTP server,
+      // otherwise GET request blocked by CORS protections.
+      if (window.location.protocol.startsWith("file")) {
+        return;
+      }
       if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) {
         return;
       }


### PR DESCRIPTION
Backports #22013 to the 3.3.6.

PR submitted by the release tooling.
[skip ci]