### PR TITLE
Backport "Remove DRI from Scaladoc warnings" to 3.3 LTS

### DIFF
--- a/scaladoc/src/dotty/tools/scaladoc/tasty/TypesSupport.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/TypesSupport.scala
@@ -75,7 +75,7 @@ trait TypesSupport:
         else inner(tpe) ++ plain(".").l ++ suffix
       case tpe => inner(tpe)
 
-  // TODO #23 add support for all types signatures that makes sense
+  // TODO #23 add support for all types signatures that make sense
   private def inner(
     using Quotes,
   )(
@@ -87,7 +87,7 @@ trait TypesSupport:
   ): SSignature =
     import reflect._
     def noSupported(name: String): SSignature =
-      println(s"WARN: Unsupported type: $name: ${tp.show}")
+      report.warning(s"Unsupported type: $name: ${tp.show}")
       plain(s"Unsupported[$name]").l
     tp match
       case OrType(left, right) =>

--- a/scaladoc/src/dotty/tools/scaladoc/tasty/comments/Comments.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/comments/Comments.scala
@@ -112,7 +112,7 @@ abstract class MarkupConversion[T](val repr: Repr)(using dctx: DocContext) {
               case None => sym.dri
             DocLink.ToDRI(dri, targetText)
           case None =>
-            val txt = s"No DRI found for query"
+            val txt = s"Couldn't resolve a member for the given link query"
             val msg = s"$txt: $queryStr"
 
             if (!summon[DocContext].args.noLinkWarnings) then

--- a/scaladoc/src/dotty/tools/scaladoc/tasty/comments/MemberLookup.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/comments/MemberLookup.scala
@@ -31,8 +31,8 @@ trait MemberLookup {
       def nearestPackage(sym: Symbol): Symbol =
         if sym.flags.is(Flags.Package) then sym else nearestPackage(sym.owner)
 
-      def nearestMembered(sym: Symbol): Symbol =
-        if sym.isClassDef || sym.flags.is(Flags.Package) then sym else nearestMembered(sym.owner)
+      def nearestMember(sym: Symbol): Symbol =
+        if sym.isClassDef || sym.flags.is(Flags.Package) then sym else nearestMember(sym.owner)
 
       val res: Option[(Symbol, String, Option[Symbol])] = {
         def toplevelLookup(querystrings: List[String]) =
@@ -43,7 +43,7 @@ trait MemberLookup {
 
         ownerOpt match {
           case Some(owner) =>
-            val nearest = nearestMembered(owner)
+            val nearest = nearestMember(owner)
             val nearestCls = nearestClass(owner)
             val nearestPkg = nearestPackage(owner)
             def relativeLookup(querystrings: List[String], owner: Symbol): Option[(Symbol, Option[Symbol])] = {

--- a/scaladoc/src/dotty/tools/scaladoc/tasty/comments/wiki/Entities.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/comments/wiki/Entities.scala
@@ -5,8 +5,7 @@ import scala.collection.{Seq => _, _}
 // import representations._
 
 /** A body of text. A comment has a single body, which is composed of
-  * at least one block. Inside every body is exactly one summary (see
-  * [[scala.tools.nsc.doc.model.comment.Summary]]). */
+  * at least one block. Inside every body is exactly one summary. */
 final case class Body(blocks: Seq[Block]) {
 
   /** The summary text of the comment body. */


### PR DESCRIPTION
Backports #22330 to the 3.3.6.

PR submitted by the release tooling.
[skip ci]