### PR TITLE
Backport "Fix #22724: Revert the PolyType case in #21744" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1960,7 +1960,7 @@ trait Applications extends Compatibility {
       resultType.revealIgnored match {
         case resultType: ValueType =>
           altType.widen match {
-            case tp: PolyType => resultConforms(altSym, tp.resultType, resultType)
+            case tp: PolyType => resultConforms(altSym, instantiateWithTypeVars(tp), resultType)
             case tp: MethodType =>
               val wildRes = wildApprox(tp.resultType)
 

--- a/tests/pos/i22724.scala
+++ b/tests/pos/i22724.scala
@@ -1,0 +1,17 @@
+import java.util.concurrent.atomic.AtomicReference
+
+object UnboundedHub:
+  final class Node[A](var value: A, val pointer: AtomicReference[Pointer[A]])
+  final case class Pointer[A](node: Node[A], subscribers: Int)
+
+private final class UnboundedHub[A]:
+  import UnboundedHub.*
+
+  val publisherHead: AtomicReference[Node[A]] = new AtomicReference(
+    new Node[A](
+      null.asInstanceOf[A],
+      new AtomicReference(
+        Pointer(null, 0) // error: too many arguments for constructor AtomicReference
+      )
+    )
+  )


### PR DESCRIPTION
Backports #22820 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]