### PR TITLE
Backport "fix: #23261 Distinguish 0.0 and -0.0 in ConstantType match types" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -390,7 +390,7 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
         compareErasedValueType
       case ConstantType(v2) =>
         tp1 match {
-          case ConstantType(v1) => v1.value == v2.value && recur(v1.tpe, v2.tpe)
+          case ConstantType(v1) => v1 == v2 && recur(v1.tpe, v2.tpe)
           case _ => secondTry
         }
       case tp2: AnyConstantType =>

--- a/tests/neg/i23261.scala
+++ b/tests/neg/i23261.scala
@@ -1,0 +1,7 @@
+@main def main(): Unit =
+  summon[0.0 =:= -0.0]   // error: Cannot prove that (0.0: Double) =:= (-0.0: Double).
+  val d: 0.0 = -0.0      // error: Cannot prove that (0.0: Double) =:= (-0.0: Double).
+  val d2: -0.0 = 0.0     // error: Cannot prove that (-0.0: Double) =:= (0.0: Double).
+  summon[0.0f =:= -0.0f] // error: Cannot prove that (0.0f: Float) =:= (-0.0f: Float).
+  val f: 0.0f = -0.0f    // error: Cannot prove that (0.0f: Float) =:= (-0.0f: Float).
+  val f2: -0.0f = 0.0f   // error: Cannot prove that (-0.0f: Float) =:= (0.0f: Float).

--- a/tests/pos/i23261.scala
+++ b/tests/pos/i23261.scala
@@ -1,0 +1,46 @@
+type DoubleToString[D <: Double] <: String = D match
+  case 0.0 => "0.0"
+  case -0.0 => "-0.0"
+  case _ => "_"
+
+type DoubleToString2[D <: Double] <: String = D match
+  case 0.0 => "0.0"
+  case _ => "_"
+
+type DoubleToString3[D <: Double] <: String = D match
+  case -0.0 => "-0.0"
+  case _ => "_"
+
+type FloatToString[F <: Float] <: String = F match
+  case 0.0f => "0.0f"
+  case -0.0f => "-0.0f"
+  case _ => "_"
+
+type FloatToString2[F <: Float] <: String = F match
+  case 0.0f => "0.0f"
+  case _ => "_"
+
+type FloatToString3[F <: Float] <: String = F match
+  case -0.0f => "-0.0f"
+  case _ => "_"
+
+@main def main(): Unit = {
+  summon[0.0 =:= 0.0]
+  summon[-0.0 =:= -0.0]
+  summon[DoubleToString[0.0] =:= "0.0"]
+  summon[DoubleToString[-0.0] =:= "-0.0"]
+  summon[DoubleToString[3.14] =:= "_"]
+  summon[DoubleToString2[0.0] =:= "0.0"]
+  summon[DoubleToString2[-0.0] =:= "_"]
+  summon[DoubleToString3[-0.0] =:= "-0.0"]
+  summon[DoubleToString3[0.0] =:= "_"]
+  summon[0.0f =:= 0.0f]
+  summon[-0.0f =:= -0.0f]
+  summon[FloatToString[0.0f] =:= "0.0f"]
+  summon[FloatToString[-0.0f] =:= "-0.0f"]
+  summon[FloatToString[3.14f] =:= "_"]
+  summon[FloatToString2[0.0f] =:= "0.0f"]
+  summon[FloatToString2[-0.0f] =:= "_"]
+  summon[FloatToString3[-0.0f] =:= "-0.0f"]
+  summon[FloatToString3[0.0f] =:= "_"]
+}


### PR DESCRIPTION
Backports #23265 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]