### PR TITLE
Backport "fix: correctly print literal types in the refined printer" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -540,6 +540,7 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
       case TypeTree() =>
         typeText(toText(tree.typeOpt))
         ~ Str("(inf)").provided(tree.isInstanceOf[InferredTypeTree] && printDebug)
+      case SingletonTypeTree(ref: Literal) => toTextLocal(ref)
       case SingletonTypeTree(ref) =>
         toTextLocal(ref) ~ "." ~ keywordStr("type")
       case RefinedTypeTree(tpt, refines) =>

--- a/tests/printing/i22349.check
+++ b/tests/printing/i22349.check
@@ -1,0 +1,15 @@
+[[syntax trees at end of                     typer]] // tests/printing/i22349.scala
+package <empty> {
+  final lazy module val i22349$package: i22349$package = new i22349$package()
+  final module class i22349$package() extends Object() {
+    this: i22349$package.type =>
+    val x: Int = 0
+    val _$1: x.type = x
+    inline val _$2: true = true
+    inline val _$3: "abc" = "abc"
+    inline val _$4: 'c' = 'c'
+    inline val _$5: 1.2f = 1.2f
+    inline val _$6: 1.2d = 1.2d
+  }
+}
+

--- a/tests/printing/i22349.scala
+++ b/tests/printing/i22349.scala
@@ -1,0 +1,7 @@
+val x = 0
+val _: x.type = x
+inline val _: true = true   // boolean literal
+inline val _: "abc" = "abc" // string literal
+inline val _: 'c' = 'c'     // character literal
+inline val _: 1.2f = 1.2f   // floating point literal
+inline val _: 1.2d = 1.2d   // double number literal


### PR DESCRIPTION
Backports #22351 to the 3.3.6.

PR submitted by the release tooling.
[skip ci]