### PR TITLE
Backport "Remove tests/pos-with-compiler-cc from VSCode ignored files" to 3.3 LTS

### DIFF
--- a/.vscode-template/settings.json
+++ b/.vscode-template/settings.json
@@ -9,7 +9,6 @@
     "**/*.class": true,
     "**/*.tasty": true,
     "**/target/": true,
-    "community-build/community-projects": true,
-    "tests/pos-with-compiler-cc/dotc/**/*.scala": true
+    "community-build/community-projects": true
   }
 }


### PR DESCRIPTION
Backports #22198 to the 3.3.6.

PR submitted by the release tooling.
[skip ci]