### PR TITLE
Backport "Guard against invalid prefixes in argForParam" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -2261,7 +2261,7 @@ object Types extends TypeUtils {
     def _1: Type
     def _2: Designator
 
-    assert(NamedType.validPrefix(prefix), s"invalid prefix $prefix")
+    if !NamedType.validPrefix(prefix) then throw InvalidPrefix()
 
     private var myName: Name | Null = null
     private var lastDenotation: Denotation | Null = null
@@ -2682,10 +2682,7 @@ object Types extends TypeUtils {
           while (tparams.nonEmpty && args.nonEmpty) {
             if (tparams.head.eq(tparam))
               return args.head match {
-                case _: TypeBounds if !widenAbstract =>
-                  if !NamedType.validPrefix(pre) then
-                    throw TypeError(em"invalid prefix $pre cannot replace parameter $tparam in result of selection")
-                  TypeRef(pre, tparam)
+                case _: TypeBounds if !widenAbstract => TypeRef(pre, tparam)
                 case arg => arg
               }
             tparams = tparams.tail
@@ -3040,6 +3037,8 @@ object Types extends TypeUtils {
     def apply(prefix: Type, name: TypeName, denot: Denotation)(using Context): TypeRef =
       apply(prefix, designatorFor(prefix, name, denot)).withDenot(denot)
   }
+
+  class InvalidPrefix extends Exception
 
   // --- Other SingletonTypes: ThisType/SuperType/ConstantType ---------------------------
 

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -2682,8 +2682,11 @@ object Types extends TypeUtils {
           while (tparams.nonEmpty && args.nonEmpty) {
             if (tparams.head.eq(tparam))
               return args.head match {
-                case _: TypeBounds if !widenAbstract => TypeRef(pre, tparam)
-                case arg => arg.boxedUnlessFun(tycon)
+                case _: TypeBounds if !widenAbstract =>
+                  if !NamedType.validPrefix(pre) then
+                    throw TypeError(em"invalid prefix $pre cannot replace parameter $tparam in result of selection")
+                  TypeRef(pre, tparam)
+                case arg => arg
               }
             tparams = tparams.tail
             args = args.tail

--- a/tests/neg/i23504.scala
+++ b/tests/neg/i23504.scala
@@ -1,0 +1,2 @@
+def test =
+  Seq.empty[[T] =>> () => ?].head() // error

--- a/tests/neg/i23504.scala
+++ b/tests/neg/i23504.scala
@@ -1,2 +1,3 @@
 def test =
   Seq.empty[[T] =>> () => ?].head() // error
+  Seq.empty[[T] =>> Int => Int].head(1) // error


### PR DESCRIPTION
Backports #23508 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]