### PR TITLE
Backport "pc: Properly adjust indentation when inlining blocks" to 3.3 LTS

### DIFF
--- a/presentation-compiler/src/main/dotty/tools/pc/ScalaPresentationCompiler.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/ScalaPresentationCompiler.scala
@@ -355,7 +355,7 @@ case class ScalaPresentationCompiler(
     val empty: Either[String, List[l.TextEdit]] = Right(List())
     (compilerAccess
       .withInterruptableCompiler(empty, params.token()) { pc =>
-        new PcInlineValueProviderImpl(pc.compiler(), params)
+        new PcInlineValueProvider(pc.compiler(), params)
           .getInlineTextEdits()
       }(params.toQueryContext))
       .thenApply {

--- a/presentation-compiler/test/dotty/tools/pc/tests/edit/InlineValueSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/edit/InlineValueSuite.scala
@@ -228,7 +228,8 @@ class InlineValueSuite extends BaseCodeActionSuite with CommonMtagsEnrichments:
          |  for {
          |    i <- List(1,2,3)
          |  } yield i + 1
-         |val b = (for {
+         |val b = (
+         |  for {
          |    i <- List(1,2,3)
          |  } yield i + 1).map(_ + 1)
          |}""".stripMargin
@@ -406,6 +407,52 @@ class InlineValueSuite extends BaseCodeActionSuite with CommonMtagsEnrichments:
          |""".stripMargin,
       InlineErrors.variablesAreShadowed("T.a")
     )
+
+  @Test def `i7137` =
+    checkEdit(
+      """|object O {
+         |  def foo = {
+         |    val newValue =
+         |      val x = true
+         |      x
+         |    val xx =new<<V>>alue
+         |  }
+         |}
+         |""".stripMargin,
+      """|object O {
+         |  def foo = {
+         |    val xx =
+         |      val x = true
+         |      x
+         |  }
+         |}
+         |""".stripMargin
+    )
+
+  @Test def `i7137a` =
+      checkEdit(
+        """|object O {
+            |  def foo = {
+            |    val newValue = {
+            |      val x = true
+            |      x
+            |    }
+            |    def bar =
+            |      val xx = new<<V>>alue
+            |  }
+            |}
+            |""".stripMargin,
+        """|object O {
+            |  def foo = {
+            |    def bar =
+            |      val xx = {
+            |        val x = true
+            |        x
+            |      }
+            |  }
+            |}
+            |""".stripMargin
+      )
 
   def checkEdit(
       original: String,


### PR DESCRIPTION
Backports #22915 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]