### PR TITLE
Backport "Use by-name parameter for Properties.*OrElse " to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/PathResolver.scala
+++ b/compiler/src/dotty/tools/dotc/config/PathResolver.scala
@@ -53,8 +53,7 @@ object PathResolver {
     def classPathEnv: String        =  envOrElse("CLASSPATH", "")
     def sourcePathEnv: String       =  envOrElse("SOURCEPATH", "")
 
-    //using propOrNone/getOrElse instead of propOrElse so that searchForBootClasspath is lazy evaluated
-    def javaBootClassPath: String   = propOrNone("sun.boot.class.path") getOrElse searchForBootClasspath
+    def javaBootClassPath: String   = propOrElse("sun.boot.class.path", searchForBootClasspath)
 
     def javaExtDirs: String         = propOrEmpty("java.ext.dirs")
     def scalaHome: String           = propOrEmpty("scala.home")

--- a/compiler/src/dotty/tools/dotc/config/Properties.scala
+++ b/compiler/src/dotty/tools/dotc/config/Properties.scala
@@ -45,7 +45,7 @@ trait PropertiesTrait {
 
   def propIsSet(name: String): Boolean                  = System.getProperty(name) != null
   def propIsSetTo(name: String, value: String): Boolean = propOrNull(name) == value
-  def propOrElse(name: String, alt: String): String     = System.getProperty(name, alt)
+  def propOrElse(name: String, alt: => String): String  = Option(System.getProperty(name)).getOrElse(alt)
   def propOrEmpty(name: String): String                 = propOrElse(name, "")
   def propOrNull(name: String): String                  = propOrElse(name, null)
   def propOrNone(name: String): Option[String]          = Option(propOrNull(name))
@@ -53,11 +53,11 @@ trait PropertiesTrait {
   def setProp(name: String, value: String): String      = System.setProperty(name, value)
   def clearProp(name: String): String                   = System.clearProperty(name)
 
-  def envOrElse(name: String, alt: String): String      = Option(System getenv name) getOrElse alt
+  def envOrElse(name: String, alt: => String): String   = Option(System getenv name) getOrElse alt
   def envOrNone(name: String): Option[String]           = Option(System getenv name)
 
   // for values based on propFilename
-  def scalaPropOrElse(name: String, alt: String): String = scalaProps.getProperty(name, alt)
+  def scalaPropOrElse(name: String, alt: => String): String = scalaProps.getProperty(name, alt)
   def scalaPropOrEmpty(name: String): String             = scalaPropOrElse(name, "")
   def scalaPropOrNone(name: String): Option[String]      = Option(scalaProps.getProperty(name))
 

--- a/compiler/src/dotty/tools/dotc/config/WrappedProperties.scala
+++ b/compiler/src/dotty/tools/dotc/config/WrappedProperties.scala
@@ -14,12 +14,12 @@ trait WrappedProperties extends PropertiesTrait {
   protected def propCategory: String     = "wrapped"
   protected def pickJarBasedOn: Class[?] = this.getClass
 
-  override def propIsSet(name: String): Boolean              = wrap(super.propIsSet(name)) exists (x => x)
-  override def propOrElse(name: String, alt: String): String = wrap(super.propOrElse(name, alt)) getOrElse alt
-  override def setProp(name: String, value: String): String  = wrap(super.setProp(name, value)).orNull
-  override def clearProp(name: String): String               = wrap(super.clearProp(name)).orNull
-  override def envOrElse(name: String, alt: String): String  = wrap(super.envOrElse(name, alt)) getOrElse alt
-  override def envOrNone(name: String): Option[String]       = wrap(super.envOrNone(name)).flatten
+  override def propIsSet(name: String): Boolean                 = wrap(super.propIsSet(name)) exists (x => x)
+  override def propOrElse(name: String, alt: => String): String = wrap(super.propOrElse(name, alt)) getOrElse alt
+  override def setProp(name: String, value: String): String     = wrap(super.setProp(name, value)).orNull
+  override def clearProp(name: String): String                  = wrap(super.clearProp(name)).orNull
+  override def envOrElse(name: String, alt: => String): String  = wrap(super.envOrElse(name, alt)) getOrElse alt
+  override def envOrNone(name: String): Option[String]          = wrap(super.envOrNone(name)).flatten
 
   def systemProperties: Iterator[(String, String)] = {
     import scala.jdk.CollectionConverters.*

--- a/compiler/test/dotty/tools/dotc/config/PropertiesTest.scala
+++ b/compiler/test/dotty/tools/dotc/config/PropertiesTest.scala
@@ -1,0 +1,45 @@
+package dotty.tools.dotc.config
+
+import org.junit.Before
+import org.junit.Test
+import org.junit.Assert._
+import scala.language.unsafeNulls
+
+class PropertiesTest {
+  final val TestProperty = "dotty.tools.dotc.config.PropertiesTest.__test_property__"
+
+  @Before
+  def beforeEach(): Unit = {
+    Properties.clearProp(TestProperty)
+  }
+
+  @Test
+  def testPropOrNone(): Unit = {
+    assertEquals(Properties.propOrNone(TestProperty), None)
+
+    Properties.setProp(TestProperty, "foo")
+
+    assertEquals(Properties.propOrNone(TestProperty), Some("foo"))
+  }
+
+  @Test
+  def testPropOrElse(): Unit = {
+    assertEquals(Properties.propOrElse(TestProperty, "bar"), "bar")
+
+    Properties.setProp(TestProperty, "foo")
+
+    var done = false
+    assertEquals(Properties.propOrElse(TestProperty, { done = true; "bar" }), "foo")
+    assertFalse("Does not evaluate alt if not needed", done)
+  }
+
+  @Test
+  def testEnvOrElse(): Unit = {
+    assertEquals(Properties.envOrElse("_PropertiesTest_NOT_DEFINED", "test"), "test")
+
+    var done = false
+    val envName = System.getenv().keySet().iterator().next()
+    assertNotEquals(Properties.envOrElse(envName, {done = true; "bar"}), "bar")
+    assertFalse("Does not evaluate alt if not needed", done)
+  }
+}


### PR DESCRIPTION
Backports #22255 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]