### PR TITLE
Backport "fix: show hover for synthetics if explicitly used" to 3.3 LTS

### DIFF
--- a/presentation-compiler/src/main/dotty/tools/pc/MetalsInteractive.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/MetalsInteractive.scala
@@ -216,13 +216,6 @@ object MetalsInteractive:
         if head.symbol.is(Exported) then
           val sym = head.symbol.sourceSymbol
           List((sym, sym.info, None))
-        else if head.symbol.is(Synthetic) then
-          enclosingSymbolsWithExpressionType(
-            tail,
-            pos,
-            indexed,
-            skipCheckOnName
-          )
         else if head.symbol != NoSymbol then
           if skipCheckOnName ||
             MetalsInteractive.isOnName(
@@ -231,6 +224,13 @@ object MetalsInteractive:
               indexed.ctx.source
             )
           then List((head.symbol, head.typeOpt, None))
+          else if head.symbol.is(Synthetic) then
+            enclosingSymbolsWithExpressionType(
+              tail,
+              pos,
+              indexed,
+              skipCheckOnName
+            )
           /* Type tree for List(1) has an Int type variable, which has span
            * but doesn't exist in code.
            * https://github.com/lampepfl/dotty/issues/15937

--- a/presentation-compiler/test/dotty/tools/pc/tests/hover/HoverTermSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/hover/HoverTermSuite.scala
@@ -718,3 +718,16 @@ class HoverTermSuite extends BaseHoverSuite:
       """def ???: Nothing""".stripMargin.hover
   )
 
+  @Test def `value-of`: Unit =
+    check(
+      """|enum Foo(val key: String) {
+         |  case Bar extends Foo("b")
+         |  case Baz extends Foo("z")
+         |}
+         |
+         |object Foo {
+         |  def parse(key: String) = Foo.va@@lueOf("b")
+         |
+         |""".stripMargin,
+         "def valueOf($name: String): Foo".hover
+    )


### PR DESCRIPTION
Backports #22973 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]