### PR TITLE
Backport "Fix this references everywhere in dependent function types" to 3.3 LTS

### DIFF
--- a/tests/neg/i23111.check
+++ b/tests/neg/i23111.check
@@ -1,0 +1,12 @@
+-- [E086] Syntax Error: tests/neg/i23111.scala:2:47 --------------------------------------------------------------------
+2 |  def bar: (a: Int, b: Int) => A.this.type = x => ??? // error
+  |                                             ^^^^^^^^
+  |                                             Wrong number of parameters, expected: 2
+  |
+  | longer explanation available when compiling with `-explain`
+-- [E086] Syntax Error: tests/neg/i23111.scala:3:45 --------------------------------------------------------------------
+3 |  def baz: (a: Int, b: Int) => this.type = x => ???   // error
+  |                                           ^^^^^^^^
+  |                                           Wrong number of parameters, expected: 2
+  |
+  | longer explanation available when compiling with `-explain`

--- a/tests/neg/i23111.scala
+++ b/tests/neg/i23111.scala
@@ -1,0 +1,3 @@
+trait A:
+  def bar: (a: Int, b: Int) => A.this.type = x => ??? // error
+  def baz: (a: Int, b: Int) => this.type = x => ???   // error


### PR DESCRIPTION
Backports #23514 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]