### PR TITLE
Backport "Spec: Integrate the specification for match types." to 3.3 LTS

### DIFF
--- a/docs/_spec/04-basic-definitions.md
+++ b/docs/_spec/04-basic-definitions.md
@@ -220,6 +220,7 @@ TypeDcl         ::=  id [TypeParamClause] [‘>:’ Type] [‘<:’ Type]
 Def             ::=  ‘type’ {nl} TypeDef
                   |  ‘opaque‘ ‘type‘ {nl} OpaqueTypeDef
 TypeDef         ::=  id [TypeParamClause] ‘=’ Type
+                  |  id [TypeParamClause] ‘<:’ Type ‘=’ MatchType
 OpaqueTypeDef   ::=  id [TypeParamClause] [‘>:’ Type] [‘<:’ Type] ‘=’ Type
 ```
 
@@ -229,6 +230,7 @@ A possibly parameterized _abstract type member_ definition `type ´t´[´\mathit
 If omitted, ´L´ and ´H´ are implied to be `Nothing` and `scala.Any`, respectively.
 
 A possibly parameterized _type alias_ definition `type ´t´[´\mathit{tps}\,´] = ´T´` defines ´t´ to be a concrete type member.
+The alternative `type ´t´[´\mathit{tps}\,´] <: ´H´ = ´T´ match { ´Cs´ }` desugars to `type ´t´[´\mathit{tps}\,´] = (´T´ match { ´Cs´ } <: ´H´)`, i.e., a match type with an upper bound, which cannot otherwise be expressed in the concrete syntax.
 
 A possibly parameterized _opaque type alias_ definition `opaque type ´t´[´\mathit{tps}\,´] >: ´L´ <: ´H´ = ´T´` defines ´t´ to be an opaque type alias with public bounds `>: ´L´ <: ´H´` and a private alias `= ´T´`.
 


### PR DESCRIPTION
Backports #22164 to the 3.3.6.

PR submitted by the release tooling.
[skip ci]