### PR TITLE
Backport "[build] Increment default thread stack size from to 2MB (was 1MB)" to 3.3 LTS

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,5 +1,5 @@
--Xss1m
--Xms512m
--Xmx4096m
+-Xss2m
+-Xms1024m
+-Xmx8192m
 -XX:MaxInlineLevel=35
 -XX:ReservedCodeCacheSize=512m


### PR DESCRIPTION
Backports #23638 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]