### PR TITLE
Backport "Add regression test for #22076" to 3.3 LTS

### DIFF
--- a/tests/pos/match-type-disjoint-22076.scala
+++ b/tests/pos/match-type-disjoint-22076.scala
@@ -1,0 +1,8 @@
+trait Foo[CP <: NonEmptyTuple]:
+  type EndNode = Tuple.Last[CP]
+
+def f(end: Foo[?]): end.EndNode =
+  ???
+
+trait Bar[CP <: NonEmptyTuple] extends Foo[CP]:
+  val v: EndNode = f(this)


### PR DESCRIPTION
Backports #22602 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]