### PR TITLE
Backport "chore: filter allowed source versions by import and by settings" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/SourceVersion.scala
+++ b/compiler/src/dotty/tools/dotc/config/SourceVersion.scala
@@ -21,10 +21,17 @@ enum SourceVersion:
   def isAtMost(v: SourceVersion) = stable.ordinal <= v.ordinal
 
 object SourceVersion extends Property.Key[SourceVersion]:
+
   def defaultSourceVersion = `3.3`
 
+  /* Illegal source versions that may not appear in the settings `-source:<...>` */
+  val illegalInSettings = List(`never`)
+
+  /* Illegal source versions that may not appear as an import `import scala.language.<...>` */
+  val illegalInImports  = List(`never`)
+
   /** language versions that may appear in a language import, are deprecated, but not removed from the standard library. */
-  val illegalSourceVersionNames = List("3.1-migration").map(_.toTermName)
+  val illegalSourceVersionNames = "3.1-migration" :: illegalInImports.map(_.toString.toTermName)
 
   /** language versions that the compiler recognises. */
   val validSourceVersionNames = values.toList.map(_.toString.toTermName)

--- a/compiler/src/dotty/tools/dotc/config/SourceVersion.scala
+++ b/compiler/src/dotty/tools/dotc/config/SourceVersion.scala
@@ -6,7 +6,8 @@ import core.Decorators.*
 import util.Property
 
 enum SourceVersion:
-  case `3.0-migration`, `3.0`, `3.1` // Note: do not add `3.1-migration` here, 3.1 is the same language as 3.0.
+  case `3.0-migration`, `3.0` 
+  case `3.1-migration`, `3.1`
   case `3.2-migration`, `3.2`
   case `3.3-migration`, `3.3`
   case `future-migration`, `future`
@@ -25,10 +26,10 @@ object SourceVersion extends Property.Key[SourceVersion]:
   def defaultSourceVersion = `3.3`
 
   /* Illegal source versions that may not appear in the settings `-source:<...>` */
-  val illegalInSettings = List(`never`)
+  val illegalInSettings = List(`3.1-migration`, `never`)
 
   /* Illegal source versions that may not appear as an import `import scala.language.<...>` */
-  val illegalInImports  = List(`never`)
+  val illegalInImports  = List(`3.1-migration`, `never`)
 
   /** language versions that may appear in a language import, are deprecated, but not removed from the standard library. */
   val illegalSourceVersionNames = "3.1-migration" :: illegalInImports.map(_.toString.toTermName)

--- a/compiler/test/dotty/tools/dotc/config/ScalaSettingsTests.scala
+++ b/compiler/test/dotty/tools/dotc/config/ScalaSettingsTests.scala
@@ -199,4 +199,11 @@ class ScalaSettingsTests:
     )
     assertEquals(result, Right(reporting.Action.Error))
 
+  @Test def `illegal source versions are not accepted when parsing the settings`: Unit =
+    for source <- SourceVersion.illegalInSettings do
+      val settings = ScalaSettings
+      val result = settings.processArguments(List("-source", source.toString()), true)
+      assertEquals(0, result.warnings.length)
+      assertEquals(1, result.errors.length)
+
 end ScalaSettingsTests


### PR DESCRIPTION
Backports #23215 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]