### PR TITLE
Backport "Quotes reflect: sort the typeMembers output list and filter out non-members" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -984,6 +984,23 @@ object Types extends TypeUtils {
       buf.toList
     }
 
+    /** For use in quotes reflect.
+     *  A bit slower than the usual approach due to the use of LinkedHashSet.
+     **/
+    def sortedParents(using Context): mutable.LinkedHashSet[Type] = this match
+      case tp: ClassInfo =>
+        mutable.LinkedHashSet(tp) | mutable.LinkedHashSet(tp.declaredParents.flatMap(_.sortedParents.toList)*)
+      case tp: RefinedType =>
+        tp.parent.sortedParents
+      case tp: TypeProxy =>
+        tp.superType.sortedParents
+      case tp: AndType =>
+        tp.tp1.sortedParents | tp.tp2.sortedParents
+      case tp: OrType =>
+        tp.tp1.sortedParents & tp.tp2.sortedParents
+      case _ =>
+        mutable.LinkedHashSet()
+
     /** The set of abstract term members of this type. */
     final def abstractTermMembers(using Context): Seq[SingleDenotation] = {
       record("abstractTermMembers")

--- a/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
+++ b/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
@@ -2757,7 +2757,33 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
         def memberTypes: List[Symbol] =
           self.typeRef.decls.filter(_.isType)
         def typeMembers: List[Symbol] =
-          lookupPrefix.typeMembers.map(_.symbol).toList
+          // lookupPrefix.typeMembers currently returns a Set wrapped into a unsorted Seq,
+          // so we try to sort that here (see discussion: https://github.com/scala/scala3/issues/22472),
+          // without adding too much of a performance hit.
+          // It first sorts by parents, then for type params by their positioning, then for members
+          // derived from declarations it sorts them by their name lexicographically
+          val parentsMap = lookupPrefix.sortedParents.map(_.typeSymbol).zipWithIndex.toList.toMap
+          val unsortedTypeMembers = lookupPrefix.typeMembers.map(_.symbol).filter(_.exists).toList
+          unsortedTypeMembers.sortWith {
+            case (typeA, typeB) =>
+              val msg = "Unknown type member found. Please consider reporting the issue to the compiler. "
+              assert(parentsMap.contains(typeA.owner), msg)
+              assert(parentsMap.contains(typeB.owner), msg)
+              val parentPlacementA = parentsMap(typeA.owner)
+              val parentPlacementB = parentsMap(typeB.owner)
+              if (parentPlacementA == parentPlacementB) then
+                if typeA.isTypeParam && typeB.isTypeParam then
+                  // put type params at the beginning (and sort them by declaration order)
+                  val pl = typeA.owner
+                  val typeParamPositionMap = pl.typeParams.map(_.asInstanceOf[Symbol]).zipWithIndex.toMap
+                  typeParamPositionMap(typeA) < typeParamPositionMap(typeB)
+                else if typeA.isTypeParam then true
+                else if typeB.isTypeParam then false
+                else
+                  // sort by name lexicographically
+                  typeA.name.toString().compareTo(typeB.name.toString()) < 0
+              else parentPlacementA < parentPlacementB
+          }.map(_.asInstanceOf[Symbol])
 
         def declarations: List[Symbol] =
           self.typeRef.info.decls.toList

--- a/tests/run-macros/i14902.check
+++ b/tests/run-macros/i14902.check
@@ -1,4 +1,4 @@
 List(X)
-List(X, Y, Z)
+List(Y, Z, X)
 List(X)
 List(Y, Z)

--- a/tests/run-macros/type-members.check
+++ b/tests/run-macros/type-members.check
@@ -1,0 +1,8 @@
+class FooSmall: List(type A, type B, type C, type D)
+class FooLarge: List(type A, type B, type C, type D, type E)
+type FooUnion: List()
+type FooAnd: List(type A, type B, type C, type D, type E)
+trait CLS1: List(type A, type B, type C, type B1, type B2, type A3, type B3, type B4)
+type SharedAnd1: List(type B, type Shared, type A, type C)
+type SharedAnd2: List(type C, type Shared, type A, type B)
+type SharedUnion: List(type A, type Shared)

--- a/tests/run-macros/type-members/Macro_1.scala
+++ b/tests/run-macros/type-members/Macro_1.scala
@@ -1,0 +1,12 @@
+package example
+
+import scala.quoted.*
+
+object Macro {
+  inline def typeMembers[T <: AnyKind]: String = ${ typeMembersImpl[T] }
+
+  def typeMembersImpl[T <: AnyKind: Type](using quotes: Quotes): Expr[String] = {
+    import quotes.reflect.*
+    Expr(s"${TypeRepr.of[T].typeSymbol}: ${TypeRepr.of[T].typeSymbol.typeMembers.toString}")
+  }
+}

--- a/tests/run-macros/type-members/Test_2.scala
+++ b/tests/run-macros/type-members/Test_2.scala
@@ -1,0 +1,33 @@
+import example.Macro
+
+class FooSmall[A, B] { type D; type C }
+class FooLarge[A, B, C] { type E; type D }
+
+type FooUnion[A, B] = FooSmall[A, B] | FooLarge[A, B, Int]
+type FooAnd[A, B] = FooSmall[A, B] & FooLarge[A, B, Int]
+
+trait CLS4[A] { type B4 }
+trait CLS3[A] extends CLS4[A] { type B3; type A3 }
+trait CLS2[A] { type B2 }
+trait CLS1[A, B, C] extends CLS2[A] with CLS3[B] { type B1 }
+
+trait SharedParent[A] { type Shared }
+trait SharedA[A] extends SharedParent[A] { type B }
+trait SharedB[A] extends SharedParent[A] { type C }
+type SharedAnd1[A] = SharedA[A] & SharedB[A]
+type SharedAnd2[A] = SharedB[A] & SharedA[A]
+type SharedUnion[A] = SharedA[A] | SharedB[A]
+
+@main def Test(): Unit = {
+  println(Macro.typeMembers[FooSmall])
+  println(Macro.typeMembers[FooLarge])
+
+  println(Macro.typeMembers[FooUnion])
+  println(Macro.typeMembers[FooAnd])
+
+  println(Macro.typeMembers[CLS1])
+
+  println(Macro.typeMembers[SharedAnd1])
+  println(Macro.typeMembers[SharedAnd2])
+  println(Macro.typeMembers[SharedUnion])
+}


### PR DESCRIPTION
Backports #22876 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]