### PR TITLE
doctool: propagate errors from inspectAllTastyFiles

### DIFF
--- a/scaladoc/src/dotty/tools/scaladoc/tasty/TastyParser.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/TastyParser.scala
@@ -160,7 +160,9 @@ object ScaladocTastyInspector:
       report.error("File extension is not `tasty` or `jar`: " + invalidPath)
 
     if tastyPaths.nonEmpty then
-      TastyInspector.inspectAllTastyFiles(tastyPaths, jarPaths, classpath)(inspector)
+      val tastyOk = TastyInspector.inspectAllTastyFiles(tastyPaths, jarPaths, classpath)(inspector)
+      if !tastyOk then
+        report.error("Failure")
 
     val all = inspector.topLevels.result()
     all.groupBy(_._1).map { case (pckName, members) =>

--- a/scaladoc/src/dotty/tools/scaladoc/tasty/TastyParser.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/TastyParser.scala
@@ -162,7 +162,7 @@ object ScaladocTastyInspector:
     if tastyPaths.nonEmpty then
       val tastyOk = TastyInspector.inspectAllTastyFiles(tastyPaths, jarPaths, classpath)(inspector)
       if !tastyOk then
-        report.error("Failure")
+        report.error("Failed to analyse some of the tasty files, please check the above logs for details")
 
     val all = inspector.topLevels.result()
     all.groupBy(_._1).map { case (pckName, members) =>


### PR DESCRIPTION
it's not pretty, but it does work. reported errors in inspectAllTastyFiles will now cause errors in scaladoc.

honestly, i can't tell if continuing past tasty errors was the intended behaviour or not. however, tasty failures will prevent scaladoc generation, so it doesn't seem useful to continue in the presence of tasty errors.

tested with:
```bash
sbt 'scaladoc/runMain dotty.tools.scaladoc.Main ./bad -d a -siteroot empty'
```
and it will produce something like
```scala
-- Error: src/main/scala/Main.scala:26:12 --------------------------------------
undefined: m.parse # -1: TermRef(TermRef(NoPrefix,val m),parse) at readTasty
1 error found
Failure
[error] nonzero exit code returned from runner: 1
[error] (scaladoc / Compile / runMain) nonzero exit code returned from runner: 1
```

related to https://github.com/scala/scala3/issues/23561