### PR TITLE
Backport "Undo patch of double-block apply" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/rewrites/Rewrites.scala
+++ b/compiler/src/dotty/tools/dotc/rewrites/Rewrites.scala
@@ -32,7 +32,7 @@ object Rewrites {
   case class ActionPatch(srcPos: SourcePosition, replacement: String)
 
   private class Patches(source: SourceFile) {
-    private[Rewrites] val pbuf = mutable.ListBuffer.empty[Patch]
+    private[Rewrites] val pbuf = new mutable.ListBuffer[Patch]()
 
     def addPatch(span: Span, replacement: String): Unit =
       pbuf += Patch(span, replacement)

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -68,6 +68,7 @@ class CompilationTests {
       compileFile("tests/rewrites/i17187.scala", unindentOptions.and("-rewrite")),
       compileFile("tests/rewrites/i17399.scala", unindentOptions.and("-rewrite")),
       compileFile("tests/rewrites/i20002.scala", defaultOptions.and("-indent", "-rewrite")),
+      compileFile("tests/rewrites/i21382.scala", defaultOptions.and("-indent", "-rewrite")),
     ).checkRewrites()
   }
 

--- a/tests/rewrites/i21382.scala
+++ b/tests/rewrites/i21382.scala
@@ -1,0 +1,8 @@
+def check(element: Any)(expected: String): Unit = ???
+
+def test =
+  check {
+    ???
+  }{
+    42.toString
+  }


### PR DESCRIPTION
Backports #21982 to the 3.3.6.

PR submitted by the release tooling.
[skip ci]