### PR TITLE
Backport "fix: synthesise value of `this.type` in `ValueOf`" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
@@ -231,6 +231,8 @@ class Synthesizer(typer: Typer)(using @constructorOnly c: Context):
             withNoErrors(success(Literal(Constant(()))))
           case n: TermRef =>
             withNoErrors(success(ref(n)))
+          case ts: ThisType =>
+            withNoErrors(success(This(ts.cls)))
           case tp =>
             EmptyTreeNoError
       case _ =>

--- a/tests/pos/i23086.scala
+++ b/tests/pos/i23086.scala
@@ -1,0 +1,2 @@
+class Test:
+  val _: this.type = summon[ValueOf[this.type]].value


### PR DESCRIPTION
Backports #23094 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]