### PR TITLE
Backport "REPL: Add back `:silent` command" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/repl/ParseResult.scala
+++ b/compiler/src/dotty/tools/repl/ParseResult.scala
@@ -93,6 +93,10 @@ object Reset {
   val command: String = ":reset"
 }
 
+/** Toggle automatic printing of results */
+case object Silent extends Command:
+  val command: String = ":silent"
+
 /** `:quit` exits the repl */
 case object Quit extends Command {
   val command: String = ":quit"
@@ -113,6 +117,7 @@ case object Help extends Command {
       |:imports                 show import history
       |:reset [options]         reset the repl to its initial state, forgetting all session entries
       |:settings <options>      update compiler options, if possible
+      |:silent                  disable/enable automatic printing of results
     """.stripMargin
 }
 
@@ -137,6 +142,7 @@ object ParseResult {
     TypeOf.command -> (arg => TypeOf(arg)),
     DocOf.command -> (arg => DocOf(arg)),
     Settings.command -> (arg => Settings(arg)),
+    Silent.command -> (_ => Silent),
   )
 
   def apply(source: SourceFile)(using state: State): ParseResult = {

--- a/compiler/test-resources/repl/silent
+++ b/compiler/test-resources/repl/silent
@@ -1,0 +1,25 @@
+scala>:silent
+scala> 1+1
+scala> case class A(x: Int)
+scala> A("string")
+-- [E007] Type Mismatch Error: -------------------------------------------------
+1 | A("string")
+  |   ^^^^^^^^
+  |   Found:    ("string" : String)
+  |   Required: Int
+  |
+  | longer explanation available when compiling with `-explain`
+1 error found
+scala> Option[Int](2) match { case Some(x) => x }
+1 warning found
+-- [E029] Pattern Match Exhaustivity Warning: ----------------------------------
+1 | Option[Int](2) match { case Some(x) => x }
+  | ^^^^^^^^^^^^^^
+  | match may not be exhaustive.
+  |
+  | It would fail on pattern case: None
+  |
+  | longer explanation available when compiling with `-explain`
+scala>:silent
+scala> 1 + 2
+val res2: Int = 3

--- a/compiler/test/dotty/tools/repl/TabcompleteTests.scala
+++ b/compiler/test/dotty/tools/repl/TabcompleteTests.scala
@@ -220,6 +220,7 @@ class TabcompleteTests extends ReplTest {
         ":quit",
         ":reset",
         ":settings",
+        ":silent",
         ":type"
       ),
       tabComplete(":")


### PR DESCRIPTION
Backports #22248 to the 3.3.6.

PR submitted by the release tooling.
[skip ci]