### PR TITLE
Backport "Scala.js: Emit `js.NewArray` IR nodes when possible." to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/backend/sjs/JSPrimitives.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSPrimitives.scala
@@ -48,9 +48,10 @@ object JSPrimitives {
   inline val UNWRAP_FROM_THROWABLE = WRAP_AS_THROWABLE + 1 // js.special.unwrapFromThrowable
   inline val DEBUGGER = UNWRAP_FROM_THROWABLE + 1          // js.special.debugger
 
-  inline val THROW = DEBUGGER + 1
+  inline val THROW = DEBUGGER + 1  // <special-ops>.throw
+  inline val NEW_ARRAY = THROW + 1 // scala.runtime.Arrays.newArray
 
-  inline val UNION_FROM = THROW + 1                       // js.|.from
+  inline val UNION_FROM = NEW_ARRAY + 1                   // js.|.from
   inline val UNION_FROM_TYPE_CONSTRUCTOR = UNION_FROM + 1 // js.|.fromTypeConstructor
 
   inline val REFLECT_SELECTABLE_SELECTDYN = UNION_FROM_TYPE_CONSTRUCTOR + 1 // scala.reflect.Selectable.selectDynamic
@@ -137,6 +138,7 @@ class JSPrimitives(ictx: Context) extends DottyPrimitives(ictx) {
     addPrimitive(jsdefn.Special_debugger, DEBUGGER)
 
     addPrimitive(defn.throwMethod, THROW)
+    addPrimitive(defn.newArrayMethod, NEW_ARRAY)
 
     addPrimitive(jsdefn.PseudoUnion_from, UNION_FROM)
     addPrimitive(jsdefn.PseudoUnion_fromTypeConstructor, UNION_FROM_TYPE_CONSTRUCTOR)

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -5794,11 +5794,13 @@ object Types extends TypeUtils {
     protected def derivedLambdaType(tp: LambdaType)(formals: List[tp.PInfo], restpe: Type): Type =
       tp.derivedLambdaType(tp.paramNames, formals, restpe)
 
+    protected def mapArg(arg: Type, tparam: ParamInfo): Type = arg match
+      case arg: TypeBounds => this(arg)
+      case arg => atVariance(variance * tparam.paramVarianceSign)(this(arg))
+
     protected def mapArgs(args: List[Type], tparams: List[ParamInfo]): List[Type] = args match
       case arg :: otherArgs if tparams.nonEmpty =>
-        val arg1 = arg match
-          case arg: TypeBounds => this(arg)
-          case arg => atVariance(variance * tparams.head.paramVarianceSign)(this(arg))
+        val arg1 = mapArg(arg, tparams.head)
         val otherArgs1 = mapArgs(otherArgs, tparams.tail)
         if ((arg1 eq arg) && (otherArgs1 eq otherArgs)) args
         else arg1 :: otherArgs1

--- a/presentation-compiler/src/main/dotty/tools/pc/utils/InteractiveEnrichments.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/utils/InteractiveEnrichments.scala
@@ -281,7 +281,7 @@ object InteractiveEnrichments extends CommonMtagsEnrichments:
             sym,
             () => parentSymbols.iterator.map(toSemanticdbSymbol).toList.asJava,
             contentType,
-          )
+          ).nn
       documentation.nn.toScala
     end symbolDocumentation
   end extension


### PR DESCRIPTION
Backports #22446 to the 3.3.6.

PR submitted by the release tooling.