### PR TITLE
Backport "[CI] Add credentials for central.sonatype.com, remove credentials for oss.sonatype.org" to 3.3 LTS

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -286,7 +286,7 @@ object Build {
       for {
         username <- sys.env.get("SONATYPE_USER")
         password <- sys.env.get("SONATYPE_PW")
-      } yield Credentials("Sonatype Nexus Repository Manager", "oss.sonatype.org", username, password)
+      } yield Credentials("Sonatype Nexus Repository Manager", "central.sonatype.com", username, password)
     ).toList,
     PgpKeys.pgpPassphrase := sys.env.get("PGP_PW").map(_.toCharArray()),
     PgpKeys.useGpgPinentry := true,


### PR DESCRIPTION
Backports #23298 to the 3.3.7.

PR submitted by the release tooling.