### PR TITLE
Backport "fix: treat static vals as enclosures in lambdalift" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -1218,6 +1218,15 @@ object SymDenotations {
       else if (this.exists) owner.enclosingMethod
       else NoSymbol
 
+    /** The closest enclosing method or static symbol containing this definition.
+     *  A local dummy owner is mapped to the primary constructor of the class.
+     */
+    final def enclosingMethodOrStatic(using Context): Symbol =
+      if this.is(Method) || this.hasAnnotation(defn.ScalaStaticAnnot) then symbol
+      else if this.isClass then primaryConstructor
+      else if this.exists then owner.enclosingMethodOrStatic
+      else NoSymbol
+
     /** The closest enclosing extension method containing this definition,
      *  including methods outside the current class.
      */

--- a/compiler/src/dotty/tools/dotc/transform/LambdaLift.scala
+++ b/compiler/src/dotty/tools/dotc/transform/LambdaLift.scala
@@ -34,8 +34,8 @@ object LambdaLift:
     val liftedDefs: HashMap[Symbol, ListBuffer[Tree]] = new HashMap
 
     val deps = new Dependencies(ctx.compilationUnit.tpdTree, ctx.withPhase(thisPhase)):
-      def isExpr(sym: Symbol)(using Context): Boolean = sym.is(Method)
-      def enclosure(using Context) = ctx.owner.enclosingMethod
+      def isExpr(sym: Symbol)(using Context): Boolean = sym.is(Method) || sym.hasAnnotation(defn.ScalaStaticAnnot)
+      def enclosure(using Context) = ctx.owner.enclosingMethodOrStatic
 
       override def process(tree: Tree)(using Context): Unit =
         super.process(tree)

--- a/tests/pos/i22408.scala
+++ b/tests/pos/i22408.scala
@@ -1,0 +1,11 @@
+object Obj:
+  @scala.annotation.static
+  val some_static_value: Int = {
+    val some_local_value: Int = {
+      val some_local_value_1 = ???
+      some_local_value_1
+    }
+    some_local_value
+  }
+
+class Obj


### PR DESCRIPTION
Backports #22452 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]