### PR TITLE
Backport "No warn for evidence params of marker traits such as NotGiven" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
@@ -595,15 +595,16 @@ object CheckUnused:
         val dd = defn
            m.isDeprecated
         || m.is(Synthetic)
-        || sym.owner.name.isContextFunction    // a ubiquitous parameter
-        || sym.name.is(ContextBoundParamName) && sym.info.typeSymbol.isMarkerTrait // a ubiquitous parameter
         || m.hasAnnotation(dd.UnusedAnnot)          // param of unused method
+        || sym.owner.name.isContextFunction         // a ubiquitous parameter
+        || sym.isCanEqual
         || sym.info.typeSymbol.match                // more ubiquity
            case dd.DummyImplicitClass | dd.SubTypeClass | dd.SameTypeClass => true
-           case _ => false
+           case tps =>
+             tps.isMarkerTrait // no members to use; was only if sym.name.is(ContextBoundParamName)
+             ||                // but consider NotGiven
+             tps.hasAnnotation(dd.LanguageFeatureMetaAnnot)
         || sym.info.isSingleton // DSL friendly
-        || sym.isCanEqual
-        || sym.info.typeSymbol.hasAnnotation(dd.LanguageFeatureMetaAnnot)
         || sym.info.isInstanceOf[RefinedType] // can't be expressed as a context bound
       if ctx.settings.WunusedHas.implicits
         && !infos.skip(m)

--- a/tests/warn/i15503f.scala
+++ b/tests/warn/i15503f.scala
@@ -19,7 +19,7 @@ trait T
 object T:
   def hole(using T) = ()
 
-class C(using T) // warn
+class C(using T) // no warn marker trait is evidence only
 
 class D(using T):
   def t = T.hole // nowarn
@@ -44,7 +44,8 @@ object Unmatched:
       case _ =>
     e
 
-trait Ctx
+trait Ctx:
+  val state: Int
 case class K(i: Int)(using val ctx: Ctx) // nowarn
 class L(val i: Int)(using val ctx: Ctx) // nowarn
 class M(val i: Int)(using ctx: Ctx) // warn

--- a/tests/warn/i22969.scala
+++ b/tests/warn/i22969.scala
@@ -1,0 +1,10 @@
+//> using options -Werror -Wunused:all
+import scala.util.NotGiven
+
+object Test {
+  def f[T](a: Int)(using NotGiven[T <:< Int]) = a + 2
+}
+
+trait Furthermore:
+  type Intish[A] = A <:< Int
+  def f[A: Intish] = ()

--- a/tests/warn/scala2-t11681.scala
+++ b/tests/warn/scala2-t11681.scala
@@ -98,7 +98,7 @@ trait Anonymous {
 }
 trait Context[A]
 trait Implicits {
-  def f[A](implicit ctx: Context[A]) = answer // warn implicit param even though only marker
+  def f[A](implicit ctx: Context[A]) = answer // no warn after all; previously, warn implicit param even though marker
   def g[A: Context] = answer // no warn bound that is marker only
 }
 class Bound[A: Context] // no warn bound that is marker only


### PR DESCRIPTION
Backports #22985 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]