### PR TITLE
Backport "Use more context for implicit search only if no default argument" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -4985,17 +4985,11 @@ object Types extends TypeUtils {
      */
     private def currentEntry(using Context): Type = ctx.typerState.constraint.entry(origin)
 
-    /** For uninstantiated type variables: the lower bound */
-    def lowerBound(using Context): Type = currentEntry.loBound
-
-    /** For uninstantiated type variables: the upper bound */
-    def upperBound(using Context): Type = currentEntry.hiBound
-
     /** For uninstantiated type variables: Is the lower bound different from Nothing? */
-    def hasLowerBound(using Context): Boolean = !lowerBound.isExactlyNothing
+    def hasLowerBound(using Context): Boolean = !currentEntry.loBound.isExactlyNothing
 
     /** For uninstantiated type variables: Is the upper bound different from Any? */
-    def hasUpperBound(using Context): Boolean = !upperBound.isTopOfSomeKind
+    def hasUpperBound(using Context): Boolean = !currentEntry.hiBound.isTopOfSomeKind
 
     /** Unwrap to instance (if instantiated) or origin (if not), until result
      *  is no longer a TypeVar

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -4985,11 +4985,17 @@ object Types extends TypeUtils {
      */
     private def currentEntry(using Context): Type = ctx.typerState.constraint.entry(origin)
 
+    /** For uninstantiated type variables: the lower bound */
+    def lowerBound(using Context): Type = currentEntry.loBound
+
+    /** For uninstantiated type variables: the upper bound */
+    def upperBound(using Context): Type = currentEntry.hiBound
+
     /** For uninstantiated type variables: Is the lower bound different from Nothing? */
-    def hasLowerBound(using Context): Boolean = !currentEntry.loBound.isExactlyNothing
+    def hasLowerBound(using Context): Boolean = !lowerBound.isExactlyNothing
 
     /** For uninstantiated type variables: Is the upper bound different from Any? */
-    def hasUpperBound(using Context): Boolean = !currentEntry.hiBound.isTopOfSomeKind
+    def hasUpperBound(using Context): Boolean = !upperBound.isTopOfSomeKind
 
     /** Unwrap to instance (if instantiated) or origin (if not), until result
      *  is no longer a TypeVar

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -3836,6 +3836,12 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
 
       def addImplicitArgs(using Context) =
         def hasDefaultParams = methPart(tree).symbol.hasDefaultParams
+        def findDefaultArgument(argIndex: Int): Tree =
+          def appPart(t: Tree): Tree = t match
+            case Block(_, expr)      => appPart(expr)
+            case Inlined(_, _, expr) => appPart(expr)
+            case t => t
+          defaultArgument(appPart(tree), n = argIndex, testOnly = false)
         def implicitArgs(formals: List[Type], argIndex: Int, pt: Type): List[Tree] = formals match
           case Nil => Nil
           case formal :: formals1 =>
@@ -3851,11 +3857,17 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
 
             val arg = inferImplicitArg(formal, tree.span.endPos)
 
+            lazy val defaultArg = findDefaultArgument(argIndex)
+              .showing(i"default argument: for $formal, $tree, $argIndex = $result", typr)
+            def argHasDefault = hasDefaultParams && !defaultArg.isEmpty
+
             def canProfitFromMoreConstraints =
               arg.tpe.isInstanceOf[AmbiguousImplicits]
-                    // ambiguity could be decided by more constraints
-              || !isFullyDefined(formal, ForceDegree.none)
-                    // more context might constrain type variables which could make implicit scope larger
+                    // Ambiguity could be decided by more constraints
+              || !isFullyDefined(formal, ForceDegree.none) && !argHasDefault
+                    // More context might constrain type variables which could make implicit scope larger.
+                    // But in this case we should search with additional arguments typed only if there
+                    // is no default argument.
 
             arg.tpe match
               case failed: SearchFailureType if canProfitFromMoreConstraints =>
@@ -3868,20 +3880,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
               case failed: AmbiguousImplicits =>
                 arg :: implicitArgs(formals1, argIndex + 1, pt)
               case failed: SearchFailureType =>
-                lazy val defaultArg =
-                  def appPart(t: Tree): Tree = t match
-                    case Block(stats, expr) => appPart(expr)
-                    case Inlined(_, _, expr) => appPart(expr)
-                    case _ => t
-                  defaultArgument(appPart(tree), argIndex, testOnly = false)
-                    .showing(i"default argument: for $formal, $tree, $argIndex = $result", typr)
-                if !hasDefaultParams || defaultArg.isEmpty then
-                  // no need to search further, the adapt fails in any case
-                  // the reason why we continue inferring arguments in case of an AmbiguousImplicits
-                  // is that we need to know whether there are further errors.
-                  // If there are none, we have to propagate the ambiguity to the caller.
-                  arg :: formals1.map(dummyArg)
-                else
+                if argHasDefault then
                   // This is tricky. On the one hand, we need the defaultArg to
                   // correctly type subsequent formal parameters in the same using
                   // clause in case there are parameter dependencies. On the other hand,
@@ -3892,6 +3891,12 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
                   // `if propFail.exists` where we re-type the whole using clause with named
                   // arguments for all implicits that were found.
                   arg :: inferArgsAfter(defaultArg)
+                else
+                  // no need to search further, the adapt fails in any case
+                  // the reason why we continue inferring arguments in case of an AmbiguousImplicits
+                  // is that we need to know whether there are further errors.
+                  // If there are none, we have to propagate the ambiguity to the caller.
+                  arg :: formals1.map(dummyArg)
               case _ =>
                 arg :: inferArgsAfter(arg)
         end implicitArgs


### PR DESCRIPTION
Backports #23664 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]