### PR TITLE
Backport "Compare TypeVar and TypeParamRef in mergeRefinedOrApplied" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -284,7 +284,15 @@ object TypeOps:
           }
         case AndType(tp11, tp12) =>
           mergeRefinedOrApplied(tp11, tp2) & mergeRefinedOrApplied(tp12, tp2)
-        case tp1: TypeParamRef if tp1 == tp2 => tp1
+        case tp1: TypeParamRef =>
+          tp2.stripTypeVar match
+            case tp2: TypeParamRef if tp1 == tp2 => tp1
+            case _ => fail
+        case tp1: TypeVar =>
+          tp2 match
+            case tp2: TypeVar if tp1 == tp2 => tp1
+            case tp2: TypeParamRef if tp1.stripTypeVar == tp2 => tp2
+            case _ => fail
         case _ => fail
       }
     }

--- a/tests/pos/i23032.scala
+++ b/tests/pos/i23032.scala
@@ -1,0 +1,2 @@
+def f[F[_], T, U]: F[T] | F[U] = ???
+def x = f.toString


### PR DESCRIPTION
Backports #23045 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]