### PR TITLE
Backport "Avoid loosing denotations of named types during `integrate`" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -832,14 +832,6 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
       Closure(tree: Tree)(env, meth, tpt)
   }
 
-  // This is a more fault-tolerant copier that does not cause errors when
-  // function types in applications are undefined.
-  // This was called `Inliner.InlineCopier` before 3.6.3.
-  class ConservativeTreeCopier() extends TypedTreeCopier:
-    override def Apply(tree: Tree)(fun: Tree, args: List[Tree])(using Context): Apply =
-      if fun.tpe.widen.exists then super.Apply(tree)(fun, args)
-      else untpd.cpy.Apply(tree)(fun, args).withTypeUnchecked(tree.tpe)
-
   override def skipTransform(tree: Tree)(using Context): Boolean = tree.tpe.isError
 
   implicit class TreeOps[ThisTree <: tpd.Tree](private val tree: ThisTree) extends AnyVal {

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -3730,8 +3730,34 @@ object Types extends TypeUtils {
     def integrate(tparams: List[ParamInfo], tp: Type)(using Context): Type =
       (tparams: @unchecked) match {
         case LambdaParam(lam, _) :: _ => tp.subst(lam, this) // This is where the precondition is necessary.
-        case params: List[Symbol @unchecked] => tp.subst(params, paramRefs)
+        case params: List[Symbol @unchecked] => IntegrateMap(params, paramRefs)(tp)
       }
+
+    /** A map that replaces references to symbols in `params` by the types in
+     *  `paramRefs`.
+     *
+     *  It is similar to [[Substituters#subst]] but avoids reloading denotations
+     *  of named types by overriding `derivedSelect`.
+     *
+     *  This is needed because during integration, [[TermParamRef]]s refer to a
+     *  [[LambdaType]] that is not yet fully constructed, in particular for wich
+     *  `paramInfos` is `null`. In that case all [[TermParamRef]]s have
+     *  [[NoType]] as underlying type. Reloading denotions of selections
+     *  involving such [[TermParamRef]]s in [[NamedType#withPrefix]] could then
+     *  result in a [[NoDenotation]], which would make later disambiguation of
+     *  overloads impossible. See `tests/pos/annot-17242.scala` for example.
+     */
+    private class IntegrateMap(params: List[Symbol], paramRefs: List[Type])(using Context) extends TypeMap:
+      override def apply(tp: Type) =
+        tp match
+          case tp: NamedType if params.contains(tp.symbol) => paramRefs(params.indexOf(tp.symbol))
+          case _: BoundType | _: ThisType => tp
+          case _ => mapOver(tp)
+
+      override def derivedSelect(tp: NamedType, pre: Type): Type =
+        if tp.prefix eq pre then tp
+        else if tp.symbol.exists then NamedType(pre, tp.name, tp.denot.asSeenFrom(pre))
+        else NamedType(pre, tp.name)
 
     final def derivedLambdaType(paramNames: List[ThisName] = this.paramNames,
                           paramInfos: List[PInfo] = this.paramInfos,

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -3747,14 +3747,26 @@ object Types extends TypeUtils {
      *  result in a [[NoDenotation]], which would make later disambiguation of
      *  overloads impossible. See `tests/pos/annot-17242.scala` for example.
      */
-    private class IntegrateMap(params: List[Symbol], paramRefs: List[Type])(using Context) extends TypeMap:
+    private class IntegrateMap(from: List[Symbol], to: List[Type])(using Context) extends TypeMap:
       override def apply(tp: Type) =
+        // Same implementation as in `SubstMap`, except the `derivedSelect` in
+        // the `NamedType` case, and the default case that just calls `mapOver`.
         tp match
-          case tp: NamedType if params.contains(tp.symbol) => paramRefs(params.indexOf(tp.symbol))
+          case tp: NamedType =>
+            val sym = tp.symbol
+            var fs = from
+            var ts = to
+            while (fs.nonEmpty && ts.nonEmpty) {
+              if (fs.head eq sym) return ts.head
+              fs = fs.tail
+              ts = ts.tail
+            }
+            if (tp.prefix `eq` NoPrefix) tp
+            else derivedSelect(tp, apply(tp.prefix))
           case _: BoundType | _: ThisType => tp
           case _ => mapOver(tp)
 
-      override def derivedSelect(tp: NamedType, pre: Type): Type =
+      override final def derivedSelect(tp: NamedType, pre: Type): Type =
         if tp.prefix eq pre then tp
         else if tp.symbol.exists then NamedType(pre, tp.name, tp.denot.asSeenFrom(pre))
         else NamedType(pre, tp.name)

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -5939,14 +5939,7 @@ object Types extends TypeUtils {
       }
     }
 
-    private def treeTypeMap = new TreeTypeMap(
-      typeMap = this,
-      // Using `ConservativeTreeCopier` is needed when copying dependent annoted
-      // types, where we can refer to a previous parameter represented as
-      // `TermParamRef` that has no underlying type yet.
-      // See tests/pos/annot-17242.scala.
-      cpy = ConservativeTreeCopier()
-    )
+    private def treeTypeMap = new TreeTypeMap(typeMap = this)
 
     def mapOver(syms: List[Symbol]): List[Symbol] = mapSymbols(syms, treeTypeMap)
 

--- a/tests/neg/i12448.scala
+++ b/tests/neg/i12448.scala
@@ -1,5 +1,5 @@
 object Main {
   def mkArray[T <: A]: T#AType // error // error
-  mkArray[Array]
-  val x = mkArray[Array]
+  mkArray[Array] // was: "assertion failed: invalid prefix HKTypeLambda..." // error
+  val x = mkArray[Array] // error
 }

--- a/tests/neg/i12448.scala
+++ b/tests/neg/i12448.scala
@@ -1,5 +1,5 @@
 object Main {
   def mkArray[T <: A]: T#AType // error // error
-  mkArray[Array] // was: "assertion failed: invalid prefix HKTypeLambda..."
+  mkArray[Array]
   val x = mkArray[Array]
 }

--- a/tests/pos/annot-17242.scala
+++ b/tests/pos/annot-17242.scala
@@ -1,5 +1,3 @@
-// See also tests/pos/annot-21595.scala
-
 class local(predicate: Int) extends annotation.StaticAnnotation
 
 def failing1(x: Int, z: Int @local(x + x)) = ()


### PR DESCRIPTION
Backports #22839 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]