### PR TITLE
Backport "Constructor companion gets privateWithin" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/NamerOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/NamerOps.scala
@@ -141,6 +141,7 @@ object NamerOps:
         cls.owner, cls.name.toTermName,
         flags, flags,
         constructorCompanionCompleter(cls),
+        cls.privateWithin,
         coord = cls.coord,
         assocFile = cls.assocFile)
     companion.moduleClass.registerCompanion(cls)

--- a/tests/neg/i18545.check
+++ b/tests/neg/i18545.check
@@ -1,0 +1,26 @@
+-- [E173] Reference Error: tests/neg/i18545.scala:16:20 ----------------------------------------------------------------
+16 |  def test: IOLocal.IOLocalImpl[Int] = // error
+   |            ^^^^^^^^^^^^^^^^^^^
+   |class IOLocalImpl cannot be accessed as a member of iolib.IOLocal.type from the top-level definitions in package tests.
+   |  private[IOLocal] class IOLocalImpl can only be accessed from object IOLocal in package iolib.
+-- [E173] Reference Error: tests/neg/i18545.scala:17:24 ----------------------------------------------------------------
+17 |    IOLocal.IOLocalImpl.apply(42) // error
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |method apply cannot be accessed as a member of iolib.IOLocal.IOLocalImpl.type from the top-level definitions in package tests.
+   |  private[IOLocal] method apply can only be accessed from object IOLocal in package iolib.
+-- [E050] Type Error: tests/neg/i18545.scala:18:22 ---------------------------------------------------------------------
+18 |  def test2 = IOLocal.IOLocalImpl(42) // error
+   |              ^^^^^^^^^^^^^^^^^^^
+   |              object IOLocalImpl in object IOLocal does not take parameters
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E173] Reference Error: tests/neg/i18545.scala:19:22 ----------------------------------------------------------------
+19 |  def test3 = IOLocal.AltIOLocalImpl.apply(42) // error
+   |              ^^^^^^^^^^^^^^^^^^^^^^
+   |object AltIOLocalImpl cannot be accessed as a member of iolib.IOLocal.type from the top-level definitions in package tests.
+   |  private[IOLocal] object AltIOLocalImpl can only be accessed from object IOLocal in package iolib.
+-- [E173] Reference Error: tests/neg/i18545.scala:20:22 ----------------------------------------------------------------
+20 |  def test4 = IOLocal.AltIOLocalImpl(42) // error
+   |              ^^^^^^^^^^^^^^^^^^^^^^
+   |object AltIOLocalImpl cannot be accessed as a member of iolib.IOLocal.type from the top-level definitions in package tests.
+   |  private[IOLocal] object AltIOLocalImpl can only be accessed from object IOLocal in package iolib.

--- a/tests/neg/i18545.scala
+++ b/tests/neg/i18545.scala
@@ -1,0 +1,20 @@
+package iolib:
+  case class IO[A](value: A)
+
+  sealed trait IOLocal[A]
+
+  object IOLocal:
+    def apply[A](default: A): IO[IOLocal[A]] = IO(new IOLocalImpl(default))
+
+    private[IOLocal] final class IOLocalImpl[A](default: A) extends IOLocal[A]
+    object IOLocalImpl
+
+    private[IOLocal] final class AltIOLocalImpl[A](default: A) extends IOLocal[A]
+
+package tests:
+  import iolib.IOLocal
+  def test: IOLocal.IOLocalImpl[Int] = // error
+    IOLocal.IOLocalImpl.apply(42) // error
+  def test2 = IOLocal.IOLocalImpl(42) // error
+  def test3 = IOLocal.AltIOLocalImpl.apply(42) // error
+  def test4 = IOLocal.AltIOLocalImpl(42) // error

--- a/tests/neg/i22560b.scala
+++ b/tests/neg/i22560b.scala
@@ -12,7 +12,9 @@ package p:
   private[p] class C(i: Int) // ctor proxy gets privateWithin of class
   private[p] class D(i: Int)
   object D
+  private class E(i: Int)
 
 package q:
   def f() = p.C(42) // error
   def g() = p.D(42) // error
+  def h() = p.E(42) // error

--- a/tests/neg/i22560c/client_2.scala
+++ b/tests/neg/i22560c/client_2.scala
@@ -1,0 +1,11 @@
+
+package i22560:
+  val alpha = C.D() // error
+
+  class Test extends Enumeration:
+    val Hearts = Val(27) // error
+    val Diamonds = Val() // error
+
+package q:
+  def f() = p.C(42) // error
+  def g() = p.D(42) // error

--- a/tests/neg/i22560c/lib_1.scala
+++ b/tests/neg/i22560c/lib_1.scala
@@ -1,0 +1,16 @@
+
+package i22560:
+
+  object C:
+    protected class D
+
+  class Enumeration:
+    protected class Val(i: Int):
+      def this() = this(42)
+    object Val
+
+package p:
+  private[p] class C(i: Int) // companion gets privateWithin of class
+  private[p] class D(i: Int) // ctor proxy gets privateWithin of class
+  object D
+

--- a/tests/pos/i22560b/client_2.scala
+++ b/tests/pos/i22560b/client_2.scala
@@ -1,0 +1,17 @@
+
+package companionless:
+
+  class Test extends Enumeration:
+    val Hearts = Val(27)
+    val Diamonds = Val()
+
+
+package companioned:
+
+  class Test extends Enumeration:
+    val Hearts = Val(27)
+    val Diamonds = Val()
+
+package p:
+
+  def f = internal.P(42)

--- a/tests/pos/i22560b/lib_1.scala
+++ b/tests/pos/i22560b/lib_1.scala
@@ -5,11 +5,6 @@ package companionless:
     protected class Val(i: Int):
       def this() = this(42)
 
-  class Test extends Enumeration:
-    val Hearts = Val(27)
-    val Diamonds = Val()
-
-
 package companioned:
 
   class Enumeration:
@@ -17,16 +12,8 @@ package companioned:
       def this() = this(42)
     protected object Val
 
-  class Test extends Enumeration:
-    val Hearts = Val(27)
-    val Diamonds = Val()
-
 package p:
 
   package internal:
 
     protected[p] class P(i : Int)
-    private[p] class Q(i : Int)
-
-  def f = internal.P(42)
-  def g = internal.Q(42)


### PR DESCRIPTION
Backports #22627 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]