### PR TITLE
Backport "Check OrType in interpolated toString lint" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/localopt/StringInterpolatorOpt.scala
+++ b/compiler/src/dotty/tools/dotc/transform/localopt/StringInterpolatorOpt.scala
@@ -109,9 +109,20 @@ class StringInterpolatorOpt extends MiniPhase:
       result
     end mkConcat
     def lintToString(t: Tree): Unit =
-      val arg: Type = t.tpe
-      if ctx.settings.Whas.toStringInterpolated && !(arg.widen =:= defn.StringType) && !arg.isPrimitiveValueType
-      then report.warning("interpolation uses toString", t.srcPos)
+      def checkIsStringify(tp: Type): Boolean = tp.widen match
+        case OrType(tp1, tp2) =>
+          checkIsStringify(tp1) || checkIsStringify(tp2)
+        case tp =>
+          !(tp =:= defn.StringType)
+          && {
+              tp =:= defn.UnitType
+              && { report.warning("interpolated Unit value", t.srcPos); true }
+            ||
+              !tp.isPrimitiveValueType
+              && { report.warning("interpolation uses toString", t.srcPos); true }
+          }
+      if ctx.settings.Whas.toStringInterpolated then
+        checkIsStringify(t.tpe): Unit
     val sym = tree.symbol
     // Test names first to avoid loading scala.StringContext if not used, and common names first
     val isInterpolatedMethod =


### PR DESCRIPTION
Backports #23365 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]