### PR TITLE
Backport "Normalise the types for Type Mismatch Error (E007)" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -339,7 +339,7 @@ class TypeMismatch(val found: Type, expected: Type, val inTree: Option[untpd.Tre
     val (found2, expected2) =
       if (found1 frozen_<:< expected1) || reported.fbounded then (found, expected)
       else (found1, expected1)
-    val (foundStr, expectedStr) = Formatting.typeDiff(found2, expected2)
+    val (foundStr, expectedStr) = Formatting.typeDiff(found2.normalized, expected2.normalized)
     i"""|Found:    $foundStr
         |Required: $expectedStr${reported.notes}"""
   end msg

--- a/tests/neg/i22333.check
+++ b/tests/neg/i22333.check
@@ -1,0 +1,7 @@
+-- [E007] Type Mismatch Error: tests/neg/i22333.scala:5:33 -------------------------------------------------------------
+5 |val _ = Container[(1,2,3)].guard((6, 8): Tuple.Tail[(5, 6, 8)]) // error
+  |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |                                 Found:    ((6 : Int), (8 : Int))
+  |                                 Required: ((2 : Int), (3 : Int))
+  |
+  | longer explanation available when compiling with `-explain`

--- a/tests/neg/i22333.scala
+++ b/tests/neg/i22333.scala
@@ -1,0 +1,5 @@
+
+class Container[Rs <: Tuple]:
+  def guard(a: Tuple.Tail[Rs]): Unit = ()
+
+val _ = Container[(1,2,3)].guard((6, 8): Tuple.Tail[(5, 6, 8)]) // error


### PR DESCRIPTION
Backports #22337 to the 3.3.6.

PR submitted by the release tooling.
[skip ci]