### PR TITLE
Backport "Fix Symbol.info remapping in TreeTypeMap" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/TreeTypeMap.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeTypeMap.scala
@@ -224,6 +224,11 @@ class TreeTypeMap(
         val tmap1 = tmap.withMappedSyms(
           origCls(cls).typeParams ::: origDcls,
           cls.typeParams ::: mappedDcls)
+        mapped.foreach { sym =>
+          // outer Symbols can reference nested ones in info,
+          // so we remap that once again with the updated TreeTypeMap
+          sym.info = tmap1.mapType(sym.info)
+        }
         origDcls.lazyZip(mappedDcls).foreach(cls.asClass.replace)
         tmap1
       }

--- a/tests/run/i23279.scala
+++ b/tests/run/i23279.scala
@@ -1,0 +1,28 @@
+inline def simpleInlineWrap(f: => Any): Unit = f
+
+@main def Test(): Unit = {
+  simpleInlineWrap {
+    object lifecycle {
+      object Lifecycle {
+        trait FromZIO
+      }
+    }
+    object defn {
+      val Lifecycle: lifecycle.Lifecycle.type = lifecycle.Lifecycle
+    }
+    val xa: defn.Lifecycle.type = defn.Lifecycle
+  }
+
+  // more nested case
+  simpleInlineWrap {
+    object lifecycle {
+      object Lifecycle {
+        object FromZIO
+      }
+    }
+    object defn {
+      val Lifecycle: lifecycle.Lifecycle.type = lifecycle.Lifecycle
+    }
+    val xa: defn.Lifecycle.FromZIO.type = defn.Lifecycle.FromZIO
+  }
+}


### PR DESCRIPTION
Backports #23432 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]