### PR TITLE
Backport "Tighten condition to preserve denotation in IntegrateMap" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -3768,8 +3768,12 @@ object Types extends TypeUtils {
 
       override final def derivedSelect(tp: NamedType, pre: Type): Type =
         if tp.prefix eq pre then tp
-        else if tp.symbol.exists then NamedType(pre, tp.name, tp.denot.asSeenFrom(pre))
-        else NamedType(pre, tp.name)
+        else
+          pre match
+            case ref: ParamRef if (ref.binder eq self) && tp.symbol.exists =>
+              NamedType(pre, tp.name, tp.denot.asSeenFrom(pre))
+            case _ =>
+              tp.derivedSelect(pre)
 
     final def derivedLambdaType(paramNames: List[ThisName] = this.paramNames,
                           paramInfos: List[PInfo] = this.paramInfos,

--- a/tests/pos/23056.scala
+++ b/tests/pos/23056.scala
@@ -1,0 +1,18 @@
+def Test = {
+  val ops: CompileOps[Option, Option, Any]  = ???
+  ops.to(List).map(_.reverse) // error
+}
+
+trait CompileOps[F[_], G[_], O]:
+  def to(collector: Collector[O]): G[collector.Out]
+trait Collector[-A] {
+  type Out
+}
+
+object Collector:
+  type Aux[A, X] = Collector[A] { type Out = X }
+
+  given [A, C[_]]: Conversion[
+    scala.collection.IterableFactory[C],
+    Collector.Aux[A, C[A]]
+  ] = ???


### PR DESCRIPTION
Backports #23060 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]