### PR TITLE
Backport "replace deprecated AnyRefMap" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/BCodeSkelBuilder.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeSkelBuilder.scala
@@ -515,7 +515,7 @@ trait BCodeSkelBuilder extends BCodeHelpers {
      */
     object locals {
 
-      private val slots = mutable.AnyRefMap.empty[Symbol, Local] // (local-or-param-sym -> Local(BType, name, idx, isSynth))
+      private val slots = mutable.HashMap.empty[Symbol, Local] // (local-or-param-sym -> Local(BType, name, idx, isSynth))
 
       private var nxtIdx = -1 // next available index for local-var
 

--- a/compiler/src/dotty/tools/dotc/classpath/DirectoryClassPath.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/DirectoryClassPath.scala
@@ -229,7 +229,7 @@ final class CtSymClassPath(ctSym: java.nio.file.Path, release: Int) extends Clas
 
   // e.g. "java.lang" -> Seq(/876/java/lang, /87/java/lang, /8/java/lang))
   private val packageIndex: scala.collection.Map[String, scala.collection.Seq[Path]] = {
-    val index = collection.mutable.AnyRefMap[String, collection.mutable.ListBuffer[Path]]()
+    val index = collection.mutable.HashMap[String, collection.mutable.ListBuffer[Path]]()
     val isJava12OrHigher = scala.util.Properties.isJavaAtLeast("12")
     rootsForRelease.foreach(root => Files.walk(root).iterator().asScala.filter(Files.isDirectory(_)).foreach { p =>
       val moduleNamePathElementCount = if (isJava12OrHigher) 1 else 0

--- a/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
@@ -162,7 +162,7 @@ class Scala2Unpickler(bytes: Array[Byte], classRoot: ClassDenotation, moduleClas
   private val entries = new Array[AnyRef](index.length)
 
   /** A map from symbols to their associated `decls` scopes */
-  private val symScopes = mutable.AnyRefMap[Symbol, Scope]()
+  private val symScopes = mutable.HashMap[Symbol, Scope]()
 
   /** A mapping from method types to the parameters used in constructing them */
   private val paramsOfMethodType = new java.util.IdentityHashMap[MethodType, List[Symbol]]

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -64,9 +64,9 @@ class Namer { typer: Typer =>
   /** A partial map from unexpanded member and pattern defs and to their expansions.
    *  Populated during enterSyms, emptied during typer.
    */
-  //lazy val expandedTree = new mutable.AnyRefMap[DefTree, Tree]
+  //lazy val expandedTree = new mutable.HashMap[DefTree, Tree]
   /*{
-    override def default(tree: DefTree) = tree // can't have defaults on AnyRefMaps :-(
+    override def default(tree: DefTree) = tree // can't have defaults on HashMaps :-(
   }*/
 
   /** A map from expanded MemberDef, PatDef or Import trees to their symbols.
@@ -74,12 +74,12 @@ class Namer { typer: Typer =>
    *  with the same symbol is created (this can be when the symbol is completed
    *  or at the latest when the tree is typechecked.
    */
-  //lazy val symOfTree = new mutable.AnyRefMap[Tree, Symbol]
+  //lazy val symOfTree = new mutable.HashMap[Tree, Symbol]
 
   /** A map from expanded trees to their typed versions.
    *  Populated when trees are typechecked during completion (using method typedAhead).
    */
-  // lazy val typedTree = new mutable.AnyRefMap[Tree, tpd.Tree]
+  // lazy val typedTree = new mutable.HashMap[Tree, tpd.Tree]
 
   /** A map from method symbols to nested typers.
    *  Populated when methods are completed. Emptied when they are typechecked.
@@ -87,7 +87,7 @@ class Namer { typer: Typer =>
    *  one, so that trees that are shared between different DefDefs can be independently
    *  used as indices. It also contains a scope that contains nested parameters.
    */
-  lazy val nestedTyper: mutable.AnyRefMap[Symbol, Typer] = new mutable.AnyRefMap
+  lazy val nestedTyper: mutable.HashMap[Symbol, Typer] = new mutable.HashMap
 
   /** We are entering symbols coming from a SourceLoader */
   private var lateCompile = false

--- a/compiler/src/dotty/tools/dotc/util/FreshNameCreator.scala
+++ b/compiler/src/dotty/tools/dotc/util/FreshNameCreator.scala
@@ -14,7 +14,7 @@ abstract class FreshNameCreator {
 object FreshNameCreator {
   class Default extends FreshNameCreator {
     protected var counter: Int = 0
-    protected val counters: mutable.Map[String, Int] = mutable.AnyRefMap() withDefaultValue 0
+    protected val counters: mutable.Map[String, Int] = mutable.HashMap() withDefaultValue 0
 
     /**
      * Create a fresh name with the given prefix. It is guaranteed

--- a/library/src/scala/runtime/coverage/Invoker.scala
+++ b/library/src/scala/runtime/coverage/Invoker.scala
@@ -3,7 +3,7 @@ package scala.runtime.coverage
 import scala.annotation.internal.sharable
 import scala.annotation.nowarn
 import scala.collection.concurrent.TrieMap
-import scala.collection.mutable.{BitSet, AnyRefMap}
+import scala.collection.mutable.{BitSet, HashMap}
 import java.io.{File, FileWriter}
 import java.nio.file.Files
 
@@ -12,7 +12,7 @@ object Invoker {
   private val runtimeUUID = java.util.UUID.randomUUID()
 
   private val MeasurementsPrefix = "scoverage.measurements."
-  private val threadFiles = new ThreadLocal[AnyRefMap[String, FileWriter]]
+  private val threadFiles = new ThreadLocal[HashMap[String, FileWriter]]
   private val dataDirToSet = TrieMap.empty[String, BitSet]
 
   /** We record that the given id has been invoked by appending its id to the coverage data file.
@@ -38,7 +38,7 @@ object Invoker {
       if added then
         var writers = threadFiles.get()
         if writers == null then
-          writers = AnyRefMap.empty
+          writers = HashMap.empty
           threadFiles.set(writers)
         val writer = writers.getOrElseUpdate(
           dataDir,


### PR DESCRIPTION
Backports #22230 to the 3.3.6.

PR submitted by the release tooling.
[skip ci]