### PR TITLE
Backport "fix: don't search for members in pc info when irrelevant" to 3.3 LTS

### DIFF
--- a/presentation-compiler/src/main/dotty/tools/pc/SymbolInformationProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/SymbolInformationProvider.scala
@@ -55,7 +55,13 @@ class SymbolInformationProvider(using Context):
         val classOwner =
           sym.ownersIterator.drop(1).find(s => s.isClass || s.is(Flags.Module))
         val overridden = sym.denot.allOverriddenSymbols.toList
-        val memberDefAnnots = sym.info.membersBasedOnFlags(Flags.Method, Flags.EmptyFlags).flatMap(_.allSymbols).flatMap(_.denot.annotations)
+        val memberDefAnnots =
+          if classSym.exists then
+            classSym.info
+              .membersBasedOnFlags(Flags.Method, Flags.EmptyFlags)
+              .flatMap(_.allSymbols)
+              .flatMap(_.denot.annotations)
+          else Nil
 
         val pcSymbolInformation =
           PcSymbolInformation(


### PR DESCRIPTION
Backports #22674 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]