### PR TITLE
Backport "Add type parameters derived from enum to default param getters of enum cases" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -481,15 +481,15 @@ object desugar {
     val originalTparams = constr1.leadingTypeParams
     val originalVparamss = asTermOnly(constr1.trailingParamss)
     lazy val derivedEnumParams = enumClass.typeParams.map(derivedTypeParamWithVariance)
-    val impliedTparams =
-      if (isEnumCase) {
+    val enumTParams =
+      if isEnumCase then
         val tparamReferenced = typeParamIsReferenced(
-            enumClass.typeParams, originalTparams, originalVparamss, parents)
-        if (originalTparams.isEmpty && (parents.isEmpty || tparamReferenced))
+          enumClass.typeParams, originalTparams, originalVparamss, parents)
+        if originalTparams.isEmpty && (parents.isEmpty || tparamReferenced) then
           derivedEnumParams.map(tdef => tdef.withFlags(tdef.mods.flags | PrivateLocal))
-        else originalTparams
-      }
-      else originalTparams
+        else Nil
+      else Nil
+    val impliedTparams = enumTParams ++ originalTparams
 
     if mods.is(Trait) then
       for vparams <- originalVparamss; vparam <- vparams do
@@ -519,6 +519,11 @@ object desugar {
         derivedTermParam(vparam).withAnnotations(Nil))
 
     val constr = cpy.DefDef(constr1)(paramss = joinParams(constrTparams, constrVparamss))
+    if enumTParams.nonEmpty then
+      defaultGetters = defaultGetters.map:
+        case ddef: DefDef =>
+          val tParams = enumTParams.map(tparam => toMethParam(tparam, KeepAnnotations.All))
+          cpy.DefDef(ddef)(paramss = joinParams(tParams, ddef.trailingParamss))
 
     val (normalizedBody, enumCases, enumCompanionRef) = {
       // Add constructor type parameters and evidence implicit parameters

--- a/tests/pos/i22137.scala
+++ b/tests/pos/i22137.scala
@@ -1,0 +1,5 @@
+enum Parser[+Value]:
+  case Success(value: Value, issues: Seq[Failure] = Seq.empty) extends Parser[Value]
+  case Failure(exception: Throwable)                           extends Parser[Nothing]
+
+val v = Parser.Success(1)


### PR DESCRIPTION
Backports #22157 to the 3.3.6.

PR submitted by the release tooling.
[skip ci]