### PR TITLE
Backport "Fix insufficient number width allocated when using `-print-lines`" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/printing/Texts.scala
+++ b/compiler/src/dotty/tools/dotc/printing/Texts.scala
@@ -139,7 +139,8 @@ object Texts {
 
     def mkString(width: Int, withLineNumbers: Boolean): String = {
       val sb = new StringBuilder
-      val numberWidth = if (withLineNumbers) (2 * maxLine.toString.length) + 2 else 0
+      // width display can be upto a range "n-n" where 1 <= n <= maxLine+1
+      val numberWidth = if (withLineNumbers) (2 * (maxLine + 1).toString.length) + 2 else 0
       layout(width - numberWidth).print(sb, numberWidth)
       sb.toString
     }

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -352,7 +352,7 @@ class TypeMismatch(val found: Type, expected: Type, val inTree: Option[untpd.Tre
     ++ addenda.dropWhile(_.isEmpty).headOption.getOrElse(importSuggestions)
 
   override def explain(using Context) =
-    val treeStr = inTree.map(x => s"\nTree: ${x.show}").getOrElse("")
+    val treeStr = inTree.map(x => s"\nTree:\n\n${x.show}\n").getOrElse("")
     treeStr + "\n" + super.explain
 
 end TypeMismatch

--- a/tests/neg/19680.check
+++ b/tests/neg/19680.check
@@ -7,7 +7,10 @@
   | Explanation (enabled by `-explain`)
   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   |
-  | Tree: new Config()
+  | Tree:
+  |
+  | new Config()
+  |
   | I tried to show that
   |   Config
   | conforms to

--- a/tests/neg/19680b.check
+++ b/tests/neg/19680b.check
@@ -7,7 +7,10 @@
   | Explanation (enabled by `-explain`)
   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   |
-  | Tree: "hello"
+  | Tree:
+  |
+  | "hello"
+  |
   | I tried to show that
   |   ("hello" : String)
   | conforms to

--- a/tests/neg/hidden-type-errors.check
+++ b/tests/neg/hidden-type-errors.check
@@ -7,7 +7,10 @@
   | Explanation (enabled by `-explain`)
   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   |
-  | Tree: t12717.A.bar("XXX")
+  | Tree:
+  |
+  | t12717.A.bar("XXX")
+  |
   | I tried to show that
   |   String
   | conforms to

--- a/tests/neg/i18737.check
+++ b/tests/neg/i18737.check
@@ -7,7 +7,10 @@
   | Explanation (enabled by `-explain`)
   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   |
-  | Tree: v
+  | Tree:
+  |
+  | v
+  |
   | I tried to show that
   |   (v : String & Long)
   | conforms to
@@ -32,7 +35,10 @@
   | Explanation (enabled by `-explain`)
   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   |
-  | Tree: v
+  | Tree:
+  |
+  | v
+  |
   | I tried to show that
   |   (v : String | Long)
   | conforms to


### PR DESCRIPTION
Backports #23336 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]