### PR TITLE
Backport "fix: drop jackson-module-scala from CB" to 3.3 LTS

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -206,6 +206,7 @@ object Build {
 
     // Avoid various sbt craziness involving classloaders and parallelism
     run / fork := true,
+    run / connectInput := true,
     Test / fork := true,
     Test / parallelExecution := false,
 


### PR DESCRIPTION
Backports #22353 to the 3.3.6.

PR submitted by the release tooling.
[skip ci]