### PR TITLE
Backport "Disallow empty parameter clauses in `extension` definition" to 3.3 LTS

### DIFF
--- a/tests/neg/extensions-can-only-have-using.scala
+++ b/tests/neg/extensions-can-only-have-using.scala
@@ -1,0 +1,3 @@
+extension(x: Any)() // error
+  def f = 42
+val x = Nil.f


### PR DESCRIPTION
Backports #23143 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]