### PR TITLE
Backport "Refine isEffectivelyFinal to avoid no-owner crash" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -1185,7 +1185,7 @@ object SymDenotations {
       || is(Inline, butNot = Deferred)
       || is(JavaDefinedVal, butNot = Method)
       || isConstructor
-      || !owner.isExtensibleClass
+      || exists && !owner.isExtensibleClass
 
     /** A class is effectively sealed if has the `final` or `sealed` modifier, or it
      *  is defined in Scala 3 and is neither abstract nor open.

--- a/tests/neg/i23637.check
+++ b/tests/neg/i23637.check
@@ -1,0 +1,6 @@
+-- [E083] Type Error: tests/neg/i23637.scala:6:9 -----------------------------------------------------------------------
+6 |  export foo.pin.* // error: (because we need reflection to get at foo.pin)
+  |         ^^^^^^^
+  |         (Test.foo.pin : Object) is not a valid export prefix, since it is not an immutable path
+  |
+  | longer explanation available when compiling with `-explain`

--- a/tests/neg/i23637.scala
+++ b/tests/neg/i23637.scala
@@ -1,0 +1,12 @@
+trait Foo extends reflect.Selectable
+object Test:
+  val foo = new Foo:
+    object pin:
+      val x = 1
+  export foo.pin.* // error: (because we need reflection to get at foo.pin)
+
+object OK:
+  object Foo:
+    object pin:
+      val x = 1
+  export Foo.pin.*


### PR DESCRIPTION
Backports #23675 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]