### PR TITLE
Backport "Process Export for unused check" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
@@ -218,6 +218,8 @@ class CheckUnused private (phaseMode: PhaseMode, suffix: String) extends MiniPha
           selector.bound match
           case untpd.TypedSplice(bound) => transformAllDeep(bound)
           case _ =>
+    case exp: Export =>
+      transformAllDeep(exp.expr)
     case AppliedTypeTree(tpt, args) =>
       transformAllDeep(tpt)
       args.foreach(transformAllDeep)

--- a/tests/warn/i22983.scala
+++ b/tests/warn/i22983.scala
@@ -1,0 +1,10 @@
+//> using options -Werror -Wunused:imports
+
+object test1:
+  object foo:
+    type X = Int
+
+object test2:
+  import test1.foo
+
+  export foo.X


### PR DESCRIPTION
Backports #22984 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]