### PR TITLE
Backport "fix: Only fallback to the definition of a synthetic valdef if it is zero extent" to 3.3 LTS

### DIFF
--- a/presentation-compiler/src/main/dotty/tools/pc/completions/CompletionProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/CompletionProvider.scala
@@ -99,9 +99,9 @@ class CompletionProvider(
              *  4|     $1$.sliding@@[Int](size, step)
              *
              */
-            if qual.symbol.is(Flags.Synthetic) && qual.symbol.name.isInstanceOf[DerivedName] =>
+            if qual.symbol.is(Flags.Synthetic) && qual.span.isZeroExtent && qual.symbol.name.isInstanceOf[DerivedName] =>
               qual.symbol.defTree match
-                case valdef: ValDef => Select(valdef.rhs, name) :: tail
+                case valdef: ValDef if !valdef.rhs.isEmpty => Select(valdef.rhs, name) :: tail
                 case _ => tpdPath0
           case _ => tpdPath0
 

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
@@ -2134,3 +2134,14 @@ class CompletionSuite extends BaseCompletionSuite:
       """|build: Unit
          |""".stripMargin,
     )
+
+  @Test def i7191 =
+    check(
+      """|val x = Some(3).map(_.@@)
+         |""".stripMargin,
+      """|!=(x: Byte): Boolean
+         |!=(x: Char): Boolean
+         |!=(x: Double): Boolean
+         |""".stripMargin,
+      topLines = Some(3)
+    )


### PR DESCRIPTION
Backports #22551 to the 3.3.6.

PR submitted by the release tooling.
[skip ci]