### PR TITLE
Backport "Rename on import is never wildcard" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
@@ -275,8 +275,11 @@ class CheckUnused private (phaseMode: PhaseMode, suffix: String) extends MiniPha
         case sel :: sels =>
           val matches =
             if sel.isWildcard then
+              // if name is different from sym.name, it must be a rename on import, not a wildcard selector
+              !name.exists(_.toTermName != sym.name.toTermName)
               // the qualifier must have the target symbol as a member
-              hasAltMember(sym.name) && {
+              && hasAltMember(sym.name)
+              && {
                 if sel.isGiven then // Further check that the symbol is a given or implicit and conforms to the bound
                      sym.isOneOf(GivenOrImplicit)
                   && (sel.bound.isEmpty || sym.info.finalResultType <:< sel.boundTpe)

--- a/tests/warn/i15503a.scala
+++ b/tests/warn/i15503a.scala
@@ -321,3 +321,10 @@ object Suppressed:
 object Suppressing:
   import Suppressed.* // no warn, see options
   def f = 42
+
+package i22692:
+  import javax.swing.*
+  import javax.swing.event as swingEvent // no warn, regression test for warning in 3.6
+
+  type b = AbstractButton
+  type t = swingEvent.AncestorListener

--- a/tests/warn/i15503f.scala
+++ b/tests/warn/i15503f.scala
@@ -57,10 +57,10 @@ package givens:
   trait Y:
     def doY: String
 
-  given X:
+  given X with
     def doX = 7
 
-  given X => Y: // warn protected param to given class
+  given (using X): Y with // warn protected param to given class
     def doY = "7"
   /* desugared. It is protected so that its type can be used in member defs without leaking.
    * possibly it should be protected only for named parameters.
@@ -72,6 +72,6 @@ package givens:
         new givens.given_Y(using x$1)()
   */
 
-  given namely: (x: X) => Y: // warn protected param to given class
+  given namely (using x: X): Y with // warn protected param to given class
     def doY = "8"
 end givens


### PR DESCRIPTION
Backports #22712 to the 3.3.7.

PR submitted by the release tooling.