### PR TITLE
Backport "Fix for #22461 Empty ClassPath attribute in one or more classpath jars causes crash" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/io/Jar.scala
+++ b/compiler/src/dotty/tools/io/Jar.scala
@@ -50,7 +50,7 @@ class Jar(file: File) {
   def mainClass: Option[String]     = manifest.map(_(Name.MAIN_CLASS))
   /** The manifest-defined classpath String if available. */
   def classPathString: Option[String] =
-    for (m <- manifest ; cp <- m.attrs.get(Name.CLASS_PATH) if !cp.isBlank()) yield cp
+    for (m <- manifest ; cp <- m.attrs.get(Name.CLASS_PATH) if !cp.trim().isEmpty()) yield cp
   def classPathElements: List[String] = classPathString match {
     case Some(s)  => s.split("\\s+").toList
     case _        => Nil

--- a/compiler/src/dotty/tools/io/Jar.scala
+++ b/compiler/src/dotty/tools/io/Jar.scala
@@ -50,7 +50,7 @@ class Jar(file: File) {
   def mainClass: Option[String]     = manifest.map(_(Name.MAIN_CLASS))
   /** The manifest-defined classpath String if available. */
   def classPathString: Option[String] =
-    for (m <- manifest ; cp <- m.attrs.get(Name.CLASS_PATH)) yield cp
+    for (m <- manifest ; cp <- m.attrs.get(Name.CLASS_PATH) if !cp.isBlank()) yield cp
   def classPathElements: List[String] = classPathString match {
     case Some(s)  => s.split("\\s+").toList
     case _        => Nil


### PR DESCRIPTION
Backports #22462 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]