### PR TITLE
Backport "Repl: emit warning for the `:sh` command" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/repl/ParseResult.scala
+++ b/compiler/src/dotty/tools/repl/ParseResult.scala
@@ -100,6 +100,12 @@ object Reset {
   val command: String = ":reset"
 }
 
+/** `:sh <command line>` run a shell command (result is implicitly => List[String]) */
+case class Sh(expr: String) extends Command
+object Sh {
+  val command: String = ":sh"
+}
+
 /** Toggle automatic printing of results */
 case object Silent extends Command:
   val command: String = ":silent"
@@ -150,6 +156,7 @@ object ParseResult {
     TypeOf.command -> (arg => TypeOf(arg)),
     DocOf.command -> (arg => DocOf(arg)),
     Settings.command -> (arg => Settings(arg)),
+    Sh.command -> (arg => Sh(arg)),
     Silent.command -> (_ => Silent),
   )
 

--- a/compiler/src/dotty/tools/repl/ReplDriver.scala
+++ b/compiler/src/dotty/tools/repl/ReplDriver.scala
@@ -539,6 +539,10 @@ class ReplDriver(settings: Array[String],
       }
       state
 
+    case Sh(expr) =>
+      out.println(s"""The :sh command is deprecated. Use `import scala.sys.process._` and `"command".!` instead.""")
+      state
+
     case Settings(arg) => arg match
       case "" =>
         given ctx: Context = state.context

--- a/compiler/test-resources/repl/i21657
+++ b/compiler/test-resources/repl/i21657
@@ -1,0 +1,2 @@
+scala>:sh
+The :sh command is deprecated. Use `import scala.sys.process._` and `"command".!` instead.

--- a/compiler/test/dotty/tools/repl/TabcompleteTests.scala
+++ b/compiler/test/dotty/tools/repl/TabcompleteTests.scala
@@ -221,6 +221,7 @@ class TabcompleteTests extends ReplTest {
         ":quit",
         ":reset",
         ":settings",
+        ":sh",
         ":silent",
         ":type"
       ),


### PR DESCRIPTION
Backports #22694 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]