### PR TITLE
Backport "Remove premature caching of lookups for unused lint" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
@@ -456,7 +456,7 @@ object CheckUnused:
         if inliners == 0
           && languageImport(imp.expr).isEmpty
           && !imp.isGeneratedByEnum
-          && !ctx.outer.owner.name.isReplWrapperName
+          && !ctx.owner.name.isReplWrapperName
         then
           imps.put(imp, ())
       case tree: Bind =>


### PR DESCRIPTION
Backports #22982 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]