### PR TITLE
Backport "Make overload pruning based on result types less aggressive" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/NamerOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/NamerOps.scala
@@ -113,8 +113,11 @@ object NamerOps:
       var flags = ApplyProxyFlags | (constr.flagsUNSAFE & AccessFlags)
       if cls.is(Protected) && !modcls.is(Protected) then flags |= Protected
       newSymbol(
-        modcls, nme.apply, flags,
-        ApplyProxyCompleter(constr), coord = constr.coord)
+        modcls, nme.apply,
+        flags,
+        ApplyProxyCompleter(constr),
+        cls.privateWithin,
+        constr.coord)
     for dcl <- cls.info.decls do
       if dcl.isConstructor then scope.enter(proxy(dcl))
     scope

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1949,16 +1949,20 @@ trait Applications extends Compatibility {
   def resolveOverloaded(alts: List[TermRef], pt: Type)(using Context): List[TermRef] =
     record("resolveOverloaded")
 
-    /** Is `alt` a method or polytype whose result type after the first value parameter
+    /** Is `alt` a method or polytype whose approximated result type after the first value parameter
      *  section conforms to the expected type `resultType`? If `resultType`
      *  is a `IgnoredProto`, pick the underlying type instead.
+     *
+     *  Using approximated result types is necessary to avoid false negatives
+     *  due to incomplete type inference such as in tests/pos/i21410.scala.
      */
     def resultConforms(altSym: Symbol, altType: Type, resultType: Type)(using Context): Boolean =
       resultType.revealIgnored match {
         case resultType: ValueType =>
           altType.widen match {
-            case tp: PolyType => resultConforms(altSym, instantiateWithTypeVars(tp), resultType)
-            case tp: MethodType => constrainResult(altSym, tp.resultType, resultType)
+            case tp: PolyType => resultConforms(altSym, tp.resultType, resultType)
+            case tp: MethodType =>
+              constrainResult(altSym, wildApprox(tp.resultType), resultType)
             case _ => true
           }
         case _ => true

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1953,8 +1953,8 @@ trait Applications extends Compatibility {
      *  section conforms to the expected type `resultType`? If `resultType`
      *  is a `IgnoredProto`, pick the underlying type instead.
      *
-     *  Using approximated result types is necessary to avoid false negatives
-     *  due to incomplete type inference such as in tests/pos/i21410.scala.
+     *  Using an approximated result type is necessary to avoid false negatives
+     *  due to incomplete type inference such as in tests/pos/i21410.scala and tests/pos/i21410b.scala.
      */
     def resultConforms(altSym: Symbol, altType: Type, resultType: Type)(using Context): Boolean =
       resultType.revealIgnored match {
@@ -1962,7 +1962,14 @@ trait Applications extends Compatibility {
           altType.widen match {
             case tp: PolyType => resultConforms(altSym, tp.resultType, resultType)
             case tp: MethodType =>
-              constrainResult(altSym, wildApprox(tp.resultType), resultType)
+              val wildRes = wildApprox(tp.resultType)
+
+              class ResultApprox extends AvoidWildcardsMap:
+                // Avoid false negatives by approximating to a lower bound
+                variance = -1
+
+              val approx = ResultApprox()(wildRes)
+              constrainResult(altSym, approx, resultType)
             case _ => true
           }
         case _ => true

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -2308,6 +2308,7 @@ trait Applications extends Compatibility {
       if t.exists && alt.symbol.exists then
         val (trimmed, skipped) = trimParamss(t.stripPoly, alt.symbol.rawParamss)
         val mappedSym = alt.symbol.asTerm.copy(info = t)
+        mappedSym.annotations = alt.symbol.annotations
         mappedSym.rawParamss = trimmed
         val (pre, totalSkipped) = mappedAltInfo(alt.symbol) match
           case Some((pre, prevSkipped)) =>

--- a/tests/pos/i21410.scala
+++ b/tests/pos/i21410.scala
@@ -1,0 +1,12 @@
+class A
+object Test:
+  type F[X] <: Any = X match
+    case A => Int
+
+  def foo[T](x: String): T = ???
+  def foo[U](x: U): F[U] = ???
+
+  val x1 = foo(A())
+  val y: Int = x1
+
+  val x2: Int = foo(A()) // error

--- a/tests/pos/i21410b.scala
+++ b/tests/pos/i21410b.scala
@@ -1,0 +1,10 @@
+object Test:
+  def foo[T](x: Option[T]): T = ???
+  def foo[T <: Tuple](x: T): Tuple.Map[T, List] = ???
+
+  val tup: (Int, String) = (1, "")
+
+  val x = foo(tup)
+  val y: (List[Int], List[String]) = x
+
+  val x2: (List[Int], List[String]) = foo(tup) // error

--- a/tests/pos/i21410c.scala
+++ b/tests/pos/i21410c.scala
@@ -1,0 +1,11 @@
+class AppliedPIso[A, B]()
+case class User(age: Int)
+
+object Test:
+  extension [From, To](from: From)
+    def focus(): AppliedPIso[From, From] = ???
+    transparent inline def focus(inline lambda: (From => To)): Any = ???
+
+
+  val u = User(1)
+  val ap: AppliedPIso[User, User] = u.focus(_.age) // error

--- a/tests/pos/i22560b/client_2.scala
+++ b/tests/pos/i22560b/client_2.scala
@@ -14,4 +14,4 @@ package companioned:
 
 package p:
 
-  def f = internal.P(42)
+  def f = new internal.P(42)


### PR DESCRIPTION
Backports #21744 to the 3.3.7.

PR submitted by the release tooling.