### PR TITLE
Backport "Preserve hard unions in widenSingletons" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -1361,9 +1361,9 @@ object Types extends TypeUtils {
       case tp =>
         tp
 
-    /** Widen all top-level singletons reachable by dealiasing
-     *  and going to the operands of & and |.
-     *  Overridden and cached in OrType.
+    /** Widen all top-level singletons reachable by dealiasing and going to the
+     *  operands of intersections and soft unions (only when `skipSoftUnions` is
+     *  `false`). Overridden and cached in [[OrType]].
      */
     def widenSingletons(skipSoftUnions: Boolean = false)(using Context): Type = dealias match {
       case tp: SingletonType =>
@@ -3543,7 +3543,7 @@ object Types extends TypeUtils {
       myAtoms
 
     override def widenSingletons(skipSoftUnions: Boolean)(using Context): Type =
-      if isSoft && skipSoftUnions then this
+      if !isSoft || skipSoftUnions then this
       else
         if widenedRunId != ctx.runId then
           myWidened = computeWidenSingletons()

--- a/tests/pos/22219.scala
+++ b/tests/pos/22219.scala
@@ -1,0 +1,5 @@
+type MonthNumber = 1 | 2
+
+def main =
+  val x = 1: MonthNumber
+  val y: MonthNumber = x

--- a/tests/pos/22219b.scala
+++ b/tests/pos/22219b.scala
@@ -1,0 +1,20 @@
+type MonthNumber =
+  1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12
+
+def main =
+  List[(String, MonthNumber)](
+      "January" -> 1,
+      "February" -> 2,
+      "March" -> 3,
+      "April" -> 4,
+      "May" -> 5,
+      "June"-> 6,
+      "July" -> 7,
+      "August" -> 8,
+      "September" -> 9,
+      "October" -> 10,
+      "November" -> 11,
+      "December" -> 12
+    ).foreach { (name, number) =>
+      summon[number.type <:< MonthNumber]
+    }


### PR DESCRIPTION
Backports #22369 to the 3.3.6.

PR submitted by the release tooling.
[skip ci]