### PR TITLE
Backport "Regression test for extension nullification, nowarn for different opacities" to 3.3 LTS

### DIFF
--- a/tests/warn/i21190.scala
+++ b/tests/warn/i21190.scala
@@ -1,0 +1,23 @@
+
+//> using options -Werror
+
+opaque type FromEnd = Int
+object FromEnd:
+  inline def apply(i: Int): FromEnd = i
+  extension (fe: FromEnd)
+    inline def value: Int = fe
+
+// Warning appears when extension is in same namespace as opaque type
+extension [A](a: Array[A])
+  inline def apply(fe: FromEnd): A =
+    a(a.length - 1 - FromEnd.value(fe))
+
+class R:
+  def run(): String =
+    val xs = Array(1, 2, 3)
+
+    s"""First element = ${xs(0)}
+       |Last element = ${xs(FromEnd(0))}""".stripMargin
+
+@main def test = println:
+  R().run()


### PR DESCRIPTION
Backports #21191 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]