### PR TITLE
Backport "chore: remove old drone configuration (dead-code)" to 3.3 LTS

### DIFF
--- a/community-build/src/scala/dotty/communitybuild/CommunityBuildRunner.scala
+++ b/community-build/src/scala/dotty/communitybuild/CommunityBuildRunner.scala
@@ -13,8 +13,7 @@ object CommunityBuildRunner:
    *  is necessary since we run tests each time on a fresh
    *  Docker container. We run the update on Docker container
    *  creation time to create the cache of the dependencies
-   *  and avoid network overhead. See https://github.com/lampepfl/dotty-drone
-   *  for more infrastructural details.
+   *  and avoid network overhead.
    */
   extension (self: CommunityProject) 
     def run()(using suite: CommunityBuildRunner): Unit =

--- a/compiler/test/dotty/Properties.scala
+++ b/compiler/test/dotty/Properties.scala
@@ -19,7 +19,6 @@ object Properties {
 
   /** Are we running on the CI? */
   val isRunByCI: Boolean = sys.env.isDefinedAt("DOTTY_CI_RUN")
-  || sys.env.isDefinedAt("DRONE")  // TODO remove this when we drop Drone
 
   val testCache: Path =
     sys.env.get("DOTTY_TEST_CACHE").map(Paths.get(_)).getOrElse {

--- a/compiler/test/dotty/tools/vulpix/VulpixUnitTests.scala
+++ b/compiler/test/dotty/tools/vulpix/VulpixUnitTests.scala
@@ -105,7 +105,7 @@ object VulpixUnitTests extends ParallelTesting {
   def maxDuration = 3.seconds
   def numberOfSlaves = 5
   def safeMode = sys.env.get("SAFEMODE").isDefined
-  def isInteractive = !sys.env.contains("DRONE")
+  def isInteractive = !sys.env.contains("DOTTY_CI_RUN")
   def testFilter = Nil
   def updateCheckFiles: Boolean = false
   def failedTests = None

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -292,15 +292,8 @@ object Build {
     PgpKeys.pgpPassphrase := sys.env.get("PGP_PW").map(_.toCharArray()),
     PgpKeys.useGpgPinentry := true,
 
-    javaOptions ++= {
-      val ciOptions = // propagate if this is a CI build
-        sys.props.get("dotty.drone.mem") match {
-          case Some(prop) => List("-Xmx" + prop)
-          case _ => List()
-        }
-      // Do not cut off the bottom of large stack traces (default is 1024)
-      "-XX:MaxJavaStackTraceDepth=1000000" :: agentOptions ::: ciOptions
-    },
+    // Do not cut off the bottom of large stack traces (default is 1024)
+    javaOptions ++= "-XX:MaxJavaStackTraceDepth=1000000" :: agentOptions,
 
     excludeLintKeys ++= Set(
       // We set these settings in `commonSettings`, if a project


### PR DESCRIPTION
Backports #22840 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]