### PR TITLE
Backport "chore: have a better error message when context bounds are not allowed" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/ErrorMessageID.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/ErrorMessageID.scala
@@ -225,6 +225,9 @@ enum ErrorMessageID(val isActive: Boolean = true) extends java.lang.Enum[ErrorMe
   case FormatInterpolationErrorID // errorNumber: 209
   case ValueClassCannotExtendAliasOfAnyValID // errorNumber: 210
   case MatchIsNotPartialFunctionID // errorNumber: 211
+  case OnlyFullyDependentAppliedConstructorTypeID // errorNumber: 212
+  case PointlessAppliedConstructorTypeID // errorNumber: 213
+  case IllegalContextBoundsID // errorNumber: 214
 
   def errorNumber = ordinal - 1
 

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -3255,3 +3255,11 @@ class MatchIsNotPartialFunction(using Context) extends SyntaxMsg(MatchIsNotParti
        |
        |Efficient operations will use `applyOrElse` to avoid computing the match twice,
        |but the `apply` body would be executed "per element" in the example."""
+
+final class IllegalContextBounds(using Context) extends SyntaxMsg(IllegalContextBoundsID):
+  override protected def msg(using Context): String =
+    i"Context bounds are not allowed in this position"
+
+  override protected def explain(using Context): String = ""
+
+end IllegalContextBounds

--- a/tests/neg/i22552.check
+++ b/tests/neg/i22552.check
@@ -1,12 +1,12 @@
--- [E040] Syntax Error: tests/neg/i22552.scala:3:10 --------------------------------------------------------------------
+-- [E214] Syntax Error: tests/neg/i22552.scala:3:10 --------------------------------------------------------------------
 3 |  type A[X: TC]                     // error
-  |          ^
-  |          ']' expected, but ':' found
--- [E040] Syntax Error: tests/neg/i22552.scala:4:13 --------------------------------------------------------------------
+  |          ^^^^
+  |          Context bounds are not allowed in this position
+-- [E214] Syntax Error: tests/neg/i22552.scala:4:13 --------------------------------------------------------------------
 4 |  type C = [X: TC] =>> List[X]      // error
-  |             ^
-  |             ']' expected, but ':' found
--- [E040] Syntax Error: tests/neg/i22552.scala:5:13 --------------------------------------------------------------------
+  |             ^^^^
+  |             Context bounds are not allowed in this position
+-- [E214] Syntax Error: tests/neg/i22552.scala:5:13 --------------------------------------------------------------------
 5 |  type D = [X: TC] => () => List[X] // error
-  |             ^
-  |             ']' expected, but ':' found
+  |             ^^^^
+  |             Context bounds are not allowed in this position

--- a/tests/neg/i22660.check
+++ b/tests/neg/i22660.check
@@ -1,0 +1,4 @@
+-- [E214] Syntax Error: tests/neg/i22660.scala:2:10 --------------------------------------------------------------------
+2 |type Foo[T: Equatable] // error
+  |          ^^^^^^^^^^^
+  |          Context bounds are not allowed in this position

--- a/tests/neg/i22660.scala
+++ b/tests/neg/i22660.scala
@@ -1,0 +1,2 @@
+trait Equatable[T]
+type Foo[T: Equatable] // error


### PR DESCRIPTION
Backports #23190 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]