### PR TITLE
Backport "scaladoc: indicate optional parameters with `= ...`" to 3.3 LTS

### DIFF
--- a/scaladoc-testcases/src/tests/extendsCall.scala
+++ b/scaladoc-testcases/src/tests/extendsCall.scala
@@ -3,4 +3,4 @@ package extendsCall
 
 class Impl() extends Base(Seq.empty, c = "-") //expected: class Impl() extends Base
 
-class Base(val a: Seq[String], val b: String = "", val c: String = "") //expected: class Base(val a: Seq[String], val b: String, val c: String)
+class Base(val a: Seq[String], val b: String = "", val c: String = "") //expected: class Base(val a: Seq[String], val b: String = ..., val c: String = ...)

--- a/scaladoc-testcases/src/tests/optionalParams.scala
+++ b/scaladoc-testcases/src/tests/optionalParams.scala
@@ -1,0 +1,23 @@
+package tests
+package optionalParams
+
+class C(val a: Seq[String], val b: String = "", var c: String = "") //expected: class C(val a: Seq[String], val b: String = ..., var c: String = ...)
+{
+  def m(x: Int, s: String = "a"): Nothing //expected: def m(x: Int, s: String = ...): Nothing
+    = ???
+}
+
+def f(x: Int, s: String = "a"): Nothing //expected: def f(x: Int, s: String = ...): Nothing
+  = ???
+
+extension (y: Int)
+  def ext(x: Int = 0): Int //expected: def ext(x: Int = ...): Int
+    = 0
+
+def byname(s: => String = "a"): Int //expected: def byname(s: => String = ...): Int
+  = 0
+
+enum E(val x: Int = 0) //expected: enum E(val x: Int = ...)
+{
+  case E1(y: Int = 10) extends E(y) //expected: final case class E1(y: Int = ...) extends E
+}

--- a/scaladoc/src/dotty/tools/scaladoc/tasty/ClassLikeSupport.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/ClassLikeSupport.scala
@@ -443,12 +443,13 @@ trait ClassLikeSupport:
     val inlinePrefix = if argument.symbol.flags.is(Flags.Inline) then "inline " else ""
     val nameIfNotSynthetic = Option.when(!argument.symbol.flags.is(Flags.Synthetic))(argument.symbol.normalizedName)
     val name = argument.symbol.normalizedName
+    val defaultValue = Option.when(argument.symbol.flags.is(Flags.HasDefault))(Plain(" = ..."))
     api.TermParameter(
       argument.symbol.getAnnotations(),
       inlinePrefix + prefix(argument.symbol),
       nameIfNotSynthetic,
       argument.symbol.dri,
-      memberInfo.get(name).fold(argument.tpt.asSignature(classDef))(_.asSignature(classDef)),
+      memberInfo.get(name).fold(argument.tpt.asSignature(classDef))(_.asSignature(classDef)) :++ defaultValue,
       isExtendedSymbol,
       isGrouped
     )

--- a/scaladoc/src/dotty/tools/scaladoc/tasty/TypesSupport.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/TypesSupport.scala
@@ -233,7 +233,7 @@ trait TypesSupport:
             tpe(tp.typeSymbol)
           case _: TermRef | _: ParamRef =>
             val suffix = if tp.typeSymbol == Symbol.noSymbol then tpe(typeName).l else tpe(tp.typeSymbol)
-            inner(qual)(using skipTypeSuffix = true) ++ plain(".").l ++ suffix
+            inner(qual)(using indent = indent, skipTypeSuffix = true) ++ plain(".").l ++ suffix
           case ThisType(tr) =>
             findSupertype(elideThis, tr.typeSymbol) match
               case Some((sym, AppliedType(tr2, args))) =>
@@ -250,7 +250,7 @@ trait TypesSupport:
                 val sig = inParens(inner(qual)(using indent = indent, skipTypeSuffix = true), wrapping)
                 sig ++ plain(".").l ++ tpe(tp.typeSymbol)
           case _ =>
-            val sig = inParens(inner(qual, skipThisTypePrefix), wrapping)
+            val sig = inParens(inner(qual), wrapping)
             sig ++ keyword("#").l ++ tpe(tp.typeSymbol)
         }
 

--- a/scaladoc/test/dotty/tools/scaladoc/signatures/TranslatableSignaturesTestCases.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/signatures/TranslatableSignaturesTestCases.scala
@@ -124,3 +124,5 @@ class InfixTypes extends SignatureTest("infixTypes", SignatureTest.all)
 class ExtendsCall extends SignatureTest("extendsCall", SignatureTest.all)
 
 class RightAssocExtension extends SignatureTest("rightAssocExtension", SignatureTest.all)
+
+class OptionalParams extends SignatureTest("optionalParams", SignatureTest.all)

--- a/tests/neg/i19414.scala
+++ b/tests/neg/i19414.scala
@@ -9,7 +9,7 @@ class Printer
 given Writer[JsValue] = ???
 given Writer[JsObject] = ???
 
-given [B: Writer] => (printer: Printer = new Printer) => BodySerializer[B] = ???
+given [B: Writer](using printer: Printer = new Printer): BodySerializer[B] = ???
 
 def f: Unit =
   summon[BodySerializer[JsObject]] // error: Ambiguous given instances


### PR DESCRIPTION
Backports #23676 to the 3.3.7.

PR submitted by the release tooling.