### PR TITLE
Backport "Better LSP completions inside of backticks" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/interactive/Completion.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/Completion.scala
@@ -145,11 +145,12 @@ object Completion:
         checkBacktickPrefix(ident.source.content(), ident.span.start, ident.span.end)
 
       case (tree: untpd.RefTree) :: _ if tree.name != nme.ERROR =>
-        tree.name.toString.take(pos.span.point - tree.span.point)
+        val nameStart = tree.span.point
+        val start = if pos.source.content().lift(nameStart).contains('`') then nameStart + 1 else nameStart
+        tree.name.toString.take(pos.span.point - start)
 
-      case _ => naiveCompletionPrefix(pos.source.content().mkString, pos.point)
-
-
+      case _ =>
+        naiveCompletionPrefix(pos.source.content().mkString, pos.point)
   end completionPrefix
 
   private object GenericImportSelector:

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/CompletionProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/CompletionProvider.scala
@@ -248,10 +248,17 @@ class CompletionProvider(
         range: Option[LspRange] = None
     ): CompletionItem =
       val oldText = params.text().nn.substring(completionPos.queryStart, completionPos.identEnd)
-      val editRange = if newText.startsWith(oldText) then completionPos.stripSuffixEditRange
+      val trimmedNewText = {
+        var nt = newText
+        if (completionPos.hasLeadingBacktick) nt = nt.stripPrefix("`")
+        if (completionPos.hasTrailingBacktick) nt = nt.stripSuffix("`")
+        nt
+      }
+
+      val editRange = if trimmedNewText.startsWith(oldText) then completionPos.stripSuffixEditRange
         else completionPos.toEditRange
 
-      val textEdit = new TextEdit(range.getOrElse(editRange), wrapInBracketsIfRequired(newText))
+      val textEdit = new TextEdit(range.getOrElse(editRange), wrapInBracketsIfRequired(trimmedNewText))
 
       val item = new CompletionItem(label)
       item.setSortText(f"${idx}%05d")

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionBacktickSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionBacktickSuite.scala
@@ -179,3 +179,60 @@ class CompletionBacktickSuite extends BaseCompletionSuite:
          |}
          |""".stripMargin
     )
+
+  @Test def `add-backticks-around-identifier` =
+    checkEdit(
+      """|object Main {
+         |  def `Foo Bar` = 123
+         |  Foo@@
+         |}
+         |""".stripMargin,
+      """|object Main {
+         |  def `Foo Bar` = 123
+         |  `Foo Bar`
+         |}
+         |""".stripMargin
+    )
+
+  @Test def `complete-inside-backticks` =
+    checkEdit(
+      """|object Main {
+         |  def `Foo Bar` = 123
+         |  `Foo@@`
+         |}
+         |""".stripMargin,
+      """|object Main {
+         |  def `Foo Bar` = 123
+         |  `Foo Bar`
+         |}
+         |""".stripMargin
+    )
+
+  @Test def `complete-inside-backticks-after-space` =
+    checkEdit(
+      """|object Main {
+         |  def `Foo Bar` = 123
+         |  `Foo B@@a`
+         |}
+         |""".stripMargin,
+      """|object Main {
+         |  def `Foo Bar` = 123
+         |  `Foo Bar`
+         |}
+         |""".stripMargin
+    )
+
+  @Test def `complete-inside-empty-backticks` =
+    checkEdit(
+      """|object Main {
+         |  def `Foo Bar` = 123
+         |  `@@`
+         |}
+         |""".stripMargin,
+      """|object Main {
+         |  def `Foo Bar` = 123
+         |  `Foo Bar`
+         |}
+         |""".stripMargin,
+      filter = _ == "Foo Bar: Int"
+    )


### PR DESCRIPTION
Backports #22555 to the 3.3.6.

PR submitted by the release tooling.
[skip ci]