### PR TITLE
Backport "Ignore ending `$` when looking at end marker names" to 3.3 LTS

### DIFF
--- a/presentation-compiler/src/main/dotty/tools/pc/PcCollector.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/PcCollector.scala
@@ -315,7 +315,7 @@ object EndMarker:
   def getPosition(df: NamedDefTree, pos: SourcePosition, sourceText: String)(
       implicit ct: Context
   ): Option[SourcePosition] =
-    val name = df.name.toString()
+    val name = df.name.toString().stripSuffix("$")
     val endMarkerLine =
       sourceText.slice(df.span.start, df.span.end).split('\n').last
     val index = endMarkerLine.length() - name.length()

--- a/presentation-compiler/test/dotty/tools/pc/tests/edit/PcRenameSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/edit/PcRenameSuite.scala
@@ -534,3 +534,14 @@ class PcRenameSuite extends BasePcRenameSuite:
         |""".stripMargin,
      wrap = false
    )
+
+  @Test def `local-object-with-end-rename` =
+   check(
+     """|def bar =
+        |  object <<fo@@o>>:
+        |    def aaa = ???
+        |  end <<foo>>
+        |  1
+        |""".stripMargin,
+     wrap = false
+   )

--- a/presentation-compiler/test/dotty/tools/pc/tests/tokens/SemanticTokensSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/tokens/SemanticTokensSuite.scala
@@ -258,7 +258,7 @@ class SemanticTokensSuite extends BaseSemanticTokensSuite:
           |  } = new:
           |    def <<scalameta>>/*method,definition*/ = "4.0"
           |  <<V>>/*variable,readonly*/.<<scalameta>>/*method*/
-          |end StructuralTypes
+          |end <<StructuralTypes>>/*class,definition*/
           |""".stripMargin
     )
 
@@ -432,3 +432,12 @@ class SemanticTokensSuite extends BaseSemanticTokensSuite:
         |}
         |""".stripMargin
     )
+
+  @Test def `local-object-with-end-i7246` =
+   check(
+      """|def <<bar>>/*method,definition*/ =
+         |  object <<foo>>/*class*/:
+         |    def <<aaa>>/*method,definition*/ = <<???>>/*method*/
+         |  end <<foo>>/*class,definition*/
+         |""".stripMargin
+   )


### PR DESCRIPTION
Backports #22798 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]