### PR TITLE
Backport "pc: fix: inline value when def indentation equals 2" to 3.3 LTS

### DIFF
--- a/presentation-compiler/test/dotty/tools/pc/tests/edit/InlineValueSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/edit/InlineValueSuite.scala
@@ -430,6 +430,25 @@ class InlineValueSuite extends BaseCodeActionSuite with CommonMtagsEnrichments:
     )
 
   @Test def `i7137a` =
+    checkEdit(
+      """|def foo = {
+         |  val newValue =
+         |    val x = true
+         |    x
+         |  def bar =
+         |    val xx =new<<V>>alue
+         |}
+         |""".stripMargin,
+      """|def foo = {
+         |  def bar =
+         |    val xx =
+         |      val x = true
+         |      x
+         |}
+         |""".stripMargin
+    )
+
+  @Test def `i7137b` =
       checkEdit(
         """|object O {
             |  def foo = {
@@ -453,6 +472,31 @@ class InlineValueSuite extends BaseCodeActionSuite with CommonMtagsEnrichments:
             |}
             |""".stripMargin
       )
+
+  @Test def `no-new-line` =
+    checkEdit(
+      """|object O {
+         |  val i: Option[Int] = ???
+         |  def foo = {
+         |    val newValue = i match
+         |      case Some(x) => x
+         |      case None => 0
+         |    def bar =
+         |      val xx = new<<V>>alue
+         |  }
+         |}
+         |""".stripMargin,
+      """|object O {
+         |  val i: Option[Int] = ???
+         |  def foo = {
+         |    def bar =
+         |      val xx = i match
+         |        case Some(x) => x
+         |        case None => 0
+         |  }
+         |}
+         |""".stripMargin
+    )
 
   def checkEdit(
       original: String,


### PR DESCRIPTION
Backports #22990 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]