### PR TITLE
Backport "fix: record calls to constructors in lambdaLift" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/Dependencies.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Dependencies.scala
@@ -239,7 +239,7 @@ abstract class Dependencies(root: ast.tpd.Tree, @constructorOnly rootContext: Co
         if isExpr(sym) && isLocal(sym) then markCalled(sym, enclosure)
       case tree: New =>
         val constr = tree.tpe.typeSymbol.primaryConstructor
-        if isExpr(constr) then
+        if constr.exists then
           symSet(called, enclosure) += constr
       case tree: This =>
         narrowTo(tree.symbol.asClass)

--- a/compiler/src/dotty/tools/dotc/transform/Dependencies.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Dependencies.scala
@@ -136,6 +136,7 @@ abstract class Dependencies(root: ast.tpd.Tree, @constructorOnly rootContext: Co
       if !enclosure.exists then throw NoPath()
       if enclosure == sym.enclosure then NoSymbol
       else
+        /** is sym a constructor or a term that is nested in a constructor? */
         def nestedInConstructor(sym: Symbol): Boolean =
           sym.isConstructor
           || sym.isTerm && nestedInConstructor(sym.enclosure)
@@ -236,6 +237,10 @@ abstract class Dependencies(root: ast.tpd.Tree, @constructorOnly rootContext: Co
         captureImplicitThis(tree.tpe)
       case tree: Select =>
         if isExpr(sym) && isLocal(sym) then markCalled(sym, enclosure)
+      case tree: New =>
+        val constr = tree.tpe.typeSymbol.primaryConstructor
+        if isExpr(constr) then
+          symSet(called, enclosure) += constr
       case tree: This =>
         narrowTo(tree.symbol.asClass)
       case tree: MemberDef if isExpr(sym) && sym.owner.isTerm =>
@@ -290,7 +295,6 @@ abstract class Dependencies(root: ast.tpd.Tree, @constructorOnly rootContext: Co
         val calleeOwner = normalizedCallee.owner
         if calleeOwner.isTerm then narrowLogicOwner(caller, logicOwner(normalizedCallee))
         else
-          assert(calleeOwner.is(Trait))
           // methods nested inside local trait methods cannot be lifted out
           // beyond the trait. Note that we can also call a trait method through
           // a qualifier; in that case no restriction to lifted owner arises.

--- a/compiler/src/dotty/tools/dotc/transform/LambdaLift.scala
+++ b/compiler/src/dotty/tools/dotc/transform/LambdaLift.scala
@@ -127,9 +127,7 @@ object LambdaLift:
 
     private def proxy(sym: Symbol)(using Context): Symbol = {
       def liftedEnclosure(sym: Symbol) =
-        if sym.is(Method)
-        then deps.logicalOwner.getOrElse(sym, sym.enclosure)
-        else sym.enclosure
+        deps.logicalOwner.getOrElse(sym, sym.enclosure)
       def searchIn(enclosure: Symbol): Symbol = {
         if (!enclosure.exists) {
           def enclosures(encl: Symbol): List[Symbol] =

--- a/tests/pos/i21931.scala
+++ b/tests/pos/i21931.scala
@@ -1,13 +1,18 @@
-def f() =
-  val NotFound: Char = 'a'
-  class crashing() {
-    class issue() {
-      NotFound
-    }
-    class Module() {
-      val obligatory =
-        class anonIssue() {
-          issue()
+object Test {
+  def f() = {
+    val NotFound: Char = 'a'
+    class crashing() {
+      class issue() {
+        NotFound
+      }
+      class Module() {
+        val obligatory = {
+          def anonIssue = {
+            issue()
+          }
+          anonIssue
         }
+      }
     }
   }
+}

--- a/tests/pos/i22470.scala
+++ b/tests/pos/i22470.scala
@@ -1,0 +1,17 @@
+trait A
+trait OuterClass
+trait MidClass
+trait InnerClass
+
+object Obj:
+  def outerDef(a: A) =
+    new OuterClass {
+      def midDef(): Unit = {
+        new MidClass {
+          val valdef = new InnerClass {
+            def innerDef() =
+              println(a)
+          }
+        }
+      }
+    }


### PR DESCRIPTION
Backports #22487 to the 3.3.6.

PR submitted by the release tooling.
[skip ci]