### PR TITLE
Backport "Unhelpful error message when trying to use named extraction, when not matching case class or named tuple" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/ErrorMessageID.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/ErrorMessageID.scala
@@ -228,6 +228,7 @@ enum ErrorMessageID(val isActive: Boolean = true) extends java.lang.Enum[ErrorMe
   case OnlyFullyDependentAppliedConstructorTypeID // errorNumber: 212
   case PointlessAppliedConstructorTypeID // errorNumber: 213
   case IllegalContextBoundsID // errorNumber: 214
+  case NamedPatternNotApplicableID // errorNumber: 215
 
   def errorNumber = ordinal - 1
 

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -3262,4 +3262,8 @@ final class IllegalContextBounds(using Context) extends SyntaxMsg(IllegalContext
 
   override protected def explain(using Context): String = ""
 
-end IllegalContextBounds
+final class NamedPatternNotApplicable(selectorType: Type)(using Context) extends PatternMatchMsg(NamedPatternNotApplicableID):
+  override protected def msg(using Context): String =
+    i"Named patterns cannot be used with $selectorType, because it is not a named tuple or case class"
+
+  override protected def explain(using Context): String = ""


### PR DESCRIPTION
Backports #23354 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]