### PR TITLE
Backport "Check trailing blank line at EOF for OUTDENT" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/util/Chars.scala
+++ b/compiler/src/dotty/tools/dotc/util/Chars.scala
@@ -50,7 +50,7 @@ object Chars:
   }
 
   /** Is character a whitespace character (but not a new line)? */
-  def isWhitespace(c: Char): Boolean =
+  inline def isWhitespace(c: Char): Boolean =
     c == ' ' || c == '\t' || c == CR
 
   /** Can character form part of a doc comment variable $xxx? */

--- a/compiler/test/dotty/tools/repl/ReplCompilerTests.scala
+++ b/compiler/test/dotty/tools/repl/ReplCompilerTests.scala
@@ -400,6 +400,16 @@ class ReplCompilerTests extends ReplTest:
     assertTrue(all.head.startsWith("-- [E103] Syntax Error"))
     assertTrue(all.exists(_.trim().startsWith("|  Illegal start of statement: this modifier is not allowed here")))
 
+  @Test def `i22844 regression colon eol`: Unit = initially:
+    run:
+      """|println:
+         |  "hello, world"
+         |""".stripMargin // outdent, but this test does not exercise the bug
+    assertEquals(List("hello, world"), lines())
+
+  @Test def `i22844b regression colon arrow eol`: Unit = contextually:
+    assertTrue(ParseResult.isIncomplete("List(42).map: x =>"))
+
 object ReplCompilerTests:
 
   private val pattern = Pattern.compile("\\r[\\n]?|\\n");


### PR DESCRIPTION
Backports #22855 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]