### PR TITLE
Backport "Fix isGenericArrayElement for higher-kinded types" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
@@ -365,6 +365,8 @@ object TypeErasure {
       case tp: MatchType =>
         val alts = tp.alternatives
         alts.nonEmpty && !fitsInJVMArray(alts.reduce(OrType(_, _, soft = true)))
+      case tp @ AppliedType(tycon, _) if tycon.isLambdaSub =>
+        !fitsInJVMArray(tp.translucentSuperType)
       case tp: TypeProxy =>
         isGenericArrayElement(tp.translucentSuperType, isScala2)
       case tp: AndType =>
@@ -779,11 +781,11 @@ class TypeErasure(sourceLanguage: SourceLanguage, semiEraseVCs: Boolean, isConst
 
   private def eraseArray(tp: Type)(using Context) = {
     val defn.ArrayOf(elemtp) = tp: @unchecked
-    if isGenericArrayElement(elemtp, isScala2 = sourceLanguage.isScala2) then 
+    if isGenericArrayElement(elemtp, isScala2 = sourceLanguage.isScala2) then
       defn.ObjectType
     else if sourceLanguage.isScala2 && (elemtp.hiBound.isNullType || elemtp.hiBound.isNothingType) then
       JavaArrayType(defn.ObjectType)
-    else 
+    else
       try erasureFn(sourceLanguage, semiEraseVCs = false, isConstructor, isSymbol, inSigName)(elemtp) match
         case _: WildcardType => WildcardType
         case elem => JavaArrayType(elem)

--- a/tests/run/i22888.scala
+++ b/tests/run/i22888.scala
@@ -1,0 +1,37 @@
+trait Foo:
+  type A[T]
+  var arr: Array[A[Int]] = null
+
+class Bar() extends Foo:
+  type A[T] = Int
+
+trait Foo2:
+  type Dummy
+  type A[T] <: Dummy
+  var arr: Array[A[Int]] = null
+
+class Bar2() extends Foo2:
+  type Dummy = Any
+  type A[T] = Int
+
+trait Foo3:
+  type A[T] <: Object
+  var arr: Array[A[String]] = null
+
+class Bar3() extends Foo3:
+  type A[T] = String
+
+object Test:
+  def main(args: Array[String]) =
+    val bar = new Bar()
+    bar.arr = Array.ofDim[Int](1)
+    bar.arr(0) = 123
+
+    val bar2 = new Bar2()
+    bar2.arr = Array.ofDim[Int](1)
+    bar2.arr(0) = 123
+
+    val bar3 = new Bar3()
+    bar3.arr = Array.ofDim[String](1)
+    bar3.arr(0) = "123"
+


### PR DESCRIPTION
Backports #22938 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]