### PR TITLE
Backport "Remove obsolete check file" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -37,7 +37,8 @@ object ScalaSettings:
     ScalaRelease.values.toList.map(_.show)
 
   def supportedSourceVersions: List[String] =
-    SourceVersion.values.toList.map(_.toString)
+    SourceVersion.values.diff(SourceVersion.illegalInSettings)
+      .map(_.toString).toList
 
   def defaultClasspath: String = sys.env.getOrElse("CLASSPATH", ".")
 

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
@@ -630,8 +630,13 @@ class TreePickler(pickler: TastyPickler) {
         case tree: TypeTree =>
           pickleType(tree.tpe)
         case SingletonTypeTree(ref) =>
-          writeByte(SINGLETONtpt)
-          pickleTree(ref)
+          val tp = ref.tpe
+          val tp1 = tp.deskolemized
+          if tp1 ne tp then
+            pickleType(tp1)
+          else
+            writeByte(SINGLETONtpt)
+            pickleTree(ref)
         case RefinedTypeTree(parent, refinements) =>
           if (refinements.isEmpty) pickleTree(parent)
           else {

--- a/tests/neg/indentRight.scala
+++ b/tests/neg/indentRight.scala
@@ -24,8 +24,8 @@ object Test {
   }
 
   trait A
-    case class B() extends A  // error: Line is indented too far to the right
-    case object C extends A   // error: Line is indented too far to the right
+    case class B() extends A
+    case object C extends A
 
   if (true)   // OK
     println("hi")

--- a/tests/pos/i23194.scala
+++ b/tests/pos/i23194.scala
@@ -1,0 +1,14 @@
+class R[T] extends annotation.StaticAnnotation
+
+class A[T]:
+  val next: A[T] = null
+  val self: this.type = this
+  val selfnext: this.next.type = this.next
+  def f: (A[T] @R[this.type], A[T] @R[this.next.type]) = ???
+  def g: (A[T] @R[self.type], A[T] @R[selfnext.type]) = ???
+
+class Test:
+  def test =
+    val (a, b) = A[String]().f
+    val (a2, b2) = A[String]().g
+  


### PR DESCRIPTION
Backports #23258 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]