### PR TITLE
Backport "Avoid inf recursion in provablyDisjointClasses" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -2772,11 +2772,11 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
    *
    *  1. Single inheritance of classes
    *  2. Final classes cannot be extended
-   *  3. ConstantTypes with distinct values are non intersecting
-   *  4. TermRefs with distinct values are non intersecting
+   *  3. ConstantTypes with distinct values are non-intersecting
+   *  4. TermRefs with distinct values are non-intersecting
    *  5. There is no value of type Nothing
    *
-   *  Note on soundness: the correctness of match types relies on on the
+   *  Note on soundness: the correctness of match types relies on the
    *  property that in all possible contexts, the same match type expression
    *  is either stuck or reduces to the same case.
    */

--- a/docs/_spec/03-types.md
+++ b/docs/_spec/03-types.md
@@ -1071,7 +1071,7 @@ The following properties hold about ´⌈X⌉´ (we have paper proofs for those)
 The "lower-bound rule" states that ´S <: T´ if ´T = q.X´ and ´q.X´ is a non-class type designator and ´S <: L´ where ´L´ is the lower bound of the underlying type definition of ´q.X´".
 That rule is known to break transitivy of subtyping in Scala already.
 
-Second, we define the relation ´⋔´ on *classes* (including traits and hidden classes of objects) as:
+Second, we define the relation ´⋔´ on *classes* (including traits, hidden classes of objects, and enum terms) as:
 
 - ´C ⋔ D´ if `´C ∉´ baseClasses´(D)´` and ´D´ is `final`
 - ´C ⋔ D´ if `´D ∉´ baseClasses´(C)´` and ´C´ is `final`

--- a/tests/pos/i22266.scala
+++ b/tests/pos/i22266.scala
@@ -1,0 +1,22 @@
+sealed trait NonPolygon
+sealed trait Polygon
+
+sealed trait SymmetryAspect
+sealed trait RotationalSymmetry      extends SymmetryAspect
+sealed trait MaybeRotationalSymmetry extends SymmetryAspect
+
+enum Shape:
+  case Circle   extends Shape with NonPolygon with RotationalSymmetry
+  case Triangle extends Shape with Polygon with MaybeRotationalSymmetry
+  case Square   extends Shape with Polygon with RotationalSymmetry
+
+object Shape:
+
+  def hasPolygon(
+    rotationalSyms: Vector[Shape & RotationalSymmetry],
+    maybeSyms: Vector[Shape & MaybeRotationalSymmetry]
+  ): Boolean =
+    val all = rotationalSyms.concat(maybeSyms)
+    all.exists:
+      case _: Polygon => true
+      case _          => false

--- a/tests/pos/i22266.unenum.scala
+++ b/tests/pos/i22266.unenum.scala
@@ -1,0 +1,22 @@
+sealed trait NonPolygon
+sealed trait Polygon
+
+sealed trait SymmetryAspect
+sealed trait RotationalSymmetry      extends SymmetryAspect
+sealed trait MaybeRotationalSymmetry extends SymmetryAspect
+
+sealed abstract class Shape
+
+object Shape:
+  case object Circle   extends Shape with NonPolygon with RotationalSymmetry
+  case object Triangle extends Shape with Polygon with MaybeRotationalSymmetry
+  case object Square   extends Shape with Polygon with RotationalSymmetry
+
+  def hasPolygon(
+    rotationalSyms: Vector[Shape & RotationalSymmetry],
+    maybeSyms: Vector[Shape & MaybeRotationalSymmetry]
+  ): Boolean =
+    val all = rotationalSyms.concat(maybeSyms)
+    all.exists:
+      case _: Polygon => true
+      case _          => false

--- a/tests/warn/ext-override.scala
+++ b/tests/warn/ext-override.scala
@@ -7,6 +7,6 @@ trait Foo[T]:
 class Bla:
   def hi: String = "hi"
 object Bla:
-  given Foo[Bla]:
+  given Foo[Bla] with
     extension (x: Bla)
       def hi: String = x.hi

--- a/tests/warn/i21860.unenum.scala
+++ b/tests/warn/i21860.unenum.scala
@@ -3,7 +3,7 @@ sealed trait Corners { self: Figure => }
 
 sealed abstract class Shape extends Figure
 object Shape:
-  case object Triange  extends Shape with Corners
+  case object Triangle extends Shape with Corners
   case object Square   extends Shape with Corners
   case object Circle   extends Shape
   case object Ellipsis extends Shape


### PR DESCRIPTION
Backports #22489 to the 3.3.6.

PR submitted by the release tooling.
[skip ci]