### PR TITLE
Backport "Append instead of prepending import selectors for the current scope when collecting them in CheckUnused" to 3.3 LTS

### DIFF
--- a/tests/warn/i21420.scala
+++ b/tests/warn/i21420.scala
@@ -1,0 +1,13 @@
+//> using options -Wunused:imports
+
+object decisions4s{
+  trait HKD
+  trait DecisionTable
+}
+
+object DiagnosticsExample {
+  import decisions4s.HKD
+  val _ = new HKD {}
+  import decisions4s.*
+  val _ = new DecisionTable {}
+}


### PR DESCRIPTION
Backports #22314 to the 3.3.6.

PR submitted by the release tooling.
[skip ci]