### PR TITLE
Backport "Warn trivial recursion with module prefix" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/TailRec.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TailRec.scala
@@ -194,7 +194,8 @@ class TailRec extends MiniPhase {
         def isInfiniteRecCall(tree: Tree): Boolean = {
           def tailArgOrPureExpr(stat: Tree): Boolean = stat match {
             case stat: ValDef if stat.name.is(TailTempName) || !stat.symbol.is(Mutable) => tailArgOrPureExpr(stat.rhs)
-            case Assign(lhs: Ident, rhs) if lhs.symbol.name.is(TailLocalName) => tailArgOrPureExpr(rhs)
+            case Assign(lhs: Ident, rhs) if lhs.symbol.name.is(TailLocalName) =>
+              tailArgOrPureExpr(rhs) || varForRewrittenThis.exists(_ == lhs.symbol && rhs.tpe.isStable)
             case Assign(lhs: Ident, rhs: Ident) => lhs.symbol == rhs.symbol
             case stat: Ident if stat.symbol.name.is(TailLocalName) => true
             case _ => tpd.isPureExpr(stat)
@@ -342,6 +343,9 @@ class TailRec extends MiniPhase {
                 assignParamPairs
               case prefix: This if prefix.symbol == enclosingClass =>
                 // Avoid assigning `this = this`
+                assignParamPairs
+              case prefix if prefix.symbol.is(Module) && prefix.symbol.moduleClass == enclosingClass =>
+                // Avoid assigning `this = MyObject`
                 assignParamPairs
               case _ =>
                 (getVarForRewrittenThis(), noTailTransform(prefix)) :: assignParamPairs

--- a/tests/warn/i23277.scala
+++ b/tests/warn/i23277.scala
@@ -1,0 +1,22 @@
+
+enum Test:
+  case One
+  case Two(i: Int)
+
+object Test:
+  object Two:
+    def apply(i: Int): Test.Two = Test.Two(i) // warn
+    def apply(i: Int, j: Int): Test.Two = new Test.Two(i+j)
+    def apply(i: Int, s: String): Two = Two(i, s) // warn because unprefixed Two is deemed pure
+    def apply(): Test.Two = other.apply() // nowarn prefix is method call
+    def other: this.type = this
+
+object R extends Runnable:
+  def r: this.type = this
+  override def run() = r.run()
+
+final class C(c: C):
+  def f(i: Int): Int = c.f(i)
+
+@main def main = println:
+  Test.Two(1)


### PR DESCRIPTION
Backports #23278 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]