### PR TITLE
Backport "Fix #22051: only trust the type application part for case class unapplies" to 3.3 LTS

### DIFF
--- a/tests/neg/i22051.scala
+++ b/tests/neg/i22051.scala
@@ -1,0 +1,19 @@
+//> using options -Werror
+
+def boundary[T](body: (T => RuntimeException) => T): T =
+  case class Break(value: T) extends RuntimeException
+  try body(Break.apply)
+  catch case Break(t) => t // error: pattern matching on local classes is unsound currently
+
+def test =
+  boundary[Int]: EInt =>
+    val v: String = boundary[String]: EString =>
+      throw EInt(3)
+    v.length // a runtime error: java.lang.ClassCastException
+
+def boundaryCorrectBehaviour[T](body: (T => RuntimeException) => T): T =
+  object local:
+    // A correct implementation, but is still treated as a local class right now
+    case class Break(value: T) extends RuntimeException
+  try body(local.Break.apply)
+  catch case local.Break(t) => t // error

--- a/tests/warn/i22051.scala
+++ b/tests/warn/i22051.scala
@@ -1,9 +1,7 @@
-//> using options -Werror
-
 def boundary[T](body: (T => RuntimeException) => T): T =
   case class Break(value: T) extends RuntimeException
   try body(Break.apply)
-  catch case Break(t) => t // error: pattern matching on local classes is unsound currently
+  catch case Break(t) => t // warn: pattern matching on local classes is unsound currently
 
 def test =
   boundary[Int]: EInt =>
@@ -16,4 +14,4 @@ def boundaryCorrectBehaviour[T](body: (T => RuntimeException) => T): T =
     // A correct implementation, but is still treated as a local class right now
     case class Break(value: T) extends RuntimeException
   try body(local.Break.apply)
-  catch case local.Break(t) => t // error
+  catch case local.Break(t) => t // warn


### PR DESCRIPTION
Backports #22099 to the 3.3.6.

PR submitted by the release tooling.
[skip ci]