### PR TITLE
Backport "Fix #21841: Check more that an `unapplySeq` on a `NonEmptyTuple` is valid." to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -1944,6 +1944,13 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
     else op2
   end necessaryEither
 
+  inline def rollbackConstraintsUnless(inline op: Boolean): Boolean =
+    val saved = constraint
+    var result = false
+    try result = ctx.gadtState.rollbackGadtUnless(op)
+    finally if !result then constraint = saved
+    result
+
   /** Decompose into conjunction of types each of which has only a single refinement */
   def decomposeRefinements(tp: Type, refines: List[(Name, Type)]): Type = tp match
     case RefinedType(parent, rname, rinfo) =>

--- a/tests/coverage/run/i16940/test.scoverage.check
+++ b/tests/coverage/run/i16940/test.scoverage.check
@@ -93,6 +93,23 @@ Test
 Object
 <empty>.Test
 <init>
+387
+390
+20
+Seq
+Ident
+false
+0
+false
+Seq
+
+5
+i16940/i16940.scala
+<empty>
+Test
+Object
+<empty>.Test
+<init>
 391
 421
 20
@@ -103,7 +120,7 @@ false
 false
 brokenSynchronizedBlock(false)
 
-5
+6
 i16940/i16940.scala
 <empty>
 Test
@@ -120,7 +137,7 @@ false
 false
 brokenSynchronizedBlock(true)
 
-6
+7
 i16940/i16940.scala
 <empty>
 Test
@@ -137,7 +154,7 @@ false
 false
 println(test)
 
-7
+8
 i16940/i16940.scala
 <empty>
 Test
@@ -154,7 +171,7 @@ false
 false
 assert(test == 2)
 
-8
+9
 i16940/i16940.scala
 <empty>
 Test
@@ -171,7 +188,7 @@ true
 false
 assert(test == 2)
 
-9
+10
 i16940/i16940.scala
 <empty>
 Test
@@ -188,7 +205,7 @@ true
 false
 assert(test == 2)
 
-10
+11
 i16940/i16940.scala
 <empty>
 Test
@@ -205,7 +222,7 @@ false
 false
 3.seconds
 
-11
+12
 i16940/i16940.scala
 <empty>
 i16940$package
@@ -222,7 +239,7 @@ false
 false
 Future {\n  if (option) {\n    Thread.sleep(500)\n  }\n  synchronized {\n    val tmp = test\n    Thread.sleep(1000)\n    test = tmp + 1\n  }\n}
 
-12
+13
 i16940/i16940.scala
 <empty>
 i16940$package
@@ -239,7 +256,7 @@ false
 false
 Thread.sleep(500)
 
-13
+14
 i16940/i16940.scala
 <empty>
 i16940$package
@@ -256,7 +273,7 @@ true
 false
 {\n    Thread.sleep(500)\n  }
 
-14
+15
 i16940/i16940.scala
 <empty>
 i16940$package
@@ -273,7 +290,7 @@ true
 false
 
 
-15
+16
 i16940/i16940.scala
 <empty>
 i16940$package
@@ -290,7 +307,7 @@ false
 false
 synchronized {\n    val tmp = test\n    Thread.sleep(1000)\n    test = tmp + 1\n  }
 
-16
+17
 i16940/i16940.scala
 <empty>
 i16940$package
@@ -307,7 +324,7 @@ false
 false
 Thread.sleep(1000)
 
-17
+18
 i16940/i16940.scala
 <empty>
 i16940$package

--- a/tests/coverage/run/i18233-min/test.scoverage.check
+++ b/tests/coverage/run/i18233-min/test.scoverage.check
@@ -110,6 +110,23 @@ i18233-min$package
 Object
 <empty>.i18233-min$package
 aList
+14
+18
+2
+List
+Ident
+false
+0
+false
+List
+
+6
+i18233-min/i18233-min.scala
+<empty>
+i18233-min$package
+Object
+<empty>.i18233-min$package
+aList
 19
 34
 2
@@ -120,7 +137,7 @@ false
 false
 Array[String]()
 
-6
+7
 i18233-min/i18233-min.scala
 <empty>
 i18233-min$package
@@ -137,7 +154,7 @@ false
 false
 def aList
 
-7
+8
 i18233-min/i18233-min.scala
 <empty>
 i18233-min$package
@@ -154,7 +171,7 @@ false
 false
 Array("abc", "def")
 
-8
+9
 i18233-min/i18233-min.scala
 <empty>
 i18233-min$package
@@ -171,7 +188,7 @@ false
 false
 def arr
 
-9
+10
 i18233-min/i18233-min.scala
 <empty>
 i18233-min$package
@@ -188,7 +205,24 @@ false
 false
 List(arr*)
 
-10
+11
+i18233-min/i18233-min.scala
+<empty>
+i18233-min$package
+Object
+<empty>.i18233-min$package
+anotherList
+91
+95
+8
+List
+Ident
+false
+0
+false
+List
+
+12
 i18233-min/i18233-min.scala
 <empty>
 i18233-min$package
@@ -205,7 +239,7 @@ false
 false
 arr
 
-11
+13
 i18233-min/i18233-min.scala
 <empty>
 i18233-min$package

--- a/tests/coverage/run/i18233/test.scoverage.check
+++ b/tests/coverage/run/i18233/test.scoverage.check
@@ -42,6 +42,23 @@ Foo
 Object
 <empty>.Foo
 render
+54
+58
+5
+List
+Ident
+false
+0
+false
+List
+
+2
+i18233/i18233.scala
+<empty>
+Foo
+Object
+<empty>.Foo
+render
 59
 65
 5
@@ -52,7 +69,7 @@ false
 false
 values
 
-2
+3
 i18233/i18233.scala
 <empty>
 Foo
@@ -69,7 +86,7 @@ false
 false
 values.tail
 
-3
+4
 i18233/i18233.scala
 <empty>
 Foo
@@ -86,7 +103,7 @@ false
 false
 List(values.tail*).mkString
 
-4
+5
 i18233/i18233.scala
 <empty>
 Foo
@@ -103,7 +120,7 @@ false
 false
 def render
 
-5
+6
 i18233/i18233.scala
 <empty>
 Test
@@ -120,7 +137,7 @@ false
 false
 println(Foo.render)
 
-6
+7
 i18233/i18233.scala
 <empty>
 Test

--- a/tests/neg/i21841.check
+++ b/tests/neg/i21841.check
@@ -1,0 +1,6 @@
+-- [E108] Declaration Error: tests/neg/i21841.scala:20:13 --------------------------------------------------------------
+20 |    case v[T](l, r) => ()  // error
+   |         ^^^^^^^^^^
+   | [31mOption[(Test.Expr[Test.T], Test.Expr[Test.T])][0m is not a valid result type of an unapplySeq method of an [35mextractor[0m.
+   |
+   | longer explanation available when compiling with `-explain`

--- a/tests/neg/i21841.scala
+++ b/tests/neg/i21841.scala
@@ -1,0 +1,22 @@
+object Test {
+
+  sealed trait T
+  sealed trait Arrow[A, B]
+
+  type ArgsTo[S1, Target] <: NonEmptyTuple = S1 match {
+    case Arrow[a, Target] => Tuple1[Expr[a]]
+    case Arrow[a, b] => Expr[a] *: ArgsTo[b, Target]
+  }
+
+  sealed trait Expr[S] :
+    def unapplySeq[Target](e: Expr[Target]): Option[ArgsTo[S, Target]] = ???
+
+  case class Variable[S](id: String) extends Expr[S]
+
+  val v = Variable[Arrow[T, Arrow[T, T]]]("v")
+  val e : Expr[T] = ???
+
+  e match
+    case v[T](l, r) => ()  // error
+    case _ => ()
+}


### PR DESCRIPTION
Backports #22366 to the 3.3.6.

PR submitted by the release tooling.