### PR TITLE
Backport "-Yprofile-trace properly report macro splicing source" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
@@ -1098,9 +1098,10 @@ class Inliner(val call: tpd.Tree)(using Context):
       if suspendable then
         ctx.compilationUnit.suspend() // this throws a SuspendException
 
-    val evaluatedSplice = inContext(quoted.MacroExpansion.context(inlinedFrom)) {
-      Splicer.splice(body, splicePos, inlinedFrom.srcPos, MacroClassLoader.fromContext)
-    }
+    val evaluatedSplice =
+      inContext(quoted.MacroExpansion.context(inlinedFrom)):
+        ctx.profiler.onMacroSplice(inlinedFrom.symbol):
+          Splicer.splice(body, splicePos, inlinedFrom.srcPos, MacroClassLoader.fromContext)
     val inlinedNormalizer = new TreeMap {
       override def transform(tree: tpd.Tree)(using Context): tpd.Tree = tree match {
         case tree @ Inlined(_, Nil, expr) if tree.inlinedFromOuterScope && enclosingInlineds.isEmpty => transform(expr)

--- a/compiler/src/dotty/tools/dotc/transform/Splicer.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Splicer.scala
@@ -54,7 +54,7 @@ object Splicer {
         inContext(sliceContext) {
           val oldContextClassLoader = Thread.currentThread().getContextClassLoader
           Thread.currentThread().setContextClassLoader(classLoader)
-          try ctx.profiler.onMacroSplice(owner){
+          try {
             val interpreter = new SpliceInterpreter(splicePos, classLoader)
 
             // Some parts of the macro are evaluated during the unpickling performed in quotedExprToTree

--- a/tests/neg/i13044.check
+++ b/tests/neg/i13044.check
@@ -1,4 +1,4 @@
--- [E172] Type Error: tests/neg/i13044.scala:46:40 ---------------------------------------------------------------------
+-- [E172] Type Error: tests/neg/i13044.scala:61:40 ---------------------------------------------------------------------
 61 |   implicit def typeSchema: Schema[A] = Schema.gen // error
    |                                        ^^^^^^^^^^
    |                                 No given instance of type Schema[B] was found.

--- a/tests/neg/i13044.scala
+++ b/tests/neg/i13044.scala
@@ -33,7 +33,22 @@ trait SchemaDerivation {
   inline given gen[A]: Schema[A] = derived
 }
 
-case class H(i: Int)
+case class X15(i: Int)
+case class X14(i: X15)
+case class X13(i: X14)
+case class X12(i: X13)
+case class X11(i: X12)
+case class X10(i: X11)
+case class X9(i: X10)
+case class X8(i: X9)
+case class X7(i: X8)
+case class X6(i: X7)
+case class X5(i: X6)
+case class X4(i: X5)
+case class X3(i: X4)
+case class X2(i: X3)
+case class X1(i: X2)
+case class H(i: X1)
 case class G(h: H)
 case class F(g: G)
 case class E(f: Option[F])


### PR DESCRIPTION
Backports #23488 to the 3.3.7.

PR submitted by the release tooling.