### PR TITLE
Backport "Fix inline reduction for CaseDef guards with asInstanceOf" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/inlines/InlineReducer.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/InlineReducer.scala
@@ -362,7 +362,7 @@ class InlineReducer(inliner: Inliner)(using Context):
         val (caseBindings, from, to) = substBindings(caseBindingMap.toList, mutable.ListBuffer(), Nil, Nil)
         val (guardOK, canReduceGuard) =
           if cdef.guard.isEmpty then (true, true)
-          else typer.typed(cdef.guard.subst(from, to), defn.BooleanType) match {
+          else stripInlined(typer.typed(cdef.guard.subst(from, to), defn.BooleanType)) match {
             case ConstantValue(v: Boolean) => (v, true)
             case _ => (false, false)
           }

--- a/tests/pos/i22300.scala
+++ b/tests/pos/i22300.scala
@@ -1,0 +1,16 @@
+class Foo:
+
+  inline def inlineMatch[T]: String =
+    inline compiletime.erasedValue[T] match
+      case _: EmptyTuple               => ""
+      case _: (h *: _) if checkType[h](0) => ""
+
+  private inline def checkType[T](i: Int): Boolean =
+    inline compiletime.erasedValue[T] match
+      case _: Int => true
+      case _      => false
+
+val foo = Foo()
+
+@main def main () =
+  foo.inlineMatch[(Int, Boolean)]


### PR DESCRIPTION
Backports #22305 to the 3.3.6.

PR submitted by the release tooling.
[skip ci]