### PR TITLE
Backport "chore: add support for 'abstract override' modifier" to 3.3 LTS

### DIFF
--- a/scaladoc/src/dotty/tools/scaladoc/api.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/api.scala
@@ -43,6 +43,7 @@ enum Modifier(val name: String, val prefix: Boolean):
   case Open extends Modifier("open", true)
   case Transparent extends Modifier("transparent", true)
   case Infix extends Modifier("infix", true)
+  case AbsOverride extends Modifier("abstract override", true)
 
 case class ExtensionTarget(name: String, typeParams: Seq[TypeParameter], argsLists: Seq[TermParameterList], signature: Signature, dri: DRI, position: Long)
 case class ImplicitConversion(from: DRI, to: DRI)

--- a/scaladoc/src/dotty/tools/scaladoc/tasty/SymOps.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/SymOps.scala
@@ -98,7 +98,8 @@ object SymOps:
         Flags.Open -> Modifier.Open,
         Flags.Override -> Modifier.Override,
         Flags.Case -> Modifier.Case,
-        Flags.Opaque -> Modifier.Opaque
+        Flags.Opaque -> Modifier.Opaque,
+        Flags.AbsOverride -> Modifier.AbsOverride,
       ).collect {
         case (flag, mod) if sym.flags.is(flag) => mod
       }


### PR DESCRIPTION
Backports #22802 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]