### PR TITLE
Backport "No outdent at eof" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -615,6 +615,7 @@ object Scanners {
             if nextWidth < lastWidth then currentRegion = topLevelRegion(nextWidth)
           else if !isLeadingInfixOperator(nextWidth) && !statCtdTokens.contains(lastToken) && lastToken != INDENT then
             currentRegion match
+              case _ if token == EOF => // no OUTDENT at EOF
               case r: Indented =>
                 insert(OUTDENT, offset)
                 handleNewIndentWidth(r.enclosing, ir =>

--- a/tests/pos/i22332.scala
+++ b/tests/pos/i22332.scala
@@ -1,0 +1,5 @@
+
+object Foo:
+  val foo = 42
+ // one space
+ 


### PR DESCRIPTION
Backports #22435 to the 3.3.6.

PR submitted by the release tooling.
[skip ci]