### PR TITLE
Backport "Allow private members when computing the denotation of a NamedType" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -2412,7 +2412,7 @@ object Types extends TypeUtils {
           else lastd match {
             case lastd: SymDenotation =>
               if stillValid(lastd) && checkedPeriod.code != NowhereCode then finish(lastd.current)
-              else finish(memberDenot(lastd.initial.name, allowPrivate = false))
+              else finish(memberDenot(lastd.initial.name, allowPrivate = lastd.is(Private)))
             case _ =>
               fromDesignator
           }

--- a/tests/pos/i22548.scala
+++ b/tests/pos/i22548.scala
@@ -1,0 +1,2 @@
+trait Bar[T]
+class Foo[T <: Bar[T]] (private val buffer: Any) extends AnyVal


### PR DESCRIPTION
Backports #22549 to the 3.3.6.

PR submitted by the release tooling.
[skip ci]