### PR TITLE
Backport "Clarify reference on inferred object-private parameter" to 3.3 LTS

### DIFF
--- a/docs/_docs/reference/dropped-features/this-qualifier.md
+++ b/docs/_docs/reference/dropped-features/this-qualifier.md
@@ -29,3 +29,15 @@ This can cause problems if a program tries to access the missing private field v
       // [C] needed if `field` is to be accessed through reflection
     val retained = field * field
 ```
+
+Class parameters are normally inferred object-private,
+so that members introduced by explicitly declaring them `val` or `var` are exempt from the rule described here.
+
+In particular, the following field is not excluded from variance checking:
+```scala
+  class C[-T](private val t: T) // error
+```
+And in contrast to the private field shown above, this field is not eliminated:
+```scala
+  class C(private val c: Int)
+```

--- a/tests/neg/i22620.scala
+++ b/tests/neg/i22620.scala
@@ -1,0 +1,4 @@
+
+import scala.collection.mutable.ArrayBuffer
+
+class PrivateTest[-M](private val v: ArrayBuffer[M]) // error


### PR DESCRIPTION
Backports #22621 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]