### PR TITLE
Backport "fix: Inconsistent annotation tooltips" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/NavigateAST.scala
+++ b/compiler/src/dotty/tools/dotc/ast/NavigateAST.scala
@@ -141,7 +141,9 @@ object NavigateAST {
           case _ =>
         val iterator = p match
           case defdef: DefTree[?] =>
-            p.productIterator ++ defdef.mods.productIterator
+            val mods = defdef.mods
+            val annotations = defdef.symbol.annotations.filter(_.tree.span.contains(span)).map(_.tree)
+            p.productIterator ++ annotations ++ mods.productIterator
           case _ =>
             p.productIterator
         childPath(iterator, p :: path)

--- a/presentation-compiler/test/dotty/tools/pc/tests/hover/HoverDefnSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/hover/HoverDefnSuite.scala
@@ -255,3 +255,51 @@ class HoverDefnSuite extends BaseHoverSuite:
          |```
          |""".stripMargin
     )
+
+  @Test def `annotation` =
+    check(
+      """|
+         |@ma@@in
+         |def example() = 
+         |    println("test")
+         |""".stripMargin,
+      """|```scala
+         |def this(): main
+         |```""".stripMargin.hover
+    )
+
+  @Test def `annotation-2` =
+      check(
+        """|
+          |@ma@@in
+          |def example() = 
+          |    List("test")
+          |""".stripMargin,
+        """|```scala
+          |def this(): main
+          |```""".stripMargin.hover
+      )
+
+  @Test def `annotation-3` =
+      check(
+        """|
+          |@ma@@in
+          |def example() = 
+          |    Array("test")
+          |""".stripMargin,
+        """|```scala
+          |def this(): main
+          |```""".stripMargin.hover
+      )
+
+  @Test def `annotation-4` =
+      check(
+        """|
+          |@ma@@in
+          |def example() = 
+          |    Array(1, 2)
+          |""".stripMargin,
+        """|```scala
+          |def this(): main
+          |```""".stripMargin.hover
+      )


### PR DESCRIPTION
Backports #23454 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]