### PR TITLE
Backport "Documentation only: update Example code linked to obsolete content in  macros-spec.md " to 3.3 LTS

### DIFF
--- a/docs/_docs/reference/metaprogramming/staging.md
+++ b/docs/_docs/reference/metaprogramming/staging.md
@@ -98,9 +98,9 @@ scala -with-compiler -classpath out Test
 ## Example
 
 Now take exactly the same example as in [Macros](./macros.md). Assume that we
-do not want to pass an array statically but generate code at run-time and pass
+do not want to pass a base double value statically but generate code at run-time and pass
 the value, also at run-time. Note, how we make a future-stage function of type
-`Expr[Array[Int] => Int]` in line 6 below. Using `staging.run { ... }` we can evaluate an
+`Expr[Double => Double]` in line 6 below. Using `staging.run { ... }` we can evaluate an
 expression at runtime. Within the scope of `staging.run` we can also invoke `show` on an expression
 to get a source-like representation of the expression.
 
@@ -110,12 +110,12 @@ import scala.quoted.*
 // make available the necessary compiler for runtime code generation
 given staging.Compiler = staging.Compiler.make(getClass.getClassLoader)
 
-val f: Array[Int] => Int = staging.run {
-  val stagedSum: Expr[Array[Int] => Int] =
-    '{ (arr: Array[Int]) => ${sum('arr)}}
-  println(stagedSum.show) // Prints "(arr: Array[Int]) => { var sum = 0; ... }"
-  stagedSum
+val power3: Double => Double = staging.run {
+  val stagedPower3: Expr[Double => Double] =
+    '{ (x: Double) => ${ unrolledPowerCode('x, 3) } }
+  println(stagedPower3.show) // Prints "((x: scala.Double) => x.*(x.*(x)))"
+  stagedPower3
 }
 
-f.apply(Array(1, 2, 3)) // Returns 6
+power3.apply(2.0) // Returns 8.0
 ```

--- a/tests/neg/21538.check
+++ b/tests/neg/21538.check
@@ -3,8 +3,8 @@
   |                                             ^^^^^^^^^^
   |                                      (value : V) is not a valid singleton type, since it is not an immutable path
   |                                      Inline parameters are not considered immutable paths and cannot be used as
-  |                                      singleton types. 
-  |                                       
+  |                                      singleton types.
+  |
   |                                      Hint: Removing the `inline` qualifier from the `value` parameter
   |                                      may help resolve this issue.
   |

--- a/tests/neg/i21696.check
+++ b/tests/neg/i21696.check
@@ -5,9 +5,9 @@
   |---------------------------------------------------------------------------------------------------------------------
   | Explanation (enabled by `-explain`)
   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-  | Referencing `T` inside a quoted expression requires a `scala.quoted.Type[T]` to be in scope. 
+  | Referencing `T` inside a quoted expression requires a `scala.quoted.Type[T]` to be in scope.
   | Since Scala is subject to erasure at runtime, the type information will be missing during the execution of the code.
-  | `scala.quoted.Type[T]` is therefore needed to carry `T`'s type information into the quoted code. 
-  | Without an implicit `scala.quoted.Type[T]`, the type `T` cannot be properly referenced within the expression. 
+  | `scala.quoted.Type[T]` is therefore needed to carry `T`'s type information into the quoted code.
+  | Without an implicit `scala.quoted.Type[T]`, the type `T` cannot be properly referenced within the expression.
   | To resolve this, ensure that a `scala.quoted.Type[T]` is available, either through a context-bound or explicitly.
    ---------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Backports #22256 to the 3.3.6.

PR submitted by the release tooling.