### PR TITLE
Backport "Scala 2.13.16 (was .15)" to Scala 3.3 LTS

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -124,8 +124,8 @@ object Build {
    *  scala-library.
    */
   def stdlibVersion(implicit mode: Mode): String = mode match {
-    case NonBootstrapped => "2.13.15"
-    case Bootstrapped => "2.13.15"
+    case NonBootstrapped => "2.13.16"
+    case Bootstrapped => "2.13.16"
   }
 
   val dottyOrganization = "org.scala-lang"
@@ -1192,7 +1192,7 @@ object Build {
           .exclude("org.eclipse.lsp4j","org.eclipse.lsp4j.jsonrpc"),
         "org.eclipse.lsp4j" % "org.eclipse.lsp4j" % "0.20.1",
       ),
-      libraryDependencies += ("org.scalameta" % "mtags-shared_2.13.15" % mtagsVersion % SourceDeps),
+      libraryDependencies += ("org.scalameta" % "mtags-shared_2.13.16" % mtagsVersion % SourceDeps),
       ivyConfigurations += SourceDeps.hide,
       transitiveClassifiers := Seq("sources"),
       Compile / scalacOptions ++= Seq("-Yexplicit-nulls", "-Ysafe-init"),

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1189,7 +1189,7 @@ object Build {
       BuildInfoPlugin.buildInfoDefaultSettings
 
   lazy val presentationCompilerSettings = {
-    val mtagsVersion = "1.4.1"
+    val mtagsVersion = "1.4.2"
     Seq(
       libraryDependencies ++= Seq(
         "org.lz4" % "lz4-java" % "1.8.0",

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -589,6 +589,13 @@ object Build {
 
   // Settings shared between scala3-compiler and scala3-compiler-bootstrapped
   lazy val commonDottyCompilerSettings = Seq(
+      /* Ignore a deprecation warning about AnyRefMap in scalajs-ir. The latter
+       * cross-compiles for 2.12, and therefore AnyRefMap remains useful there
+       * for performance reasons.
+       * The build of Scala.js core does the same thing.
+       */
+      scalacOptions += "-Wconf:cat=deprecation&origin=scala\\.collection\\.mutable\\.AnyRefMap.*:s",
+
       // Generate compiler.properties, used by sbt
       (Compile / resourceGenerators) += Def.task {
         import java.util._

--- a/tests/patmat/i7186.scala
+++ b/tests/patmat/i7186.scala
@@ -92,7 +92,7 @@ object printMips {
 
   def apply(nodes: List[Assembler]): Unit = {
     var symbCount = 0L
-    val symbols = new scala.collection.mutable.AnyRefMap[Scoped,Long]()
+    val symbols = new scala.collection.mutable.HashMap[Scoped,Long]()
 
     print(mipsNode(nodes, "  "))
 


### PR DESCRIPTION
Backports https://github.com/scala/scala3/pull/22386
Upgrade to Scala 2.13.16 was done in main after 3.6.4 cutoff, but we should still include it in the next LTS