### PR TITLE
Backport "improvement: Simplify match types when possible" to 3.3 LTS

### DIFF
--- a/presentation-compiler/src/main/dotty/tools/pc/printer/ShortenedTypePrinter.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/printer/ShortenedTypePrinter.scala
@@ -349,7 +349,9 @@ class ShortenedTypePrinter(
     val paramLabelss = label(methodParams)
     val extLabelss = label(extParams)
 
-    val returnType = tpe(gtpe.finalResultType)
+    val retType = gtpe.finalResultType
+    val simplified = if (retType.typeSymbol.isAliasType) retType else retType.deepDealiasAndSimplify
+    val returnType = tpe(simplified)
     def extensionSignatureString =
       val extensionSignature = paramssString(extLabelss, extParams)
       if extParams.nonEmpty then

--- a/presentation-compiler/src/main/dotty/tools/pc/utils/InteractiveEnrichments.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/utils/InteractiveEnrichments.scala
@@ -407,12 +407,13 @@ object InteractiveEnrichments extends CommonMtagsEnrichments:
         case app @ AppliedType(tycon, params) =>
           AppliedType(tycon, params.map(_.deepDealias))
         case aliasingBounds: AliasingBounds =>
-          aliasingBounds.derivedAlias(aliasingBounds.alias.dealias)
+          aliasingBounds.derivedAlias(aliasingBounds.alias.deepDealiasAndSimplify)
         case TypeBounds(lo, hi) =>
           TypeBounds(lo.dealias, hi.dealias)
         case RefinedType(parent, name, refinedInfo) =>
           RefinedType(parent.dealias, name, refinedInfo.deepDealias)
         case dealised => dealised
+      dealiased.simplified
 
   extension[T] (list: List[T])
     def get(n: Int): Option[T] = if 0 <= n && n < list.size then Some(list(n)) else None

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
@@ -94,18 +94,18 @@ class CompletionSuite extends BaseCompletionSuite:
          |newBuilder[A]: Builder[A, List[A]]
          |apply[A](elems: A*): List[A]
          |concat[A](xss: Iterable[A]*): List[A]
-         |fill[A](n1: Int, n2: Int)(elem: => A): List[List[A] @uncheckedVariance]
-         |fill[A](n1: Int, n2: Int, n3: Int)(elem: => A): List[List[List[A]] @uncheckedVariance]
-         |fill[A](n1: Int, n2: Int, n3: Int, n4: Int)(elem: => A): List[List[List[List[A]]] @uncheckedVariance]
-         |fill[A](n1: Int, n2: Int, n3: Int, n4: Int, n5: Int)(elem: => A): List[List[List[List[List[A]]]] @uncheckedVariance]
+         |fill[A](n1: Int, n2: Int)(elem: => A): List[List[A]]
+         |fill[A](n1: Int, n2: Int, n3: Int)(elem: => A): List[List[List[A]]]
+         |fill[A](n1: Int, n2: Int, n3: Int, n4: Int)(elem: => A): List[List[List[List[A]]]]
+         |fill[A](n1: Int, n2: Int, n3: Int, n4: Int, n5: Int)(elem: => A): List[List[List[List[List[A]]]]]
          |fill[A](n: Int)(elem: => A): List[A]
          |iterate[A](start: A, len: Int)(f: A => A): List[A]
          |range[A: Integral](start: A, end: A): List[A]
          |range[A: Integral](start: A, end: A, step: A): List[A]
-         |tabulate[A](n1: Int, n2: Int)(f: (Int, Int) => A): List[List[A] @uncheckedVariance]
-         |tabulate[A](n1: Int, n2: Int, n3: Int)(f: (Int, Int, Int) => A): List[List[List[A]] @uncheckedVariance]
-         |tabulate[A](n1: Int, n2: Int, n3: Int, n4: Int)(f: (Int, Int, Int, Int) => A): List[List[List[List[A]]] @uncheckedVariance]
-         |tabulate[A](n1: Int, n2: Int, n3: Int, n4: Int, n5: Int)(f: (Int, Int, Int, Int, Int) => A): List[List[List[List[List[A]]]] @uncheckedVariance]
+         |tabulate[A](n1: Int, n2: Int)(f: (Int, Int) => A): List[List[A]]
+         |tabulate[A](n1: Int, n2: Int, n3: Int)(f: (Int, Int, Int) => A): List[List[List[A]]]
+         |tabulate[A](n1: Int, n2: Int, n3: Int, n4: Int)(f: (Int, Int, Int, Int) => A): List[List[List[List[A]]]]
+         |tabulate[A](n1: Int, n2: Int, n3: Int, n4: Int, n5: Int)(f: (Int, Int, Int, Int, Int) => A): List[List[List[List[List[A]]]]]
          |tabulate[A](n: Int)(f: Int => A): List[A]
          |unapplySeq[A](x: List[A] @uncheckedVariance): UnapplySeqWrapper[A]
          |unfold[A, S](init: S)(f: S => Option[(A, S)]): List[A]
@@ -116,7 +116,7 @@ class CompletionSuite extends BaseCompletionSuite:
          |ensuring(cond: List.type => Boolean, msg: => Any): List.type
          |fromSpecific(from: Any)(it: IterableOnce[Nothing]): List[Nothing]
          |fromSpecific(it: IterableOnce[Nothing]): List[Nothing]
-         |nn: List.type & List.type
+         |nn: List.type
          |toFactory(from: Any): Factory[Nothing, List[Nothing]]
          |formatted(fmtstr: String): String
          |→[B](y: B): (List.type, B)

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionTypeSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionTypeSuite.scala
@@ -21,3 +21,33 @@ class CompletionTypeSuite extends BaseCompletionSuite:
       s"""|method[T <: FS](a: T): Nothing
           |""".stripMargin
     )
+
+  @Test def `long-types-match` =
+    check(
+      s"""|@main
+          |def run =
+          |  (1, 2).to@@
+          |""".stripMargin,
+      s"""|toString(): String
+          |toArray: Array[Object]
+          |toIArray: IArray[Object]
+          |toList: List[Int]
+          |productIterator: Iterator[Any]
+          |asInstanceOf[X0]: X0
+          |isInstanceOf[X0]: Boolean
+          |""".stripMargin
+    )
+
+  @Test def `union-types` =
+    check(
+      s"""|
+          |def itsAUnionType(): Int | String = ???
+          |
+          |def hello =
+          |  its@@
+          |
+          |
+          |""".stripMargin,
+      s"""|itsAUnionType(): Int | String
+          |""".stripMargin
+    )


### PR DESCRIPTION
Backports #23146 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]