### PR TITLE
Backport "Skip splice level checking for <refinement> symbols" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/staging/HealType.scala
+++ b/compiler/src/dotty/tools/dotc/staging/HealType.scala
@@ -76,7 +76,7 @@ class HealType(pos: SrcPos)(using Context) extends TypeMap {
     tp match
       case tp @ NamedType(NoPrefix, _) if level > levelOf(tp.symbol) => tp.symbol
       case tp: NamedType if !tp.symbol.isStatic => levelInconsistentRootOfPath(tp.prefix)
-      case tp: ThisType if level > levelOf(tp.cls) => tp.cls
+      case tp: ThisType if level > levelOf(tp.cls) && !tp.cls.isRefinementClass => tp.cls
       case _ => NoSymbol
 
   /** Try to heal reference to type `T` used in a higher level than its definition.

--- a/tests/pos/i22648.scala
+++ b/tests/pos/i22648.scala
@@ -1,0 +1,14 @@
+import scala.quoted.*
+
+def fooImpl(using Quotes): Expr[Any] =
+  '{
+    new AnyRef {
+      type T = Unit
+      def make: T = ()
+      def take(t: T): Unit = ()
+    }: {
+      type T
+      def make: T
+      def take(t: T): Unit
+    }
+  }


### PR DESCRIPTION
Backports #22782 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]