### PR TITLE
Backport "Fix regression: do not approximate prefixes when using memberType in reflect API" to 3.3 LTS

### DIFF
--- a/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
+++ b/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
@@ -1795,7 +1795,15 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
         def termSymbol: Symbol = self.termSymbol
         def isSingleton: Boolean = self.isSingleton
         def memberType(member: Symbol): TypeRepr =
-          member.info.asSeenFrom(self, member.owner)
+          // we replace thisTypes here to avoid resolving otherwise unstable prefixes into Nothing
+          val memberInfo =
+            if self.typeSymbol.isClassDef then
+              member.info.substThis(self.classSymbol.asClass, self)
+            else
+              member.info
+          memberInfo
+            .asSeenFrom(self, member.owner)
+
         def baseClasses: List[Symbol] = self.baseClasses
         def baseType(cls: Symbol): TypeRepr = self.baseType(cls)
         def derivesFrom(cls: Symbol): Boolean = self.derivesFrom(cls)

--- a/tests/pos-macros/i22424/Macro_1.scala
+++ b/tests/pos-macros/i22424/Macro_1.scala
@@ -1,0 +1,25 @@
+
+import scala.quoted.*
+
+object MockMaker:
+  inline def inlineMock[T]: Unit = ${instance[T]}
+  transparent inline def transparentInlineMock[T]: Unit = ${instance[T]}
+
+  def instance[T: Type](using quotes: Quotes): Expr[Unit] =
+    import quotes.reflect._
+    val tpe = TypeRepr.of[T]
+    val symbol = tpe.typeSymbol.methodMember("innerTraitInOptions").head
+    tpe.memberType(symbol) match
+      case mt @ MethodType(_, args, _) =>
+        assert(args.head.typeSymbol != TypeRepr.of[Nothing].typeSymbol, "argument is incorrectly approximated")
+        val shownType = mt.show
+        val expectedType = "(x: m.Embedded#ATrait[scala.Predef.String, scala.Int])m.Embedded#ATrait[scala.Predef.String, scala.Int]"
+        assert(shownType == expectedType, s"Incorrect type shown. Obtained: $shownType, Expected: $expectedType")
+    '{()}
+
+trait PolymorphicTrait {
+  trait Embedded {
+    trait ATrait[A, B]
+    def innerTraitInOptions(x: ATrait[String, Int]): ATrait[String, Int]
+  }
+}

--- a/tests/pos-macros/i22424/Test_2.scala
+++ b/tests/pos-macros/i22424/Test_2.scala
@@ -1,0 +1,4 @@
+@main def Test =
+  val m = new PolymorphicTrait {}
+  MockMaker.inlineMock[m.Embedded]
+  MockMaker.transparentInlineMock[m.Embedded]


### PR DESCRIPTION
Backports #22448 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]