### PR TITLE
Backport "Fix inline proxy generation for opaque types referencing other opaque types" to 3.3 LTS

### DIFF
--- a/tests/pos/22359a.scala
+++ b/tests/pos/22359a.scala
@@ -1,0 +1,15 @@
+opaque type NT[N <: Tuple, V <: Tuple] = V
+opaque type System = NT[Tuple1["wires"], Tuple1[Any]]
+
+extension [N <: Tuple, V <: Tuple] (x: NT[N, V]) {
+  inline def apply(n: Int): Any =
+    x.productElement(n)
+}
+
+extension (system: System) {
+  inline def foo =
+    system.apply(0)
+}
+
+val simulation: System = ???
+val _ = simulation.foo

--- a/tests/pos/22359b.scala
+++ b/tests/pos/22359b.scala
@@ -1,0 +1,17 @@
+object Obj2:
+  opaque type NT[N <: Tuple, V <: Tuple] = V
+
+  extension [N <: Tuple, V <: Tuple] (x: NT[N, V]) {
+    inline def apply(n: Int): Any =
+      x.productElement(n)
+  }
+
+object Obj:
+  opaque type System = Obj2.NT[Tuple1["wires"], Tuple1[Any]]
+
+  extension (system: System) {
+    inline def foo = system.apply(0)
+  }
+import Obj._
+val simulation: System = ???
+val _ = simulation.foo

--- a/tests/pos/i17243.scala
+++ b/tests/pos/i17243.scala
@@ -1,0 +1,17 @@
+object Opaque:
+  opaque type A = Int
+
+  val va: A = 1
+
+  inline def a(x: A) =
+    x + 1
+
+object Opaque2:
+  opaque type B = Opaque.A
+
+  val vb: B = Opaque.va
+
+  inline def b(x: B) = Opaque.a(x)
+
+@main def Test() =
+  print(Opaque2.b(Opaque2.vb))


### PR DESCRIPTION
Backports #22381 to the 3.3.6.

PR submitted by the release tooling.
[skip ci]