### PR TITLE
Backport "Use result of lambda type of implicit in CheckUnused" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
@@ -964,7 +964,7 @@ object CheckUnused:
     def isCanEqual: Boolean =
       sym.isOneOf(GivenOrImplicit) && sym.info.finalResultType.baseClasses.exists(_.derivesFrom(defn.CanEqualClass))
     def isMarkerTrait: Boolean =
-      sym.info.hiBound.allMembers.forall: d =>
+      sym.info.hiBound.resultType.allMembers.forall: d =>
         val m = d.symbol
         !m.isTerm || m.isSelfSym || m.is(Method) && (m.owner == defn.AnyClass || m.owner == defn.ObjectClass)
     def isEffectivelyPrivate: Boolean =

--- a/tests/warn/i15503f.scala
+++ b/tests/warn/i15503f.scala
@@ -1,4 +1,4 @@
-//> using options  -Wunused:implicits
+//> using options -Wunused:implicits
 
 /* This goes around the "trivial method" detection */
 val default_int = 1
@@ -58,6 +58,8 @@ package givens:
   trait Y:
     def doY: String
 
+  trait Z
+
   given X with
     def doX = 7
 
@@ -75,6 +77,9 @@ package givens:
 
   given namely (using x: X): Y with // warn protected param to given class
     def doY = "8"
+
+  def f(using => X) = println() // warn
+  def g(using => Z) = println() // nowarn marker trait
 end givens
 
 object i22895:

--- a/tests/warn/i23494.scala
+++ b/tests/warn/i23494.scala
@@ -1,0 +1,15 @@
+//> using options -Wunused:implicits
+
+import scala.deriving.Mirror
+
+abstract class EnumerationValues[A]:
+  type Out
+
+object EnumerationValues:
+  type Aux[A, B] = EnumerationValues[A] { type Out = B }
+
+  def apply[A, B](): EnumerationValues.Aux[A, B] = new EnumerationValues[A]:
+    override type Out = B
+
+  given sum[A, B <: Tuple](using mirror: Mirror.SumOf[A] { type MirroredElemTypes = B }): EnumerationValues.Aux[A, A] =
+    EnumerationValues[A, A]()


### PR DESCRIPTION
Backports #23497 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]