### PR TITLE
Backport "Avoid crash in uninhab check in Space" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -655,7 +655,7 @@ object SpaceEngine {
           val superType = child.typeRef.superType
           if typeArgs.exists(_.isBottomType) && superType.isInstanceOf[ClassInfo] then
             val parentClass = superType.asInstanceOf[ClassInfo].declaredParents.find(_.classSymbol == parent).get
-            val paramTypeMap = Map.from(parentClass.argTypes.map(_.typeSymbol).zip(typeArgs))
+            val paramTypeMap = Map.from(parentClass.argInfos.map(_.typeSymbol).zip(typeArgs))
             val substArgs = child.typeRef.typeParamSymbols.map(param => paramTypeMap.getOrElse(param, WildcardType))
             substArgs
           else Nil

--- a/tests/pos/i22518.scala
+++ b/tests/pos/i22518.scala
@@ -1,0 +1,9 @@
+sealed trait Foo[T]
+class Bar extends Foo[?]
+
+def mkFoo[T]: Foo[T] =
+  ???
+
+def test: Unit =
+  mkFoo match
+    case _ => ()


### PR DESCRIPTION
Backports #22601 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]