### PR TITLE
Backport "feature: Skip auto importing symbols we know are wrong in current context" to 3.3 LTS

### DIFF
--- a/presentation-compiler/src/main/dotty/tools/pc/AutoImportsProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/AutoImportsProvider.scala
@@ -10,6 +10,7 @@ import scala.meta.pc.*
 
 import dotty.tools.dotc.ast.tpd.*
 import dotty.tools.dotc.core.Symbols.*
+import dotty.tools.dotc.core.StdNames.*
 import dotty.tools.dotc.interactive.Interactive
 import dotty.tools.dotc.interactive.InteractiveDriver
 import dotty.tools.dotc.util.SourceFile
@@ -17,6 +18,7 @@ import dotty.tools.pc.completions.CompletionPos
 import dotty.tools.pc.utils.InteractiveEnrichments.*
 
 import org.eclipse.lsp4j as l
+import dotty.tools.dotc.core.Flags.Method
 
 final class AutoImportsProvider(
     search: SymbolSearch,
@@ -46,6 +48,17 @@ final class AutoImportsProvider(
       Interactive.contextOfPath(path)(using newctx)
     )
     import indexedContext.ctx
+
+
+    def correctInTreeContext(sym: Symbol) = path match
+      case (_: Ident) :: (sel: Select) :: _ =>
+        sym.info.allMembers.exists(_.name == sel.name)
+      case (_: Ident) :: (_: Apply) :: _ if !sym.is(Method) =>
+        def applyInObject =
+          sym.companionModule.info.allMembers.exists(_.name == nme.apply)
+        def applyInClass = sym.info.allMembers.exists(_.name == nme.apply)
+        applyInClass || applyInObject
+      case _ => true
 
     val isSeen = mutable.Set.empty[String]
     val symbols = List.newBuilder[Symbol]
@@ -90,13 +103,24 @@ final class AutoImportsProvider(
         end match
       end mkEdit
 
-      for
+      val all = for
         sym <- results
         edits <- mkEdit(sym)
-      yield AutoImportsResultImpl(
+      yield (AutoImportsResultImpl(
         sym.owner.showFullName,
         edits.asJava
-      )
+      ), sym)
+
+      all match
+        case (onlyResult, _) :: Nil => List(onlyResult)
+        case Nil => Nil
+        case moreResults =>
+          val moreExact = moreResults.filter { case (_, sym) =>
+            correctInTreeContext(sym)
+          }
+          if moreExact.nonEmpty then moreExact.map(_._1)
+          else moreResults.map(_._1)
+
     else List.empty
     end if
   end autoImports

--- a/presentation-compiler/src/main/dotty/tools/pc/PcDefinitionProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/PcDefinitionProvider.scala
@@ -149,7 +149,7 @@ class PcDefinitionProvider(
         case srcTree if srcTree.namePos.exists =>
           new Location(params.uri().toString(), srcTree.namePos.toLsp)
       .toList
-    else search.definition(semanticdbSymbol, uri).asScala.toList
+    else search.definition(semanticdbSymbol, uri).nn.asScala.toList
 
   def semanticSymbolsSorted(
       syms: List[Symbol]

--- a/presentation-compiler/test/dotty/tools/pc/tests/edit/AutoImportsSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/edit/AutoImportsSuite.scala
@@ -13,6 +13,69 @@ class AutoImportsSuite extends BaseAutoImportsSuite:
          |}
          |""".stripMargin,
       """|scala.concurrent
+         |""".stripMargin
+    )
+
+  @Test def `basic-apply` =
+    check(
+      """|object A {
+          |  <<Future>>(2)
+          |}
+          |""".stripMargin,
+      """|scala.concurrent
+         |""".stripMargin,
+    )
+
+  @Test def `basic-function-apply` =
+    check(
+      """|
+          |object ForgeFor{
+          |  def importMe(): Int = ???
+          |}
+          |object ForgeFor2{
+          |  case class importMe()
+          |}
+          |
+          |
+          |object test2 {
+          |  <<importMe>>()
+          |}
+          |""".stripMargin,
+      """|ForgeFor2
+         |ForgeFor
+         |""".stripMargin
+    )
+
+  @Test def `basic-apply-wrong` =
+    check(
+      """|object A {
+          |  new <<Future>>(2)
+          |}
+          |""".stripMargin,
+      """|scala.concurrent
+         |java.util.concurrent
+         |""".stripMargin
+    )
+
+  @Test def `basic-fuzzy` =
+    check(
+      """|object A {
+          |  <<Future>>.thisMethodDoesntExist(2)
+          |}
+          |""".stripMargin,
+      """|scala.concurrent
+         |java.util.concurrent
+         |""".stripMargin
+    )
+
+  @Test def `typed-simple` =
+    check(
+      """|object A {
+          |  import scala.concurrent.Promise
+          |  val fut: <<Future>> = Promise[Unit]().future
+          |}
+          |""".stripMargin,
+      """|scala.concurrent
          |java.util.concurrent
          |""".stripMargin
     )


### PR DESCRIPTION
Backports #22813 to the 3.3.7.

PR submitted by the release tooling.