### PR TITLE
Backport "Don't StackOverflow when printing RecursiveType structure." to 3.3 LTS

### DIFF
--- a/tests/run/i22649/Macro_1.scala
+++ b/tests/run/i22649/Macro_1.scala
@@ -1,0 +1,9 @@
+import scala.quoted.*
+
+inline def structureOf[T]: String =
+  ${ structureOfImpl[T] }
+
+private def structureOfImpl[T](using Quotes, Type[T]): Expr[String] =
+  import quotes.reflect.*
+  val str = Printer.TypeReprStructure.show(TypeRepr.of[T])
+  Expr(str)

--- a/tests/run/i22649/Test_2.scala
+++ b/tests/run/i22649/Test_2.scala
@@ -1,0 +1,11 @@
+@main def Test =
+  val str =
+    structureOf[{
+      type T
+      def make: T
+    }]
+
+  assert(
+    str == """RecursiveType(rec1 => Refinement(Refinement(TypeRef(ThisType(TypeRef(NoPrefix(), "lang")), "Object"), "T", TypeBounds(TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Nothing"), TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Any"))), "make", ByNameType(TypeRef(RecursiveThis(<rec1>), "T"))))""",
+    s"Was $str"
+  )


### PR DESCRIPTION
Backports #22859 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]