### PR TITLE
Backport "patvar: adjust caret in error message" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -2971,7 +2971,7 @@ object Parsers {
                 |  * variable pattern, e.g. `case x: String =>`
                 |  * number literal pattern, e.g. `case 10.5: Double =>`
                 |are no longer supported. Remove the type ascription or move it to a separate variable pattern.""",
-            in.sourcePos(),
+            p.sourcePos,
             warnFrom = `3.3`,
             errorFrom = future
           )

--- a/tests/neg/i15784.check
+++ b/tests/neg/i15784.check
@@ -10,17 +10,17 @@
   |                      Not found: A
   |
   | longer explanation available when compiling with `-explain`
--- Warning: tests/neg/i15784.scala:7:8 ---------------------------------------------------------------------------------
+-- Warning: tests/neg/i15784.scala:7:7 ---------------------------------------------------------------------------------
 7 |  case X: Int => X  // warn
-  |        ^
-  |        Type ascriptions after patterns other than:
-  |          * variable pattern, e.g. `case x: String =>`
-  |          * number literal pattern, e.g. `case 10.5: Double =>`
-  |        are no longer supported. Remove the type ascription or move it to a separate variable pattern.
--- Warning: tests/neg/i15784.scala:10:12 -------------------------------------------------------------------------------
+  |       ^
+  |       Type ascriptions after patterns other than:
+  |         * variable pattern, e.g. `case x: String =>`
+  |         * number literal pattern, e.g. `case 10.5: Double =>`
+  |       are no longer supported. Remove the type ascription or move it to a separate variable pattern.
+-- Warning: tests/neg/i15784.scala:10:7 --------------------------------------------------------------------------------
 10 |  case `Int`: Int => `Int` // warn
-   |            ^
-   |            Type ascriptions after patterns other than:
-   |              * variable pattern, e.g. `case x: String =>`
-   |              * number literal pattern, e.g. `case 10.5: Double =>`
-   |            are no longer supported. Remove the type ascription or move it to a separate variable pattern.
+   |       ^^^^^
+   |       Type ascriptions after patterns other than:
+   |         * variable pattern, e.g. `case x: String =>`
+   |         * number literal pattern, e.g. `case 10.5: Double =>`
+   |       are no longer supported. Remove the type ascription or move it to a separate variable pattern.

--- a/tests/neg/t5702-neg-bad-and-wild.check
+++ b/tests/neg/t5702-neg-bad-and-wild.check
@@ -46,13 +46,6 @@
    |                    no pattern match extractor named * was found
    |
    | longer explanation available when compiling with `-explain`
--- Warning: tests/neg/t5702-neg-bad-and-wild.scala:13:22 ---------------------------------------------------------------
-13 |      case List(1, _*3:) =>  // error // error
-   |                      ^
-   |                  Type ascriptions after patterns other than:
-   |                    * variable pattern, e.g. `case x: String =>`
-   |                    * number literal pattern, e.g. `case 10.5: Double =>`
-   |                  are no longer supported. Remove the type ascription or move it to a separate variable pattern.
 -- Warning: tests/neg/t5702-neg-bad-and-wild.scala:22:20 ---------------------------------------------------------------
 22 |    val K(x @ _*) = k
    |                    ^


### PR DESCRIPTION
Backports #23115 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]