### PR TITLE
Backport "Disallow context bounds in type lambdas" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1677,8 +1677,9 @@ object Parsers {
         val start = in.offset
         val tparams = typeParamClause(ParamOwner.TypeParam)
         if in.token == TLARROW then
+          // Filter illegal context bounds and report syntax error
           atSpan(start, in.skipToken()):
-            LambdaTypeTree(tparams, toplevelTyp())
+            LambdaTypeTree(tparams.mapConserve(stripContextBounds("type lambdas")), toplevelTyp())
         else if in.token == ARROW || isPureArrow(nme.PUREARROW) then
           val arrowOffset = in.skipToken()
           val body = toplevelTyp()
@@ -1698,6 +1699,13 @@ object Parsers {
       else
         typeRest(infixType())
     end typ
+
+    /** Removes context bounds from TypeDefs and returns a syntax error. */
+    private def stripContextBounds(in: String)(tparam: TypeDef) = tparam match
+      case TypeDef(name, rhs: ContextBounds) =>
+        syntaxError(em"context bounds are not allowed in $in", rhs.span)
+        TypeDef(name, rhs.bounds)
+      case other => other
 
     private def makeKindProjectorTypeDef(name: TypeName): TypeDef = {
       val isVarianceAnnotated = name.startsWith("+") || name.startsWith("-")
@@ -3267,7 +3275,8 @@ object Parsers {
      *  TypTypeParam      ::=  {Annotation} id [HkTypePamClause] TypeBounds
      *
      *  HkTypeParamClause ::=  ‘[’ HkTypeParam {‘,’ HkTypeParam} ‘]’
-     *  HkTypeParam       ::=  {Annotation} [‘+’ | ‘-’] (id [HkTypePamClause] | ‘_’) TypeBounds
+     *  HkTypeParam       ::=  {Annotation} [‘+’ | ‘-’]
+     *                         (id | ‘_’) [HkTypeParamClause] TypeBounds
      */
     def typeParamClause(paramOwner: ParamOwner): List[TypeDef] = inBracketsWithCommas {
 

--- a/tests/neg/i22552.check
+++ b/tests/neg/i22552.check
@@ -1,0 +1,8 @@
+-- [E040] Syntax Error: tests/neg/i22552.scala:3:10 --------------------------------------------------------------------
+3 |  type A[X: TC]                     // error
+  |          ^
+  |          ']' expected, but ':' found
+-- Error: tests/neg/i22552.scala:4:15 ----------------------------------------------------------------------------------
+4 |  type C = [X: TC] =>> List[X]      // error
+  |               ^^
+  |               context bounds are not allowed in type lambdas

--- a/tests/neg/i22552.scala
+++ b/tests/neg/i22552.scala
@@ -1,0 +1,5 @@
+trait Foo:
+  type TC[T]
+  type A[X: TC]                     // error
+  type C = [X: TC] =>> List[X]      // error
+  type D = [X: TC] => () => List[X] // allowed context bound


### PR DESCRIPTION
Backports #22659 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]