### PR TITLE
Backport "Fix incorrect warning with -no-indent" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -680,7 +680,7 @@ object Parsers {
     def checkNextNotIndented(): Unit =
       if in.isNewLine then
         val nextIndentWidth = in.indentWidth(in.next.offset)
-        if in.currentRegion.indentWidth < nextIndentWidth then
+        if in.currentRegion.indentWidth < nextIndentWidth && in.currentRegion.closedBy == OUTDENT then
           warning(em"Line is indented too far to the right, or a `{` or `:` is missing", in.next.offset)
 
 /* -------- REWRITES ----------------------------------------------------------- */

--- a/tests/pos/i21749.scala
+++ b/tests/pos/i21749.scala
@@ -1,0 +1,9 @@
+//> using options -Xfatal-warnings -no-indent
+
+object Test {
+  1 match {
+    case 1 =>
+      case class Test(name: String)
+      Nil
+  }
+}


### PR DESCRIPTION
Backports #23216 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]