### PR TITLE
Backport "Replace internal tab char in comment in Synthesizer.scala" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
@@ -37,16 +37,16 @@ class Synthesizer(typer: Typer)(using @constructorOnly c: Context):
         // bounds are usually widened during instantiation.
         instArg(tp.tp1)
       case tvar: TypeVar if ctx.typerState.constraint.contains(tvar) =>
-      	// If tvar has a lower or upper bound:
-      	//   1. If the bound is not another type variable, use this as approximation.
-      	//   2. Otherwise, if the type can be forced to be fully defined, use that type
-      	//      as approximation.
-      	//   3. Otherwise leave argument uninstantiated.
-      	// The reason for (2) is that we observed complicated constraints in i23611.scala
-      	// that get better types if a fully defined type is computed than if several type
-      	// variables are approximated incrementally. This is a minimization of some ZIO code.
-      	// So in order to keep backwards compatibility (where before we _only_ did 2) we
-      	// add that special case.
+        // If tvar has a lower or upper bound:
+        //   1. If the bound is not another type variable, use this as approximation.
+        //   2. Otherwise, if the type can be forced to be fully defined, use that type
+        //      as approximation.
+        //   3. Otherwise leave argument uninstantiated.
+        // The reason for (2) is that we observed complicated constraints in i23611.scala
+        // that get better types if a fully defined type is computed than if several type
+        // variables are approximated incrementally. This is a minimization of some ZIO code.
+        // So in order to keep backwards compatibility (where before we _only_ did 2) we
+        // add that special case.
         def isGroundConstr(tp: Type): Boolean = tp.dealias match
           case tvar: TypeVar if ctx.typerState.constraint.contains(tvar) => false
           case pref: TypeParamRef if ctx.typerState.constraint.contains(pref) => false


### PR DESCRIPTION
Backports #23691 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]