### PR TITLE
Backport "improvement: Add environement variable for those working on presentation-compiler or scaladoc" to 3.3 LTS

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -414,7 +414,7 @@ object Build {
     "scala2-library-tasty"
   )
 
-  val enableBspAllProjects = false
+  val enableBspAllProjects = sys.env.get("ENABLE_BSP_ALL_PROJECTS").map(_.toBoolean).getOrElse(false)
 
   // Settings used when compiling dotty with a non-bootstrapped dotty
   lazy val commonBootstrappedSettings = commonDottySettings ++ Seq(


### PR DESCRIPTION
Backports #23210 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]