### PR TITLE
Backport "Resolve name when named imp is behind wild imps" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -522,7 +522,7 @@ object desugar {
     if enumTParams.nonEmpty then
       defaultGetters = defaultGetters.map:
         case ddef: DefDef =>
-          val tParams = enumTParams.map(tparam => toMethParam(tparam, KeepAnnotations.All))
+          val tParams = enumTParams.map(tparam => toDefParam(tparam, keepAnnotations = true))
           cpy.DefDef(ddef)(paramss = joinParams(tParams, ddef.trailingParamss))
 
     val (normalizedBody, enumCases, enumCompanionRef) = {

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -885,6 +885,8 @@ trait Applications extends Compatibility {
       val app1 =
         if !success then app0.withType(UnspecifiedErrorType)
         else {
+          if isAnnotConstr(methRef.symbol) && !isJavaAnnotConstr(methRef.symbol) then
+            typedArgs
           if !sameSeq(args, orderedArgs)
              && !isJavaAnnotConstr(methRef.symbol)
              && !typedArgs.forall(isSafeArg)

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -205,27 +205,29 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
         !owner.isEmptyPackage || ctx.owner.enclosingPackageClass.isEmptyPackage
       }
 
+    import BindingPrec.*
+    type Result = (Type, BindingPrec)
+    val NoResult = (NoType, NothingBound)
+
     /** Find the denotation of enclosing `name` in given context `ctx`.
-     *  @param previous    A denotation that was found in a more deeply nested scope,
-     *                     or else `NoDenotation` if nothing was found yet.
-     *  @param prevPrec    The binding precedence of the previous denotation,
-     *                     or else `nothingBound` if nothing was found yet.
+     *  @param prevResult  A type that was found in a more deeply nested scope,
+     *                     and its precedence, or NoResult if nothing was found yet.
      *  @param prevCtx     The context of the previous denotation,
      *                     or else `NoContext` if nothing was found yet.
      */
-    def findRefRecur(previous: Type, prevPrec: BindingPrec, prevCtx: Context)(using Context): Type = {
-      import BindingPrec.*
+    def findRefRecur(prevResult: Result, prevCtx: Context)(using Context): Result = {
+      val (previous, prevPrec) = prevResult
 
       /** Check that any previously found result from an inner context
        *  does properly shadow the new one from an outer context.
-       *  @param found     The newly found result
-       *  @param newPrec   Its precedence
+       *  @param newResult The newly found type and its precedence.
        *  @param scala2pkg Special mode where we check members of the same package, but defined
        *                   in different compilation units under Scala2. If set, and the
        *                   previous and new contexts do not have the same scope, we select
        *                   the previous (inner) definition. This models what scalac does.
        */
-      def checkNewOrShadowed(found: Type, newPrec: BindingPrec, scala2pkg: Boolean = false)(using Context): Type =
+      def checkNewOrShadowed(newResult: Result, scala2pkg: Boolean = false)(using Context): Result =
+        val (found, newPrec) = newResult
         if !previous.exists || TypeComparer.isSameRef(previous, found) then
            found
         else if (prevCtx.scope eq ctx.scope)
@@ -233,29 +235,24 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
         then
           // special cases: definitions beat imports, and named imports beat
           // wildcard imports, provided both are in contexts with same scope
-          found
+          newResult
         else
           if !scala2pkg && !previous.isError && !found.isError then
             fail(AmbiguousReference(name, newPrec, prevPrec, prevCtx))
           previous
-
-      /** Assemble and check alternatives to an imported reference. This implies:
-       *   - If we expand an extension method (i.e. altImports != null),
-       *     search imports on the same level for other possible resolutions of `name`.
-       *     The result and altImports together then contain all possible imported
-       *     references of the highest possible precedence, where `NamedImport` beats
        *     `WildImport`.
        *   - Find a posssibly shadowing reference in an outer context.
        *     If the result is the same as `previous`, check that it is new or
        *     shadowed. This order of checking is necessary since an outer package-level
        *     definition might trump two conflicting inner imports, so no error should be
        *     issued in that case. See i7876.scala.
-       *  @param previous   the previously found reference (which is an import)
-       *  @param prevPrec   the precedence of the reference (either NamedImport or WildImport)
+       *  @param prevResult the previously found reference (which is an import), and
+       *                    the precedence of the reference (either NamedImport or WildImport)
        *  @param prevCtx    the context in which the reference was found
        *  @param using_Context the outer context of `precCtx`
        */
-      def checkImportAlternatives(previous: Type, prevPrec: BindingPrec, prevCtx: Context)(using Context): Type =
+      def checkImportAlternatives(prevResult: Result, prevCtx: Context)(using Context): Result =
+        val (previous, prevPrec) = prevResult
 
         def addAltImport(altImp: TermRef) =
           if !TypeComparer.isSameRef(previous, altImp)
@@ -270,20 +267,20 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
               if prevPrec == WildImport then
                 // Discard all previously found references and continue with `altImp`
                 altImports.clear()
-                checkImportAlternatives(altImp, NamedImport, ctx)(using ctx.outer)
+                checkImportAlternatives((altImp, NamedImport), ctx)(using ctx.outer)
               else
                 addAltImport(altImp)
-                checkImportAlternatives(previous, prevPrec, prevCtx)(using ctx.outer)
+                checkImportAlternatives(prevResult, prevCtx)(using ctx.outer)
             case _ =>
               if prevPrec == WildImport then
                 wildImportRef(curImport) match
                   case altImp: TermRef => addAltImport(altImp)
                   case _ =>
-              checkImportAlternatives(previous, prevPrec, prevCtx)(using ctx.outer)
+              checkImportAlternatives(prevResult, prevCtx)(using ctx.outer)
         else
-          val found = findRefRecur(previous, prevPrec, prevCtx)
-          if found eq previous then checkNewOrShadowed(found, prevPrec)(using prevCtx)
-          else found
+          val foundResult = findRefRecur(prevResult, prevCtx)
+          if foundResult._1 eq previous then checkNewOrShadowed(foundResult)(using prevCtx)
+          else foundResult
       end checkImportAlternatives
 
       def selection(imp: ImportInfo, name: Name, checkBounds: Boolean): Type =
@@ -370,10 +367,10 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
         !noImports &&
         (prevPrec.ordinal < prec.ordinal || prevPrec == prec && (prevCtx.scope eq ctx.scope))
 
-      @tailrec def loop(lastCtx: Context)(using Context): Type =
-        if (ctx.scope eq EmptyScope) previous
+      @tailrec def loop(lastCtx: Context)(using Context): Result =
+        if (ctx.scope eq EmptyScope) prevResult
         else {
-          var result: Type = NoType
+          var result: Result = NoResult
           val curOwner = ctx.owner
 
           /** Is curOwner a package object that should be skipped?
@@ -472,7 +469,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
                   effectiveOwner.thisType.select(name, defDenot)
                 }
               if !curOwner.is(Package) || isDefinedInCurrentUnit(defDenot) then
-                result = checkNewOrShadowed(found, Definition) // no need to go further out, we found highest prec entry
+                result = checkNewOrShadowed((found, Definition)) // no need to go further out, we found highest prec entry
                 found match
                   case found: NamedType
                   if curOwner.isClass && isInherited(found.denot) && !ctx.compilationUnit.isJava =>
@@ -480,29 +477,28 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
                   case _ =>
               else
                 if migrateTo3 && !foundUnderScala2.exists then
-                  foundUnderScala2 = checkNewOrShadowed(found, Definition, scala2pkg = true)
+                  foundUnderScala2 = checkNewOrShadowed((found, Definition), scala2pkg = true)._1
                 if (defDenot.symbol.is(Package))
-                  result = checkNewOrShadowed(previous orElse found, PackageClause)
+                  result = checkNewOrShadowed((previous orElse found, PackageClause))
                 else if (prevPrec.ordinal < PackageClause.ordinal)
-                  result = findRefRecur(found, PackageClause, ctx)(using ctx.outer)
+                  result = findRefRecur((found, PackageClause), ctx)(using ctx.outer)
             }
 
-          if result.exists then result
+          if result._1.exists then result
           else {  // find import
             val outer = ctx.outer
             val curImport = ctx.importInfo
-            def updateUnimported() =
-              if (curImport.nn.unimported ne NoSymbol) unimported += curImport.nn.unimported
             if (curOwner.is(Package) && curImport != null && curImport.isRootImport && previous.exists)
-              previous // no more conflicts possible in this case
-            else if (isPossibleImport(NamedImport) && (curImport nen outer.importInfo)) {
-              val namedImp = namedImportRef(curImport.uncheckedNN)
+              prevResult // no more conflicts possible in this case
+            else if (isPossibleImport(NamedImport) && curImport != null && (curImport ne outer.importInfo)) {
+              def updateUnimported() = if curImport.unimported ne NoSymbol then unimported += curImport.unimported
+              val namedImp = namedImportRef(curImport)
               if (namedImp.exists)
-                checkImportAlternatives(namedImp, NamedImport, ctx)(using outer)
-              else if (isPossibleImport(WildImport) && !curImport.nn.importSym.isCompleting) {
-                val wildImp = wildImportRef(curImport.uncheckedNN)
+                checkImportAlternatives((namedImp, NamedImport), ctx)(using outer)
+              else if (isPossibleImport(WildImport) && !curImport.importSym.isCompleting) {
+                val wildImp = wildImportRef(curImport)
                 if (wildImp.exists)
-                  checkImportAlternatives(wildImp, WildImport, ctx)(using outer)
+                  checkImportAlternatives((wildImp, WildImport), ctx)(using outer)
                 else {
                   updateUnimported()
                   loop(ctx)(using outer)
@@ -521,7 +517,8 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
       loop(NoContext)
     }
 
-    findRefRecur(NoType, BindingPrec.NothingBound, NoContext)
+    val (foundRef, foundPrec) = findRefRecur(NoResult, NoContext)
+    foundRef
   }
 
   /** If `tree`'s type is a `TermRef` identified by flow typing to be non-null, then

--- a/tests/pos/i18529/JCode1.java
+++ b/tests/pos/i18529/JCode1.java
@@ -1,0 +1,9 @@
+package bug.code;
+
+import bug.util.List;
+import bug.util.*;
+import java.util.*;
+
+public class JCode1 {
+    public void m1(List<Integer> xs) { return; }
+}

--- a/tests/pos/i18529/JCode2.java
+++ b/tests/pos/i18529/JCode2.java
@@ -1,0 +1,9 @@
+package bug.code;
+
+import bug.util.*;
+import bug.util.List;
+import java.util.*;
+
+public class JCode2 {
+    public void m1(List<Integer> xs) { return; }
+}

--- a/tests/pos/i18529/List.java
+++ b/tests/pos/i18529/List.java
@@ -1,0 +1,3 @@
+package bug.util;
+
+public final class List<E> {}

--- a/tests/pos/i18529/SCode1.scala
+++ b/tests/pos/i18529/SCode1.scala
@@ -1,0 +1,9 @@
+package bug.code
+
+import bug.util.List
+import bug.util.*
+import java.util.*
+
+class SCode1 {
+  def work(xs: List[Int]): Unit = {}
+}

--- a/tests/pos/i18529/SCode2.scala
+++ b/tests/pos/i18529/SCode2.scala
@@ -1,0 +1,9 @@
+package bug.code
+
+import bug.util.*
+import bug.util.List
+import java.util.*
+
+class SCode2 {
+  def work(xs: List[Int]): Unit = {}
+}

--- a/tests/pos/i18529/Test.scala
+++ b/tests/pos/i18529/Test.scala
@@ -1,0 +1,1 @@
+class Test

--- a/tests/printing/dependent-annot-default-args.check
+++ b/tests/printing/dependent-annot-default-args.check
@@ -8,39 +8,16 @@ package <empty> {
   final module class annot() extends AnyRef() { this: annot.type =>
     def $lessinit$greater$default$2: Any @uncheckedVariance = 42
   }
-  class annot2(x: Any, y: Array[Any]) extends annotation.Annotation() {
-    private[this] val x: Any
-    private[this] val y: Array[Any]
-  }
-  final lazy module val annot2: annot2 = new annot2()
-  final module class annot2() extends AnyRef() { this: annot2.type =>
-    def $lessinit$greater$default$1: Any @uncheckedVariance = -1
-    def $lessinit$greater$default$2: Array[Any] @uncheckedVariance =
-      Array.apply[Any](["Hello" : Any]*)(scala.reflect.ClassTag.Any)
-  }
   final lazy module val dependent-annot-default-args$package:
     dependent-annot-default-args$package =
     new dependent-annot-default-args$package()
   final module class dependent-annot-default-args$package() extends Object() {
     this: dependent-annot-default-args$package.type =>
     def f(x: Int): Int @annot(x) = x
-    def f2(x: Int):
-      Int @annot2(
-        y = Array.apply[Any](["Hello",x : Any]*)(scala.reflect.ClassTag.Any))
-     = x
     def test: Unit =
       {
         val y: Int = ???
         val z: Int @annot(y) = f(y)
-        val z2:
-          Int @annot2(
-            y = Array.apply[Any](["Hello",y : Any]*)(scala.reflect.ClassTag.Any)
-            )
-         = f2(y)
-        @annot(44) val z3: Int = 45
-        @annot2(
-          y = Array.apply[Any](["Hello",y : Any]*)(scala.reflect.ClassTag.Any))
-          val z4: Int = 45
         ()
       }
   }

--- a/tests/printing/dependent-annot-default-args.scala
+++ b/tests/printing/dependent-annot-default-args.scala
@@ -1,15 +1,6 @@
 class annot(x: Any, y: Any = 42) extends annotation.Annotation
-class annot2(x: Any = -1, y: Array[Any] = Array("Hello")) extends annotation.Annotation
-
 def f(x: Int): Int @annot(x) = x
-def f2(x: Int): Int @annot2(y = Array("Hello", x)) = x
 
 def test =
   val y: Int = ???
-
   val z = f(y)
-  val z2 = f2(y)
-
-  @annot(44) val z3 = 45
-  @annot2(y = Array("Hello", y)) val z4 = 45
-


### PR DESCRIPTION
Backports #21888 to the 3.3.6.

PR submitted by the release tooling.