### PR TITLE
Backport "improvement: Cache compilation on . and don't add CURSOR" to 3.3 LTS

### DIFF
--- a/presentation-compiler/src/main/dotty/tools/pc/completions/CompletionProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/CompletionProvider.scala
@@ -176,9 +176,10 @@ class CompletionProvider(
     val text = params.text().nn
     val offset = params.offset().nn
     val query = Completion.naiveCompletionPrefix(text, offset)
-
-    if offset > 0 && text.charAt(offset - 1).isUnicodeIdentifierPart
-      && !CompletionProvider.allKeywords.contains(query) then false -> text
+    def isValidLastChar =
+      val lastChar = text.charAt(offset - 1)
+      lastChar.isUnicodeIdentifierPart || lastChar == '.'
+    if offset > 0 && isValidLastChar && !CompletionProvider.allKeywords.contains(query) then false -> text
     else
       val isStartMultilineComment =
 

--- a/presentation-compiler/test/dotty/tools/pc/tests/CompilerCachingSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/CompilerCachingSuite.scala
@@ -84,6 +84,22 @@ class CompilerCachingSuite extends BasePCSuite:
     checkCompilationCount(4)
 
   @Test
+  def `dot-compilation-does-not-corrupt-cache`: Unit =
+    val contextPreCompilation = getContext()
+
+    val fakeParams = CompilerOffsetParams(Paths.get("Test.scala").toUri(), "def hello = 1.", 14, EmptyCancelToken)
+    presentationCompiler.complete(fakeParams).get(timeout.length, timeout.unit)
+    val contextPostFirst = getContext()
+    assert(contextPreCompilation != contextPostFirst)
+    checkCompilationCount(4)
+
+    presentationCompiler.complete(fakeParams).get(timeout.length, timeout.unit)
+    val contextPostSecond = getContext()
+    assert(contextPreCompilation != contextPostFirst)
+    assert(contextPostSecond == contextPostFirst)
+    checkCompilationCount(4)
+
+  @Test
   def `compilation-for-same-snippet-is-cached`: Unit =
     val contextPreCompilation = getContext()
 


### PR DESCRIPTION
Backports #23356 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]