### PR TITLE
Backport "Keep unused annot on params" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -194,8 +194,10 @@ class PostTyper extends MacroTransform with IdentityDenotTransformer { thisPhase
           else
             if sym.is(Param) then
               // @unused is getter/setter but we want it on ordinary method params
-              if !sym.owner.is(Method) || sym.owner.isConstructor then
-                sym.keepAnnotationsCarrying(thisPhase, Set(defn.ParamMetaAnnot), orNoneOf = defn.NonBeanMetaAnnots)
+              // @param should be consulted only for fields
+              val unusing = sym.getAnnotation(defn.UnusedAnnot)
+              sym.keepAnnotationsCarrying(thisPhase, Set(defn.ParamMetaAnnot), orNoneOf = defn.NonBeanMetaAnnots)
+              unusing.foreach(sym.addAnnotation)
             else if sym.is(ParamAccessor) then
               sym.keepAnnotationsCarrying(thisPhase, Set(defn.GetterMetaAnnot, defn.FieldMetaAnnot))
             else

--- a/tests/warn/i23033.scala
+++ b/tests/warn/i23033.scala
@@ -1,0 +1,13 @@
+//> using options -Werror -Wunused:all
+
+import scala.annotation.unused
+import scala.concurrent.ExecutionContext
+import scala.util.NotGiven
+
+object Test {
+  given [T](using @unused ev: NotGiven[T <:< Int]): AnyRef with {}
+}
+object Useful:
+  given [T](using @unused ec: ExecutionContext): AnyRef with {}
+object Syntax:
+  given [T] => (@unused ec: ExecutionContext) => AnyRef


### PR DESCRIPTION
Backports #23037 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]