### PR TITLE
Backport "Erased fields are not nullable" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/CollectNullableFields.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CollectNullableFields.scala
@@ -60,7 +60,7 @@ class CollectNullableFields extends MiniPhase {
     val sym = tree.symbol
     val isNullablePrivateField =
       sym.isField &&
-      !sym.is(Lazy) &&
+      !sym.isOneOf(Lazy | Erased) &&
       !sym.owner.is(Trait) &&
       sym.initial.isAllOf(PrivateLocal) &&
       // We need `isNullableClassAfterErasure` and not `isNullable` because

--- a/tests/run/i23305.scala
+++ b/tests/run/i23305.scala
@@ -1,0 +1,24 @@
+//> using options -language:experimental.erasedDefinitions
+
+erased trait DBMeta[A]
+
+trait Table[A]
+
+case class Saved[A]()
+object Saved {
+  def table[A](using dbm: DBMeta[A]): Table[Saved[A]] = new Table[Saved[A]] {}
+}
+
+case class deleteBulk[A](as: List[Saved[A]])(using dbm: DBMeta[A], tbl: Table[A]) {
+  final given savedTable: Table[Saved[A]] = Saved.table[A]
+}
+
+case class Foo()
+object Foo {
+  given dbMeta: DBMeta[Foo] = new DBMeta[Foo] {}
+  given table: Table[Foo] = new Table[Foo] {}
+}
+
+@main def Test =
+  val del = deleteBulk(List(Saved[Foo]()))
+  del.savedTable


### PR DESCRIPTION
Backports #23311 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]