### PR TITLE
Fix publishing chocolatey packages in LTS

### DIFF
--- a/.github/workflows/publish-chocolatey.yml
+++ b/.github/workflows/publish-chocolatey.yml
@@ -35,5 +35,4 @@ jobs:
         with:
           name: scala.nupkg
       - name: Publish the package to Chocolatey
-        run: choco push scala.nupkg --source https://push.chocolatey.org/ --api-key ${{ secrets.API-KEY }}
-        
+        run: choco push scala.${{inputs.version}}.nupkg --source https://push.chocolatey.org/ --api-key ${{ secrets.API-KEY }}


### PR DESCRIPTION
Add fix to publishing Choco packages. 
The other part of the fix was added in #214 but for some reason it was not included in `release-3.3.6` branch https://github.com/scala/scala3/blob/refs/heads/release-3.3.6/.github/workflows/test-chocolatey.yml