### PR TITLE
Backport "bugfix: Check for error before checking members of product type in getUnapplySelectors" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -124,8 +124,11 @@ object Applications {
   }
 
   def productSelectorTypes(tp: Type, errorPos: SrcPos)(using Context): List[Type] = {
-    val sels = for (n <- Iterator.from(0)) yield extractorMemberType(tp, nme.selectorName(n), errorPos)
-    sels.takeWhile(_.exists).toList
+    if tp.isError then
+      Nil
+    else
+      val sels = for (n <- Iterator.from(0)) yield extractorMemberType(tp, nme.selectorName(n), errorPos)
+      sels.takeWhile(_.exists).toList
   }
 
   def tupleComponentTypes(tp: Type)(using Context): List[Type] =

--- a/tests/neg/i23156.scala
+++ b/tests/neg/i23156.scala
@@ -2,5 +2,5 @@ object Unpack {
   (1, 2) match {
     case Unpack(first, _) => first
   }
-  def unapply(e: (Int, Int)): Option[T] = ???
+  def unapply(e: (Int, Int)): Option[T] = ??? // error
 }

--- a/tests/pos/i23156.scala
+++ b/tests/pos/i23156.scala
@@ -1,0 +1,6 @@
+object Unpack {
+  (1, 2) match {
+    case Unpack(first, _) => first
+  }
+  def unapply(e: (Int, Int)): Option[T] = ???
+}


### PR DESCRIPTION
Backports #23358 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]