### PR TITLE
Backport "Add a check for correct Array shape in quotes.reflect.ClassOfConstant" to 3.3 LTS

### DIFF
--- a/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
+++ b/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
@@ -2448,7 +2448,17 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
 
     object ClassOfConstant extends ClassOfConstantModule:
       def apply(x: TypeRepr): ClassOfConstant =
-        // TODO check that the type is a valid class when creating this constant or let Ycheck do it?
+        // We only check if the supplied TypeRepr is valid if it contains an Array,
+        // as so far only that Array could cause issues
+        def correctTypeApplicationForArray(typeRepr: TypeRepr): Boolean =
+            val isArray = typeRepr.typeSymbol != dotc.core.Symbols.defn.ArrayClass
+            typeRepr match
+              case AppliedType(_, targs) if !targs.isEmpty => true
+              case _ => isArray
+        xCheckMacroAssert(
+          correctTypeApplicationForArray(x),
+          "Illegal empty Array type constructor. Please supply a type parameter."
+        )
         dotc.core.Constants.Constant(x)
       def unapply(constant: ClassOfConstant): Some[TypeRepr] = Some(constant.typeValue)
     end ClassOfConstant

--- a/tests/neg-macros/i21916.check
+++ b/tests/neg-macros/i21916.check
@@ -1,0 +1,15 @@
+
+-- Error: tests/neg-macros/i21916/Test_2.scala:3:27 --------------------------------------------------------------------
+3 |@main def Test = Macro.test() // error
+  |                 ^^^^^^^^^^^^
+  |                 Exception occurred while executing macro expansion.
+  |                 java.lang.AssertionError: Illegal empty Array type constructor. Please supply a type parameter.
+  |                 	at Macro$.testImpl(Macro_1.scala:8)
+  |
+  |---------------------------------------------------------------------------------------------------------------------
+  |Inline stack trace
+  |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  |This location contains code that was inlined from Macro_1.scala:3
+3 |  inline def test() = ${testImpl}
+  |                      ^^^^^^^^^^^
+   ---------------------------------------------------------------------------------------------------------------------

--- a/tests/neg-macros/i21916/Macro_1.scala
+++ b/tests/neg-macros/i21916/Macro_1.scala
@@ -1,0 +1,9 @@
+import scala.quoted._
+object Macro:
+  inline def test() = ${testImpl}
+  def testImpl(using Quotes): Expr[Any] = {
+    import quotes.reflect._
+    val tpe = TypeRepr.of[Array[Byte]] match
+      case AppliedType(tycons, _) => tycons
+    Literal(ClassOfConstant(tpe)).asExpr
+  }

--- a/tests/neg-macros/i21916/Test_2.scala
+++ b/tests/neg-macros/i21916/Test_2.scala
@@ -1,0 +1,3 @@
+// lack of type ascription is on purpose,
+// as that was part of what would cause the crash before.
+@main def Test = Macro.test() // error


### PR DESCRIPTION
Backports #22033 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]