### PR TITLE
Backport "Fix copy of annotation on @main methods" to 3.3 LTS

### DIFF
--- a/tests/pos/annot-main-22364.scala
+++ b/tests/pos/annot-main-22364.scala
@@ -1,0 +1,5 @@
+def id[T](x: T): T = x
+
+class ann(x: Int) extends annotation.Annotation
+
+@ann(id(22)) @main def blop = ()

--- a/tests/pos/annot-main-22364b.scala
+++ b/tests/pos/annot-main-22364b.scala
@@ -1,0 +1,6 @@
+import util.chaining.*
+
+class ann(x: Int = 1, y: Int) extends annotation.Annotation
+
+@ann(y = 22.tap(println)) @main def blop = ()
+

--- a/tests/pos/annot-main-22364c.scala
+++ b/tests/pos/annot-main-22364c.scala
@@ -1,0 +1,10 @@
+package p
+
+object P1:
+  class ann(x: Int) extends annotation.Annotation
+
+object P2:
+  def id[T](x: T): T = x
+
+object P3:
+  @P1.ann(P2.id(22)) @main def blop = ()


### PR DESCRIPTION
Backports #22582 to the 3.3.6.

PR submitted by the release tooling.
[skip ci]