### PR TITLE
Backport "Do not return java outline dummy constructor in `primaryConstructor`" to 3.3 LTS

### DIFF
--- a/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
+++ b/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
@@ -2740,7 +2740,26 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
           self.typeRef.info.decls.toList
 
         def paramSymss: List[List[Symbol]] = self.denot.paramSymss
-        def primaryConstructor: Symbol = self.denot.primaryConstructor
+        def primaryConstructor: Symbol =
+          val initialPrimary = self.denot.primaryConstructor
+          // Java outline parser creates a dummyConstructor. We want to avoid returning it here,
+          // instead returning the first non-dummy one, which is what happens when a java classfile
+          // is read from classpath instead of using the java outline parser.
+          // We check if the constructor is dummy if it has the same parameters as defined in JavaParsers.scala,
+          // incliding the private[this] flags and parameter shape with scala.Unit argument.
+          val isJavaDummyConstructor =
+            val paramSymss = initialPrimary.paramSymss
+            initialPrimary.flags.is(Flags.JavaDefined | Flags.Local | Flags.Method | Flags.Private | Flags.PrivateLocal)
+            && {
+              paramSymss match
+                case List(List(typeTree)) if self.typeRef.memberType(typeTree).typeSymbol == defn.UnitClass => true
+                case _ => false
+            }
+          if isJavaDummyConstructor then
+            declarations.filter(sym => sym != initialPrimary && sym.isConstructor).headOption.getOrElse(Symbol.noSymbol)
+          else
+            initialPrimary
+
         def allOverriddenSymbols: Iterator[Symbol] = self.denot.allOverriddenSymbols
         def overridingSymbol(ofclazz: Symbol): Symbol =
           if ofclazz.isClass then self.denot.overridingSymbol(ofclazz.asClass)

--- a/tests/run-macros/i20052.check
+++ b/tests/run-macros/i20052.check
@@ -1,0 +1,5 @@
+method <init> (Flags.JavaDefined | Flags.Method) List(List((x$0,scala.Int)))
+method <init> (Flags.JavaDefined | Flags.Method) List(List())
+method <init> (Flags.JavaDefined | Flags.Method | Flags.Private) List(List())
+method <init> (Flags.JavaDefined | Flags.Method | Flags.Private) List(List())
+method <init> (Flags.JavaDefined | Flags.Method) List(List((A,_ >: scala.Nothing <: <special-ops>.<FromJavaObject>)), List((x$0,A)))

--- a/tests/run-macros/i20052/JavaClass.java
+++ b/tests/run-macros/i20052/JavaClass.java
@@ -1,0 +1,4 @@
+public class JavaClass {
+  public JavaClass(int a) {}
+  public JavaClass(float a) {}
+}

--- a/tests/run-macros/i20052/JavaClassEmpty.java
+++ b/tests/run-macros/i20052/JavaClassEmpty.java
@@ -1,0 +1,1 @@
+public class JavaClassEmpty {}

--- a/tests/run-macros/i20052/JavaClassParam.java
+++ b/tests/run-macros/i20052/JavaClassParam.java
@@ -1,0 +1,3 @@
+public class JavaClassParam<A> {
+  public JavaClassParam(A a) {}
+}

--- a/tests/run-macros/i20052/JavaClassPrivate.java
+++ b/tests/run-macros/i20052/JavaClassPrivate.java
@@ -1,0 +1,3 @@
+class JavaClassPrivate {
+  private JavaClassPrivate() {}
+}

--- a/tests/run-macros/i20052/JavaClassStartsWithPrivate.java
+++ b/tests/run-macros/i20052/JavaClassStartsWithPrivate.java
@@ -1,0 +1,4 @@
+class JavaClassStartsWithPrivate {
+  private JavaClassStartsWithPrivate() {}
+  public JavaClassStartsWithPrivate(int a) {}
+}

--- a/tests/run-macros/i20052/Macro.scala
+++ b/tests/run-macros/i20052/Macro.scala
@@ -1,0 +1,16 @@
+import scala.quoted.*
+
+object Macro {
+  inline def logPrimaryConstructor[A]: String = ${ logPrimaryConstructorImpl[A] }
+
+  def logPrimaryConstructorImpl[A](using Type[A], Quotes): Expr[String] = {
+    import quotes.reflect.*
+
+    val primaryConstructor = TypeRepr.of[A].typeSymbol.primaryConstructor
+    val flags = primaryConstructor.flags.show
+    val paramSymss = primaryConstructor.paramSymss
+    val clauses = paramSymss.map(_.map(param => (param.name, TypeRepr.of[A].memberType(param).show)))
+    val str = s"${primaryConstructor} (${primaryConstructor.flags.show}) ${clauses}"
+    Expr(str)
+  }
+}

--- a/tests/run-macros/i20052/Test_2.scala
+++ b/tests/run-macros/i20052/Test_2.scala
@@ -1,0 +1,6 @@
+@main def Test() =
+  println(Macro.logPrimaryConstructor[JavaClass])
+  println(Macro.logPrimaryConstructor[JavaClassEmpty])
+  println(Macro.logPrimaryConstructor[JavaClassPrivate])
+  println(Macro.logPrimaryConstructor[JavaClassStartsWithPrivate])
+  println(Macro.logPrimaryConstructor[JavaClassParam[Int]])


### PR DESCRIPTION
Backports #22104 to the 3.3.6.

PR submitted by the release tooling.
[skip ci]