### PR TITLE
Backport "Lazy val def member is pattern var" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -14,12 +14,12 @@ import config.Feature.{sourceVersion, migrateTo3, enabled}
 import config.SourceVersion.*
 import collection.mutable.ListBuffer
 import reporting.*
-import annotation.constructorOnly
 import printing.Formatting.hl
 import config.Printers
 
 import scala.annotation.internal.sharable
 import dotty.tools.dotc.util.SrcPos
+import scala.annotation.{unchecked as _, *}
 
 object desugar {
   import untpd.*
@@ -1255,6 +1255,7 @@ object desugar {
                 DefDef(named.name.asTermName, Nil, tpt, selector(n))
                   .withMods(mods &~ Lazy)
                   .withSpan(named.span)
+                  .withAttachment(PatternVar, ())
               else
                 valDef(
                   ValDef(named.name.asTermName, tpt, selector(n))
@@ -1557,6 +1558,7 @@ object desugar {
     mayNeedSetter
   }
 
+  @unused
   private def derivedDefDef(original: Tree, named: NameTree, tpt: Tree, rhs: Tree, mods: Modifiers)(implicit src: SourceFile) =
     DefDef(named.name.asTermName, Nil, tpt, rhs)
       .withMods(mods)

--- a/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
@@ -455,11 +455,11 @@ object CheckUnused:
       case tree: Bind =>
         if !tree.name.isInstanceOf[DerivedName] && !tree.name.is(WildcardParamName) && !tree.hasAttachment(NoWarn) then
           pats.addOne((tree.symbol, tree.namePos))
-      case tree: ValDef if tree.hasAttachment(PatternVar) =>
-        if !tree.name.isInstanceOf[DerivedName] then
-          pats.addOne((tree.symbol, tree.namePos))
       case tree: NamedDefTree =>
-        if (tree.symbol ne NoSymbol)
+        if tree.hasAttachment(PatternVar) then
+          if !tree.name.isInstanceOf[DerivedName] then
+            pats.addOne((tree.symbol, tree.namePos))
+        else if (tree.symbol ne NoSymbol)
           && !tree.name.isWildcard
           && !tree.hasAttachment(NoWarn)
           && !tree.symbol.is(ModuleVal) // track only the ModuleClass using the object symbol, with correct namePos

--- a/tests/warn/i15503d.scala
+++ b/tests/warn/i15503d.scala
@@ -115,3 +115,9 @@ object `mutable patvar in for`:
 class `unset var requires -Wunused`:
   private var i = 0 // no warn as we didn't ask for it
   def f = println(i)
+
+class `i22743 lazy vals are defs`:
+  def f: (Int, String) = (42, "hello, world")
+  lazy val (i, s) = f // no warn because def is neither local nor private
+  val (j, t) = f // existing no warn for val with attachment
+  private lazy val (k, u) = f // warn // warn a warning so nice, they warn it twice


### PR DESCRIPTION
Backports #22750 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]