### PR TITLE
Backport "Handle type aliases in contextFunctionResultTypeAfter" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/ContextFunctionResults.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ContextFunctionResults.scala
@@ -104,7 +104,7 @@ object ContextFunctionResults:
   def contextFunctionResultTypeAfter(meth: Symbol, depth: Int)(using Context) =
     def recur(tp: Type, n: Int): Type =
       if n == 0 then tp
-      else tp match
+      else tp.dealias match
         case defn.ContextFunctionType(_, resTpe) => recur(resTpe, n - 1)
     recur(meth.info.finalResultType, depth)
 

--- a/tests/pos/i21433.scala
+++ b/tests/pos/i21433.scala
@@ -1,0 +1,6 @@
+trait A[T]:
+  type R = T ?=> Unit
+  def f: R = ()
+
+class B extends A[Int]:
+  override def f: R = ()


### PR DESCRIPTION
Backports #21517 to the 3.3.6.

PR submitted by the release tooling.
[skip ci]