### PR TITLE
Backport "Don't approximate a type using `Nothing` as prefix" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -792,6 +792,8 @@ object Types extends TypeUtils {
           goOr(tp)
         case tp: JavaArrayType =>
           defn.ObjectType.findMember(name, pre, required, excluded)
+        case tp: WildcardType =>
+          go(tp.bounds)
         case err: ErrorType =>
           newErrorSymbol(pre.classSymbol.orElse(defn.RootClass), name, err.msg)
         case _ =>
@@ -6052,9 +6054,24 @@ object Types extends TypeUtils {
   abstract class ApproximatingTypeMap(using Context) extends TypeMap { thisMap =>
 
     protected def range(lo: Type, hi: Type): Type =
-      if (variance > 0) hi
-      else if (variance < 0) lo
-      else if (lo `eq` hi) lo
+      if variance > 0 then hi
+      else if variance < 0 then
+        if (lo eq defn.NothingType) && hi.hasSimpleKind then
+          // Approximate by Nothing & hi instead of just Nothing, in case the
+          // approximated type is used as the prefix of another type (this would
+          // lead to a type with a `NoDenotation` denot and a possible
+          // MissingType in `TypeErasure#sigName`).
+          //
+          // Note that we cannot simply check for a `Nothing` prefix in
+          // `derivedSelect`, because the substitution might be done lazily (for
+          // example if Nothing is the type of a parameter being depended on in
+          // a MethodType)
+          //
+          // Test case in tests/pos/i23530.scala
+          AndType(lo, hi)
+        else
+          lo
+      else if lo `eq` hi then lo
       else Range(lower(lo), upper(hi))
 
     protected def emptyRange = range(defn.NothingType, defn.AnyType)

--- a/presentation-compiler/src/main/dotty/tools/pc/printer/ShortenedTypePrinter.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/printer/ShortenedTypePrinter.scala
@@ -17,8 +17,7 @@ import dotty.tools.dotc.core.Names
 import dotty.tools.dotc.core.Names.Name
 import dotty.tools.dotc.core.Names.NameOrdering
 import dotty.tools.dotc.core.StdNames
-import dotty.tools.dotc.core.Symbols.NoSymbol
-import dotty.tools.dotc.core.Symbols.Symbol
+import dotty.tools.dotc.core.Symbols.*
 import dotty.tools.dotc.core.Types.*
 import dotty.tools.dotc.core.Types.Type
 import dotty.tools.dotc.printing.RefinedPrinter
@@ -254,7 +253,6 @@ class ShortenedTypePrinter(
   end hoverSymbol
 
   def isImportedByDefault(sym: Symbol): Boolean =
-    import dotty.tools.dotc.core.Symbols.defn
     lazy val effectiveOwner = sym.effectiveOwner
     sym.isType && (effectiveOwner == defn.ScalaPackageClass || effectiveOwner == defn.ScalaPredefModuleClass)
 
@@ -496,9 +494,9 @@ class ShortenedTypePrinter(
     val info = nameToInfo
       .get(param.name)
       .flatMap { info =>
-        // In some cases, paramInfo becomes Nothing (e.g. CompletionOverrideSuite#cake)
+        // In some cases, paramInfo becomes `... & Nothing` (e.g. CompletionOverrideSuite#cake)
         // which is meaningless, in that case, fallback to param.info
-        if info.isNothingType then None
+        if info <:< defn.NothingType then None
         else Some(info)
       }
       .getOrElse(param.info)

--- a/tests/pos/i23530.scala
+++ b/tests/pos/i23530.scala
@@ -1,0 +1,18 @@
+trait TestContainer:
+  trait TestPath:
+    type AbsMember
+
+  extension (path: TestPath)
+    infix def ext(color: path.AbsMember): Unit = ???
+    infix def ext(other: Int): Unit = ???
+
+object Repro:
+  val dc2: TestContainer = ???
+  import dc2.TestPath
+
+  def transition(path: TestPath)(using DummyImplicit): TestPath = ???
+
+  def test: Unit =
+    val di: TestPath = ???
+    // error
+    val z1 = transition(di).ext(1)


### PR DESCRIPTION
Backports #23531 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]