### PR TITLE
Backport "Fix: Prevent GADT reasoning in pattern alternatives" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2443,8 +2443,10 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
       else
         assert(ctx.reporter.errorsReported)
         tree.withType(defn.AnyType)
+    val savedGadt = nestedCtx.gadt
     val trees1 = tree.trees.mapconserve(typed(_, pt)(using nestedCtx))
       .mapconserve(ensureValueTypeOrWildcard)
+    nestedCtx.gadtState.restore(savedGadt)  // Disable GADT reasoning for pattern alternatives
     assignType(cpy.Alternative(tree)(trees1), trees1)
   }
 

--- a/tests/neg/gadt-alternatives.scala
+++ b/tests/neg/gadt-alternatives.scala
@@ -1,0 +1,9 @@
+enum Expr[+T]:
+  case StringVal(x: String) extends Expr[String]
+  case IntVal(x: Int) extends Expr[Int]
+  case IntValAlt(x: Int) extends Expr[Int]
+import Expr.*
+def eval[T](e: Expr[T]): T = e match
+  case StringVal(_) | IntVal(_) => "42"  // error
+def eval1[T](e: Expr[T]): T = e match
+  case IntValAlt(_) | IntVal(_) => 42  // error // limitation


### PR DESCRIPTION
Backports #22853 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]