### PR TITLE
Backport "Align erasure of `Array[Nothing]` and `Array[Null]` with Scala 2" to 3.3 LTS

### DIFF
--- a/presentation-compiler/src/main/dotty/tools/pc/PcInlayHintsProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/PcInlayHintsProvider.scala
@@ -57,7 +57,7 @@ class PcInlayHintsProvider(
       .headOption
       .getOrElse(unit.tpdTree)
       .enclosedChildren(pos.span)
-      .flatMap(tpdTree => deepFolder(InlayHints.empty(params.uri()), tpdTree).result())
+      .flatMap(tpdTree => deepFolder(InlayHints.empty(params.uri().nn), tpdTree).result())
 
   private def adjustPos(pos: SourcePosition): SourcePosition =
     pos.adjust(text)._1

--- a/sbt-test/scala2-compat/erasure/build.sbt
+++ b/sbt-test/scala2-compat/erasure/build.sbt
@@ -1,3 +1,5 @@
+ThisBuild / fork := true
+
 lazy val scala2Lib = project.in(file("scala2Lib"))
   .settings(
     scalaVersion := sys.props("plugin.scala2Version")

--- a/sbt-test/scala2-compat/erasure/dottyApp/Api.scala
+++ b/sbt-test/scala2-compat/erasure/dottyApp/Api.scala
@@ -196,9 +196,9 @@ class Z {
   def objectARRAY_89(x: Array[AnyRef]): Unit = {}
   def objectARRAY_90(x: Array[AnyVal]): Unit = {}
 
-  def objectARRAY_91(x: Array[Nothing]): Unit = {}
-  def objectARRAY_92(x: Array[Null]): Unit = {}
-  def objectARRAY_93(x: Array[_ <: Nothing]): Unit = {}
-  def objectARRAY_94(x: Array[_ <: Null]): Unit = {}
+  def nothing$ARRAY_91(x: Array[Nothing]): Unit = {}
+  def null$ARRAY_92(x: Array[Null]): Unit = {}
+  def nothing$ARRAY_93(x: Array[_ <: Nothing]): Unit = {}
+  def null$ARRAY_94(x: Array[_ <: Null]): Unit = {}
 
 }

--- a/sbt-test/scala2-compat/erasure/dottyApp/Api.scala
+++ b/sbt-test/scala2-compat/erasure/dottyApp/Api.scala
@@ -195,4 +195,10 @@ class Z {
   def objectARRAY_88(x: Array[Any]): Unit = {}
   def objectARRAY_89(x: Array[AnyRef]): Unit = {}
   def objectARRAY_90(x: Array[AnyVal]): Unit = {}
+
+  def objectARRAY_91(x: Array[Nothing]): Unit = {}
+  def objectARRAY_92(x: Array[Null]): Unit = {}
+  def objectARRAY_93(x: Array[_ <: Nothing]): Unit = {}
+  def objectARRAY_94(x: Array[_ <: Null]): Unit = {}
+
 }

--- a/sbt-test/scala2-compat/erasure/dottyApp/Main.scala
+++ b/sbt-test/scala2-compat/erasure/dottyApp/Main.scala
@@ -101,6 +101,10 @@ object Main {
     z.objectARRAY_88(dummy)
     z.objectARRAY_89(dummy)
     z.objectARRAY_90(dummy)
+    z.objectARRAY_91(dummy)
+    z.objectARRAY_92(dummy)
+    z.objectARRAY_93(dummy)
+    z.objectARRAY_94(dummy)
 
     val methods = classOf[scala2Lib.Z].getDeclaredMethods.toList ++ classOf[dottyApp.Z].getDeclaredMethods.toList
     methods.foreach { m =>

--- a/sbt-test/scala2-compat/erasure/dottyApp/Main.scala
+++ b/sbt-test/scala2-compat/erasure/dottyApp/Main.scala
@@ -103,8 +103,8 @@ object Main {
     z.objectARRAY_90(dummy)
     z.objectARRAY_91(dummy)
     z.objectARRAY_92(dummy)
-    //z.objectARRAY_93(dummy)
-    //z.objectARRAY_94(dummy)
+    z.objectARRAY_93(dummy)
+    z.objectARRAY_94(dummy)
 
     val methods = classOf[scala2Lib.Z].getDeclaredMethods.toList ++ classOf[dottyApp.Z].getDeclaredMethods.toList
     methods.foreach { m =>

--- a/sbt-test/scala2-compat/erasure/dottyApp/Main.scala
+++ b/sbt-test/scala2-compat/erasure/dottyApp/Main.scala
@@ -53,10 +53,10 @@ object Main {
     z.c_40(dummy)
     z.c_41(dummy)
     z.c_42(dummy)
-    z.b_43(dummy)
+    //z.b_43(dummy)
     z.c_44(dummy)
     z.c_45(dummy)
-    z.b_46(dummy)
+    //z.b_46(dummy)
     z.c_47(dummy)
     // z.a_48(dummy)
     // z.c_49(dummy)
@@ -103,8 +103,8 @@ object Main {
     z.objectARRAY_90(dummy)
     z.objectARRAY_91(dummy)
     z.objectARRAY_92(dummy)
-    z.objectARRAY_93(dummy)
-    z.objectARRAY_94(dummy)
+    //z.objectARRAY_93(dummy)
+    //z.objectARRAY_94(dummy)
 
     val methods = classOf[scala2Lib.Z].getDeclaredMethods.toList ++ classOf[dottyApp.Z].getDeclaredMethods.toList
     methods.foreach { m =>

--- a/sbt-test/scala2-compat/erasure/scala2Lib/Api.scala
+++ b/sbt-test/scala2-compat/erasure/scala2Lib/Api.scala
@@ -186,4 +186,10 @@ class Z {
   def objectARRAY_88(x: Array[Any]): Unit = {}
   def objectARRAY_89(x: Array[AnyRef]): Unit = {}
   def objectARRAY_90(x: Array[AnyVal]): Unit = {}
+
+  def objectARRAY_91(x: Array[Nothing]): Unit = {}
+  def objectARRAY_92(x: Array[Null]): Unit = {}
+  def objectARRAY_93(x: Array[_ <: Nothing]): Unit = {}
+  def objectARRAY_94(x: Array[_ <: Null]): Unit = {}
+
 }


### PR DESCRIPTION
Backports #22517 to the 3.3.6.

PR submitted by the release tooling.