### PR TITLE
Backport "Test chars safely when highlighting" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -692,16 +692,17 @@ object Parsers {
 
     def testChar(idx: Int, p: Char => Boolean): Boolean = {
       val txt = source.content
-      idx < txt.length && p(txt(idx))
+      idx >= 0 && idx < txt.length && p(txt(idx))
     }
 
     def testChar(idx: Int, c: Char): Boolean = {
       val txt = source.content
-      idx < txt.length && txt(idx) == c
+      idx >= 0 && idx < txt.length && txt(idx) == c
     }
 
     def testChars(from: Int, str: String): Boolean =
-      str.isEmpty ||
+      str.isEmpty
+      ||
       testChar(from, str.head) && testChars(from + 1, str.tail)
 
     def skipBlanks(idx: Int, step: Int = 1): Int =

--- a/compiler/test/dotty/tools/utils.scala
+++ b/compiler/test/dotty/tools/utils.scala
@@ -89,6 +89,9 @@ private val toolArg = raw"(?://|/\*| \*) ?(?i:(${ToolName.values.mkString("|")})
 /** Directive to specify to vulpix the options to pass to Dotty */
 private val directiveOptionsArg = raw"//> using options (.*)".r.unanchored
 private val directiveJavacOptions = raw"//> using javacOpt (.*)".r.unanchored
+private val directiveTargetOptions = raw"//> using target.platform (jvm|scala-js)".r.unanchored
+private val directiveUnsupported = raw"//> using (scala) (.*)".r.unanchored
+private val directiveUnknown = raw"//> using (.*)".r.unanchored
 
 // Inspect the lines for compiler options of the form
 // `//> using options args`, `// scalajs: args`, `/* scalajs: args`, ` * scalajs: args` etc.
@@ -104,6 +107,9 @@ def toolArgsParse(lines: List[String], filename: Option[String]): List[(String,S
   lines.flatMap {
     case directiveOptionsArg(args) => List(("scalac", args))
     case directiveJavacOptions(args) => List(("javac", args))
+    case directiveTargetOptions(platform) => List(("target", platform))
+    case directiveUnsupported(name, args) => Nil
+    case directiveUnknown(rest) => sys.error(s"Unknown directive: `//> using ${CommandLineParser.tokenize(rest).headOption.getOrElse("''")}`${filename.fold("")(f => s" in file $f")}")
     case _ => Nil
   }
 

--- a/tests/neg/i19320.scala
+++ b/tests/neg/i19320.scala
@@ -1,7 +1,7 @@
-//> using scala "3.3.1"
-//> using dep org.http4s::http4s-ember-client:1.0.0-M40
-//> using dep org.http4s::http4s-ember-server:1.0.0-M40
-//> using dep org.http4s::http4s-dsl:1.0.0-M40
+//!> using scala "3.3.1"
+//!> using dep org.http4s::http4s-ember-client:1.0.0-M40
+//!> using dep org.http4s::http4s-ember-server:1.0.0-M40
+//!> using dep org.http4s::http4s-dsl:1.0.0-M40
 
 //import cats.effect.*
 //import cats.implicits.*

--- a/tests/neg/i22906.check
+++ b/tests/neg/i22906.check
@@ -1,0 +1,6 @@
+Flag -indent set repeatedly
+-- Error: tests/neg/i22906.scala:6:15 ----------------------------------------------------------------------------------
+6 |    {`1`: Int  =>  5} // error
+  |               ^
+  |               parentheses are required around the parameter of a lambda
+  |               This construct can be rewritten automatically under -rewrite -source 3.0-migration.

--- a/tests/neg/i22906.scala
+++ b/tests/neg/i22906.scala
@@ -1,0 +1,6 @@
+//> using options -rewrite -indent
+//> nominally using scala 3.7.0-RC1
+// does not reproduce under "vulpix" test rig, which enforces certain flag sets?
+
+def program: Int => Int =
+    {`1`: Int  =>  5} // error


### PR DESCRIPTION
Backports #22918 to the 3.3.7.

PR submitted by the release tooling.