### PR TITLE
Backport "fix: don't add `()` to semanticdb symbol for java variables" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/semanticdb/SemanticSymbolBuilder.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/SemanticSymbolBuilder.scala
@@ -111,7 +111,7 @@ class SemanticSymbolBuilder:
         addName(b, sym.name)
         if sym.is(Package) then b.append('/')
         else if sym.isType || sym.isAllOf(JavaModule) then b.append('#')
-        else if sym.isOneOf(Method | Mutable)
+        else if sym.is(Method) || (sym.is(Mutable) && !sym.is(JavaDefined))
         && (!sym.is(StableRealizable) || sym.isConstructor) then
           b.append('('); addOverloadIdx(sym); b.append(").")
         else b.append('.')

--- a/tests/semanticdb/expect/JavaStaticVar.expect.scala
+++ b/tests/semanticdb/expect/JavaStaticVar.expect.scala
@@ -1,0 +1,7 @@
+package example
+
+import com.javacp.JavaStaticVar/*->com::javacp::JavaStaticVar#*/
+
+class ScalaFoo/*<-example::ScalaFoo#*/ {
+  val javaStaticVarFoo/*<-example::ScalaFoo#javaStaticVarFoo.*/ = JavaStaticVar/*->com::javacp::JavaStaticVar#*/.foo/*->com::javacp::JavaStaticVar#foo.*/
+}

--- a/tests/semanticdb/expect/JavaStaticVar.scala
+++ b/tests/semanticdb/expect/JavaStaticVar.scala
@@ -1,0 +1,7 @@
+package example
+
+import com.javacp.JavaStaticVar
+
+class ScalaFoo {
+  val javaStaticVarFoo = JavaStaticVar.foo
+}

--- a/tests/semanticdb/javacp/com/javacp/JavaStaticVar.java
+++ b/tests/semanticdb/javacp/com/javacp/JavaStaticVar.java
@@ -1,0 +1,5 @@
+package com.javacp;
+
+public class JavaStaticVar {
+  public static int foo = 0;
+}

--- a/tests/semanticdb/metac.expect
+++ b/tests/semanticdb/metac.expect
@@ -2249,6 +2249,33 @@ Synthetics:
 [8:2..8:10):(x1, x1) => *(Tuple2(Int, Int))
 [8:10..8:10): => *(Int, Int)
 
+expect/JavaStaticVar.scala
+--------------------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => JavaStaticVar.scala
+Text => empty
+Language => Scala
+Symbols => 3 entries
+Occurrences => 9 entries
+
+Symbols:
+example/ScalaFoo# => class ScalaFoo extends Object { self: ScalaFoo => +2 decls }
+example/ScalaFoo#`<init>`(). => primary ctor <init> (): ScalaFoo
+example/ScalaFoo#javaStaticVarFoo. => val method javaStaticVarFoo Int
+
+Occurrences:
+[0:8..0:15): example <- example/
+[2:7..2:10): com -> com/
+[2:11..2:17): javacp -> com/javacp/
+[2:18..2:31): JavaStaticVar -> com/javacp/JavaStaticVar#
+[4:6..4:14): ScalaFoo <- example/ScalaFoo#
+[5:2..5:2): <- example/ScalaFoo#`<init>`().
+[5:6..5:22): javaStaticVarFoo <- example/ScalaFoo#javaStaticVarFoo.
+[5:25..5:38): JavaStaticVar -> com/javacp/JavaStaticVar#
+[5:39..5:42): foo -> com/javacp/JavaStaticVar#foo.
+
 expect/Local.scala
 ------------------
 


### PR DESCRIPTION
Backports #22573 to the 3.3.6.

PR submitted by the release tooling.
[skip ci]