### PR TITLE
Backport "Add regression test for #22320" to 3.3 LTS

### DIFF
--- a/tests/neg/i22320.check
+++ b/tests/neg/i22320.check
@@ -1,0 +1,12 @@
+-- [E008] Not Found Error: tests/neg/i22320.scala:19:19 ----------------------------------------------------------------
+19 |    val z = system.z // error
+   |            ^^^^^^^^
+   |            value z is not a member of a.System.
+   |            An extension method was tried, but could not be fully constructed:
+   |
+   |                a.z(system)
+   |
+   |                failed with:
+   |
+   |                    Found:    (system : a.System)
+   |                    Required: a.SimulatedSystem

--- a/tests/neg/i22320.scala
+++ b/tests/neg/i22320.scala
@@ -1,0 +1,19 @@
+package a:
+  opaque type System = Any
+  opaque type SimulatedSystem <: System = System
+
+  extension (system: System)
+    def x: BigInt = ???
+    def y: BigInt = ???
+  end extension
+
+  extension (system: SimulatedSystem)
+    def z: BigInt = ???
+  end extension
+
+package b:
+  import a.*
+  def issue(system: System) =
+    val x = system.x
+    val y = system.y
+    val z = system.z // error


### PR DESCRIPTION
Backports #22321 to the 3.3.6.

PR submitted by the release tooling.
[skip ci]