### PR TITLE
Backport "Normalize tuple types in var args seq literals and classOf instances" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeUtils.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeUtils.scala
@@ -115,6 +115,16 @@ class TypeUtils:
         case Some(types) => TypeOps.nestedPairs(types)
         case None => throw new AssertionError("not a tuple")
 
+    /** If this is a generic tuple type with arity <= MaxTupleArity, return the
+     *  corresponding TupleN type, otherwise return this.
+     */
+    def normalizedTupleType(using Context): Type =
+      if self.isGenericTuple then
+        self.tupleElementTypes match
+          case Some(elems) if elems.size <= Definitions.MaxTupleArity => defn.tupleType(elems)
+          case _ => self
+      else
+        self
     def refinedWith(name: Name, info: Type)(using Context) = RefinedType(self, name, info)
 
     /** Is this type a methodic type that takes at least one parameter? */

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -841,7 +841,7 @@ trait Applications extends Compatibility {
     def makeVarArg(n: Int, elemFormal: Type): Unit = {
       val args = typedArgBuf.takeRight(n).toList
       typedArgBuf.dropRightInPlace(n)
-      val elemtpt = TypeTree(elemFormal)
+      val elemtpt = TypeTree(elemFormal.normalizedTupleType)
       typedArgBuf += seqToRepeated(SeqLiteral(args, elemtpt))
     }
 

--- a/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
@@ -51,7 +51,7 @@ class Synthesizer(typer: Typer)(using @constructorOnly c: Context):
             if defn.SpecialClassTagClasses.contains(sym) then
               classTagModul.select(sym.name.toTermName).withSpan(span)
             else
-              val ctype = escapeJavaArray(erasure(tp))
+              val ctype = escapeJavaArray(erasure(tp.normalizedTupleType))
               if ctype.exists then
                 classTagModul.select(nme.apply)
                   .appliedToType(tp)

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -738,10 +738,11 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
     // Otherwise, map combinations of A *: B *: .... EmptyTuple with nesting levels <= 22
     // to the Tuple class of the right arity and select from that one
     def trySmallGenericTuple(qual: Tree, withCast: Boolean) =
-      if qual.tpe.isSmallGenericTuple then
+      val tp = qual.tpe.widenTermRefExpr
+      val tpNormalized = tp.normalizedTupleType
+      if tp ne tpNormalized then
         if withCast then
-          val elems = qual.tpe.widenTermRefExpr.tupleElementTypes.getOrElse(Nil)
-          typedSelectWithAdapt(tree, pt, qual.cast(defn.tupleType(elems)))
+          typedSelectWithAdapt(tree, pt, qual.cast(tpNormalized))
         else
           typedSelectWithAdapt(tree, pt, qual)
       else EmptyTree

--- a/tests/run/i22345.scala
+++ b/tests/run/i22345.scala
@@ -1,0 +1,2 @@
+@main def Test: Unit =
+  val a: Array[(Int, String)] = Array[Int *: String *: EmptyTuple]()

--- a/tests/run/i22345b.scala
+++ b/tests/run/i22345b.scala
@@ -1,0 +1,2 @@
+@main def Test: Unit =
+  val a: Array[(Int, String)] = Array[Int *: String *: EmptyTuple]((1, "hello"))

--- a/tests/run/i22345c.scala
+++ b/tests/run/i22345c.scala
@@ -1,0 +1,4 @@
+def makeSeq[T](args: T*): Seq[T] = args
+
+@main def Test: Unit =
+  val a: Array[(Int, String)] = makeSeq[Int *: String *: EmptyTuple]().toArray


### PR DESCRIPTION
Backports #23465 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]