### PR TITLE
Backport "Only keep denotation for methods in IntegrateMap" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -3770,7 +3770,7 @@ object Types extends TypeUtils {
         if tp.prefix eq pre then tp
         else
           pre match
-            case ref: ParamRef if (ref.binder eq self) && tp.symbol.exists =>
+            case ref: ParamRef if (ref.binder eq self) && tp.symbol.exists && tp.symbol.is(Method) =>
               NamedType(pre, tp.name, tp.denot.asSeenFrom(pre))
             case _ =>
               tp.derivedSelect(pre)

--- a/tests/pos/i23217.scala
+++ b/tests/pos/i23217.scala
@@ -1,0 +1,20 @@
+trait HasA[T]:
+  type A = T
+
+object Test1:
+  def foo1(h: HasA[?])(a: h.A): Unit = {}
+
+  def foo2(h1: HasA[?])(a1: h1.A): Unit =
+    foo1(h1)(a1)
+
+  def foo3(h1: HasA[?], a1: h1.A): Unit =
+    foo1(h1)(a1)
+
+object Test2:
+  def bar1(h: HasA[?], a: h.A): Unit = {}
+
+  def bar2(h1: HasA[?], a1: h1.A): Unit =
+    bar1(h1, a1)
+
+  def foo3(h1: HasA[?])(a1: h1.A): Unit =
+    bar2(h1, a1)


### PR DESCRIPTION
Backports #23226 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]