### PR TITLE
Backport "Check path of module prefix for tailrec" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/TailRec.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TailRec.scala
@@ -344,7 +344,10 @@ class TailRec extends MiniPhase {
               case prefix: This if prefix.symbol == enclosingClass =>
                 // Avoid assigning `this = this`
                 assignParamPairs
-              case prefix if prefix.symbol.is(Module) && prefix.symbol.moduleClass == enclosingClass =>
+              case prefix
+              if prefix.symbol.is(Module)
+              && prefix.symbol.moduleClass == enclosingClass
+              && isPurePath(prefix) =>
                 // Avoid assigning `this = MyObject`
                 assignParamPairs
               case _ =>

--- a/tests/run/i23444.scala
+++ b/tests/run/i23444.scala
@@ -1,0 +1,22 @@
+
+import annotation.*
+
+class Path(action: () => Unit, parent: Option[Path]):
+  object O:
+    @tailrec
+    def apply(): Unit =
+      action()
+
+      parent match
+        case Some(p) =>
+          p.O.apply()
+        case None =>
+
+@main def Test: Unit =
+  var counter = 0
+  val fun = () => {
+    counter += 1
+    if counter > 2 then throw AssertionError("bad loop")
+  }
+  val path = Path(fun, Some(Path(fun, None)))
+  path.O()


### PR DESCRIPTION
Backports #23491 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]