### PR TITLE
Backport "Generalize "Don't approximate a type using Nothing as prefix"" to 3.3 LTS

### DIFF
--- a/tests/pos/i23627.scala
+++ b/tests/pos/i23627.scala
@@ -1,0 +1,18 @@
+trait TestContainer:
+  trait TestPath[T]:
+    type AbsMember
+
+  extension (path: TestPath[?])
+    infix def ext(color: path.AbsMember): Unit = ???
+    infix def ext(other: Int): Unit = ???
+
+object Repro:
+  val dc2: TestContainer = ???
+  import dc2.TestPath
+
+  def transition(path: TestPath[?])(using DummyImplicit): TestPath[?] = ???
+
+  def test: Unit =
+    val di: TestPath[?] = ???
+    // error
+    val z1 = transition(di).ext(1)


### PR DESCRIPTION
Backports #23628 to the 3.3.7.

PR submitted by the release tooling.