### PR TITLE
Backport "Test case for regression #23095" to 3.3 LTS

### DIFF
--- a/tests/pos/i23095/defs.scala
+++ b/tests/pos/i23095/defs.scala
@@ -1,0 +1,18 @@
+import scala.compiletime.*
+import scala.deriving.*
+
+trait SeqStringCodec[A]:
+  def decode(value: Seq[String]): Either[Any, A]
+
+trait UrlForm
+trait FormCodec[A]
+
+object FormCodec {
+  inline given derived[A](using p: Mirror.ProductOf[A]): FormCodec[A] =
+    val codecs = summonAll[Tuple.Map[p.MirroredElemTypes, SeqStringCodec]].toArray
+    val values = codecs.map {
+      _.asInstanceOf[SeqStringCodec[?]]
+        .decode(List.empty[String])
+    }
+    ???
+}

--- a/tests/pos/i23095/test.scala
+++ b/tests/pos/i23095/test.scala
@@ -1,0 +1,3 @@
+given SeqStringCodec[Int] = ???
+given SeqStringCodec[String] = ???
+final case class Form(int: Int, string: String) derives FormCodec


### PR DESCRIPTION
Backports #23359 to the 3.3.7.

PR submitted by the release tooling.