### PR TITLE
Backport "Fix regressions in asSeenFrom introduced in 3.7" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -123,7 +123,9 @@ object TypeOps:
   }
 
   def isLegalPrefix(pre: Type)(using Context): Boolean =
-    pre.isStable || !ctx.phase.isTyper
+    // isLegalPrefix is relaxed after typer unless we're doing an implicit
+    // search (this matters when doing summonInline in an inline def like in tests/pos/i17222.8.scala).
+    pre.isStable || !ctx.phase.isTyper && ctx.mode.is(Mode.ImplicitsEnabled)
 
   /** Implementation of Types#simplified */
   def simplify(tp: Type, theMap: SimplifyMap | Null)(using Context): Type = {

--- a/tests/neg-custom-args/captures/lazylist.check
+++ b/tests/neg-custom-args/captures/lazylist.check
@@ -26,11 +26,11 @@
    |                                    Required: lazylists.LazyList[Int]^{cap2}
    |
    | longer explanation available when compiling with `-explain`
--- [E007] Type Mismatch Error: tests/neg-custom-args/captures/lazylist.scala:41:48 -------------------------------------
-41 |  val ref4c: LazyList[Int]^{cap1, ref3, cap3} = ref4 // error
-   |                                                ^^^^
-   |                                             Found:    (ref4 : lazylists.LazyList[Int]^{cap3, cap2, ref1, cap1})
-   |                                             Required: lazylists.LazyList[Int]^{cap1, ref3, cap3}
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/lazylist.scala:41:42 -------------------------------------
+41 |  val ref4c: LazyList[Int]^{cap1, ref3} = ref4 // error
+   |                                          ^^^^
+   |                                          Found:    (ref4 : lazylists.LazyList[Int]^{cap3, cap1, cap2})
+   |                                          Required: lazylists.LazyList[Int]^{cap1, ref3}
    |
    | longer explanation available when compiling with `-explain`
 -- [E164] Declaration Error: tests/neg-custom-args/captures/lazylist.scala:22:6 ----------------------------------------

--- a/tests/pos-macros/i23423/A_1.scala
+++ b/tests/pos-macros/i23423/A_1.scala
@@ -1,0 +1,16 @@
+package pkg
+
+import scala.quoted.*
+
+trait HasElem {
+  type Elem
+  type Alias = Elem
+}
+
+object Macro:
+  inline def foo: Unit = ${fooImpl}
+  def fooImpl(using Quotes): Expr[Unit] =
+    '{
+      val lll: (he: HasElem) => he.Alias =
+        (hx: HasElem) => ???
+    }

--- a/tests/pos-macros/i23423/B_2.scala
+++ b/tests/pos-macros/i23423/B_2.scala
@@ -1,0 +1,6 @@
+object Test:
+  def test: Unit = pkg.Macro.foo
+  // used to be error:
+  // Found:    (hx: pkg.HasElem) => hx.Elem
+  // Required: (he: pkg.HasElem) => he.Elem
+

--- a/tests/pos/i22676.scala
+++ b/tests/pos/i22676.scala
@@ -1,0 +1,11 @@
+package example
+
+trait Example {
+  class Input
+
+  type Output[A] = A match {
+    case Input => Int
+  }
+}
+
+class Ref(ref: Example#Input)


### PR DESCRIPTION
Backports #23438 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]