### PR TITLE
Backport "Fix #22226: Use `classOf[BoxedUnit]` for Unit array in `ArrayConstructors`." to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/ArrayConstructors.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ArrayConstructors.scala
@@ -27,7 +27,10 @@ class ArrayConstructors extends MiniPhase {
 
   override def transformApply(tree: tpd.Apply)(using Context): tpd.Tree = {
     def expand(elemType: Type, dims: List[Tree]) =
-      tpd.newArray(elemType, tree.tpe, tree.span, JavaSeqLiteral(dims, TypeTree(defn.IntClass.typeRef)))
+      val elemTypeNonVoid =
+        if elemType.isValueSubType(defn.UnitType) then defn.BoxedUnitClass.typeRef
+        else elemType
+      tpd.newArray(elemTypeNonVoid, tree.tpe, tree.span, JavaSeqLiteral(dims, TypeTree(defn.IntClass.typeRef)))
 
     if (tree.fun.symbol eq defn.ArrayConstructor) {
       val TypeApply(tycon, targ :: Nil) = tree.fun: @unchecked

--- a/tests/sjs-junit/test/org/scalajs/testsuite/compiler/RegressionTestScala3.scala
+++ b/tests/sjs-junit/test/org/scalajs/testsuite/compiler/RegressionTestScala3.scala
@@ -145,6 +145,17 @@ class RegressionTestScala3 {
     assertEquals(5, Issue14289.Container.b())
     assertEquals(true, Issue14289.Container.c())
   }
+
+  @Test def createArrayOfUnitIssue22226(): Unit = {
+    val a = Array.ofDim[Unit](0)
+    assertSame(classOf[Array[Unit]], a.getClass())
+
+    val b = new Array[Unit](0)
+    assertSame(classOf[Array[Unit]], b.getClass())
+
+    val c = Array.ofDim[Unit](0, 0)
+    assertSame(classOf[Array[Array[Unit]]], c.getClass())
+  }
 }
 
 object RegressionTestScala3 {


### PR DESCRIPTION
Backports #22238 to the 3.3.6.

PR submitted by the release tooling.
[skip ci]