### PR TITLE
Backport "[CI] Switch releasing to Sontype Central instead of legacy Sonatype OSS" to 3.3 LTS

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -605,7 +605,7 @@ jobs:
       - name: Publish Nightly
         if: "steps.not_yet_published.outcome == 'success'"
         run: |
-          ./project/scripts/sbtPublish ";project scala3-bootstrapped ;publishSigned ;sonatypeBundleRelease"
+          ./project/scripts/sbtPublish ";project scala3-bootstrapped ;publishSigned ;sonaRelease"
 
   nightly_documentation:
     runs-on: [self-hosted, Linux]
@@ -746,7 +746,7 @@ jobs:
           ./dist/target/sha256sum.txt
 
       - name: Publish Release
-        run: ./project/scripts/sbtPublish ";project scala3-bootstrapped ;publishSigned ;sonatypeBundleUpload"
+        run: ./project/scripts/sbtPublish ";project scala3-bootstrapped ;publishSigned ;sonaUpload"
 
 
   open_issue_on_failure:

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -16,7 +16,6 @@ import sbt.plugins.SbtPlugin
 import sbt.ScriptedPlugin.autoImport._
 import xerial.sbt.pack.PackPlugin
 import xerial.sbt.pack.PackPlugin.autoImport._
-import xerial.sbt.Sonatype.autoImport._
 import com.typesafe.tools.mima.plugin.MimaPlugin.autoImport._
 import org.scalajs.sbtplugin.ScalaJSPlugin
 import org.scalajs.sbtplugin.ScalaJSPlugin.autoImport._
@@ -1915,7 +1914,11 @@ object Build {
   lazy val publishSettings = Seq(
     publishMavenStyle := true,
     isSnapshot := version.value.contains("SNAPSHOT"),
-    publishTo := sonatypePublishToBundle.value,
+    publishTo := {
+      val centralSnapshots = "https://central.sonatype.com/repository/maven-snapshots/"
+      if (isSnapshot.value) Some("central-snapshots" at centralSnapshots)
+      else localStaging.value
+    },
     publishConfiguration ~= (_.withOverwrite(true)),
     publishLocalConfiguration ~= (_.withOverwrite(true)),
     projectID ~= {id =>

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.7
+sbt.version=1.11.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,8 +8,6 @@ libraryDependencySchemes +=
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.12.0")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.21")
-
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.2.1")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-pack" % "0.17")


### PR DESCRIPTION
Backports #23290 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]