### PR TITLE
Backport "bugfix: Fix adjust type when already exists" to 3.3 LTS

### DIFF
--- a/presentation-compiler/src/main/dotty/tools/pc/InferredTypeProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/InferredTypeProvider.scala
@@ -183,8 +183,7 @@ final class InferredTypeProvider(
           typeNameEdit ::: imports
 
         rhs match
-          case t: Tree[?]
-              if t.typeOpt.isErroneous && retryType && !tpt.sourcePos.span.isZeroExtent =>
+          case t: Tree[?] if !tpt.sourcePos.span.isZeroExtent =>
             inferredTypeEdits(
               Some(
                 AdjustTypeOpts(
@@ -224,8 +223,7 @@ final class InferredTypeProvider(
           while i >= 0 && sourceText(i) != ':' do i -= 1
           i
         rhs match
-          case t: Tree[?]
-              if t.typeOpt.isErroneous && retryType && !tpt.sourcePos.span.isZeroExtent =>
+          case t: Tree[?] if !tpt.sourcePos.span.isZeroExtent =>
             inferredTypeEdits(
               Some(
                 AdjustTypeOpts(

--- a/presentation-compiler/test/dotty/tools/pc/tests/edit/InsertInferredTypeSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/edit/InsertInferredTypeSuite.scala
@@ -1035,6 +1035,70 @@ class InsertInferredTypeSuite extends BaseCodeActionSuite:
          |""".stripMargin
     )
 
+  @Test def `Adjust type for val` =
+    checkEdit(
+      """|object A{
+         |  val <<alpha>>:String = 123
+         |}""".stripMargin,
+
+      """|object A{
+         |  val alpha: Int = 123
+         |}""".stripMargin,
+    )
+
+  @Test def `Adjust type for val2` =
+    checkEdit(
+      """|object A{
+         |  val <<alpha>>:Int = 123
+         |}""".stripMargin,
+      """|object A{
+         |  val alpha: Int = 123
+         |}""".stripMargin,
+    )
+
+  @Test def `Adjust type for val3` =
+    checkEdit(
+      """|object A{
+         |  val <<alpha>>: Int = 123
+         |}""".stripMargin,
+      """|object A{
+         |  val alpha: Int = 123
+         |}""".stripMargin,
+    )
+
+  @Test def `Adjust type for def` =
+    checkEdit(
+      """|object A{
+         |  def <<alpha>>:String = 123
+         |}""".stripMargin,
+
+      """|object A{
+         |  def alpha: Int = 123
+         |}""".stripMargin,
+    )
+
+  @Test def `Adjust type for def2` =
+    checkEdit(
+      """|object A{
+         |  def <<alpha>>:Int = 123
+         |}""".stripMargin,
+      """|object A{
+         |  def alpha: Int = 123
+         |}""".stripMargin,
+    )
+
+
+  @Test def `Adjust type for def3` =
+    checkEdit(
+      """|object A{
+         |  def <<alpha>>: Int = 123
+         |}""".stripMargin,
+      """|object A{
+         |  def alpha: Int = 123
+         |}""".stripMargin,
+    )
+
+
   def checkEdit(
       original: String,
       expected: String


### PR DESCRIPTION
Backports #23455 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]