### PR TITLE
Backport "Do not bring forward symbols created in transform and backend phases" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Denotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Denotations.scala
@@ -736,6 +736,8 @@ object Denotations {
      *     the old version otherwise.
      *   - If the symbol did not have a denotation that was defined at the current phase
      *     return a NoDenotation instead.
+     *   - If the symbol was first defined in one of the transform phases (after pickling), it should not
+     *     be visible in new runs, so also return a NoDenotation.
      */
     private def bringForward()(using Context): SingleDenotation = {
       this match {
@@ -749,6 +751,7 @@ object Denotations {
       }
       if (!symbol.exists) return updateValidity()
       if (!coveredInterval.containsPhaseId(ctx.phaseId)) return NoDenotation
+      if (coveredInterval.firstPhaseId >= Phases.firstTransformPhase.id) return NoDenotation
       if (ctx.debug) traceInvalid(this)
       staleSymbolError
     }

--- a/tests/pos-macros/i21844/Macro.scala
+++ b/tests/pos-macros/i21844/Macro.scala
@@ -1,0 +1,6 @@
+import scala.quoted.*
+
+object Macro:
+  inline def foo = ${ fooImpl }
+  def fooImpl(using Quotes): Expr[Int] =
+    '{ 123 }

--- a/tests/pos-macros/i21844/SubClass.scala
+++ b/tests/pos-macros/i21844/SubClass.scala
@@ -1,0 +1,3 @@
+class SubClass extends SuperClass
+object SubClass:
+  val foo: Int = Macro.foo

--- a/tests/pos-macros/i21844/SuperClassWithLazyVal.scala
+++ b/tests/pos-macros/i21844/SuperClassWithLazyVal.scala
@@ -1,0 +1,2 @@
+class SuperClass:
+  lazy val xyz: Int = 123


### PR DESCRIPTION
Backports #21865 to the 3.3.6.

PR submitted by the release tooling.
[skip ci]