### PR TITLE
Backport "Scaladoc tool: render `@deprecated` correctly even when named arguments weren't used" to 3.3 LTS

### DIFF
--- a/scaladoc-testcases/src/tests/deprecated.scala
+++ b/scaladoc-testcases/src/tests/deprecated.scala
@@ -2,22 +2,61 @@ package tests
 package deprecated
 
 class A:
-  def defInt: Int = 1
+  def defInt: Int
+    = 1
   @deprecated(message = "1")
-  def def1: 1 = 1
+  def def1: 1
+    = 1
   @deprecated("reason")
-  val valInt: Int = 1
-  val val1: 1 = 1
-  var varInt: Int = 1
-  var var1: 1 = 1
+  val valInt: Int
+    = 1
+  val val1: 1
+    = 1
+  var varInt: Int
+    = 1
+  var var1: 1
+    = 1
   class InnerA:
-    val innerVal: Int = 1
+    val innerVal: Int
+      = 1
 
 class B extends A:
   @deprecated(since = "1", message = "some reason")
-  def x: Int = 1
-  val y: Int = 1
+  def x: Int
+    = 1
+  val y: Int
+    = 1
 
-
-@java.lang.Deprecated
-class JavaDeprecated
+class C:
+  /** zero */
+  @deprecated
+  def noInfo: Int
+    = 0
+  /** one */
+  @deprecated()
+  def noInfo2: Int
+    = 0
+  /** two */
+  @deprecated("without names", "2.10.0")
+  def noNames: Int
+    = 0
+  /** three */
+  @deprecated(message = "with names", since = "2.10.0")
+  def withNames: Int
+    = 1
+  /** four */
+  @deprecated(since = "2.10.0", message = "backwards names")
+  def backwardNames: Int
+    = 2
+  /** five */
+  @deprecated("only message")
+  def onlyUnnamedMessage: Int
+    = 0
+  /** six */
+  @deprecated(message = "only named message")
+  def onlyNamedMessage: Int
+    = 1
+  /** seven */
+  @deprecated(since = "2.10.0")
+  def onlyNamedSince: Int
+    = 2

--- a/scaladoc/src/dotty/tools/scaladoc/renderers/MemberRenderer.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/renderers/MemberRenderer.scala
@@ -80,9 +80,12 @@ class MemberRenderer(signatureRenderer: SignatureRenderer)(using DocContext) ext
         signatureRenderer.renderLink(stripQuotes(text), dri)
       case Annotation.UnresolvedParameter(_, value) => stripQuotes(value)
 
+    // named arguments might be used, so we can't always rely on the order of the parameters
     val (named, unnamed) = a.params.partition(_.name.nonEmpty)
-    val message = named.find(_.name.get == "message")
-    val since = named.find(_.name.get == "since")
+    val message: Option[Annotation.AnnotationParameter] =
+      named.find(_.name.get == "message").fold(unnamed.lift(0))(Some(_))
+    val since: Option[Annotation.AnnotationParameter] =
+      named.find(_.name.get == "since").fold(unnamed.lift(1))(Some(_))
 
     val content = (
       Seq(

--- a/scaladoc/test/dotty/tools/scaladoc/signatures/TranslatableSignaturesTestCases.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/signatures/TranslatableSignaturesTestCases.scala
@@ -55,6 +55,8 @@ class GivenSignatures extends SignatureTest("givenSignatures", SignatureTest.all
 
 class Annotations extends SignatureTest("annotations", SignatureTest.all)
 
+class Deprecated extends SignatureTest("deprecated", SignatureTest.all)
+
 class InheritanceLoop extends SignatureTest("inheritanceLoop", SignatureTest.all)
 
 class InheritedMembers extends SignatureTest("inheritedMembers2", SignatureTest.all.filter(_ != "class"),


### PR DESCRIPTION
Backports #21925 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]