### PR TITLE
Backport "Fix #21721: make case TypeBlock(_, _) not match non-type Block" to 3.3 LTS

### DIFF
--- a/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
+++ b/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
@@ -1390,7 +1390,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
 
     object TypeBlockTypeTest extends TypeTest[Tree, TypeBlock]:
       def unapply(x: Tree): Option[TypeBlock & x.type] = x match
-        case tpt: (tpd.Block & x.type) => Some(tpt)
+        case tpt: (tpd.Block & x.type) if x.isType => Some(tpt)
         case _ => None
     end TypeBlockTypeTest
 

--- a/tests/pos/i21721/Macro.scala
+++ b/tests/pos/i21721/Macro.scala
@@ -1,0 +1,12 @@
+import quoted.*
+
+object Macro:
+  inline def impl(inline expr: Any): Any =
+    ${implImpl('expr)}
+
+  def implImpl(expr: Expr[Any])(using q: Quotes): Expr[Any] =
+    import q.reflect.*
+    expr.asTerm.asInstanceOf[Inlined].body match
+      // this should not fail with a MatchError
+      case TypeBlock(_, _) => '{ "TypeBlock" }
+      case _ => '{ "Nothing" }

--- a/tests/pos/i21721/Test.scala
+++ b/tests/pos/i21721/Test.scala
@@ -1,0 +1,5 @@
+object Test:
+  // give a Block(...) to the macro
+  Macro.impl:
+    val a = 3
+    a


### PR DESCRIPTION
Backports #21722 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]