### PR TITLE
Backport "Update indentation.md to fix a typo" to 3.3 LTS

### DIFF
--- a/docs/_docs/reference/other-new-features/indentation.md
+++ b/docs/_docs/reference/other-new-features/indentation.md
@@ -189,7 +189,7 @@ Define for an arbitrary sequence of tokens or non-terminals `TS`:
 
 ```ebnf
 :<<< TS >>>   ::=   ‘{’ TS ‘}’
-                |   <colon> <indent" TS <outdent>
+                |   <colon> <indent> TS <outdent>
 ```
 Then the grammar changes as follows:
 ```ebnf


### PR DESCRIPTION
Backports #23505 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]