### PR TITLE
Backport "Warn on bad extensions of aliases" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -1089,7 +1089,7 @@ object RefChecks {
             }
           }
         .exists
-      if !target.typeSymbol.denot.isAliasType && !target.typeSymbol.denot.isOpaqueAlias && hidden
+      if !target.typeSymbol.isOpaqueAlias && hidden
       then report.warning(ExtensionNullifiedByMember(sym, target.typeSymbol), sym.srcPos)
   end checkExtensionMethods
 

--- a/tests/warn/ext-override.scala
+++ b/tests/warn/ext-override.scala
@@ -7,6 +7,6 @@ trait Foo[T]:
 class Bla:
   def hi: String = "hi"
 object Bla:
-  given Foo[Bla] with
+  given Foo[Bla]:
     extension (x: Bla)
       def hi: String = x.hi

--- a/tests/warn/i16743.check
+++ b/tests/warn/i16743.check
@@ -1,3 +1,10 @@
+-- [E194] Potential Issue Warning: tests/warn/i16743.scala:90:8 --------------------------------------------------------
+90 |    def length() = 42 // warn This extension method will be shadowed by .length() on String.
+   |        ^
+   |        Extension method length will never be selected from type String
+   |        because String already has a member with the same name and compatible parameter types.
+   |
+   | longer explanation available when compiling with `-explain`
 -- [E194] Potential Issue Warning: tests/warn/i16743.scala:30:6 --------------------------------------------------------
 30 |  def t = 27 // warn
    |      ^

--- a/tests/warn/i16743.scala
+++ b/tests/warn/i16743.scala
@@ -87,7 +87,7 @@ class Depends:
 object Depending:
   extension (using depends: Depends)(x: depends.Thing)
     def y = 42
-    def length() = 42 // nowarn see Quote above
+    def length() = 42 // warn This extension method will be shadowed by .length() on String.
   def f(using d: Depends) = d.thing.y
   def g(using d: Depends) = d.thing.length()
 

--- a/tests/warn/i22233.scala
+++ b/tests/warn/i22233.scala
@@ -1,0 +1,1 @@
+extension (s: String) def length = 42 // warn


### PR DESCRIPTION
Backports #22362 to the 3.3.6.

PR submitted by the release tooling.
[skip ci]