### PR TITLE
Backport "Fix issue with pc breaking in requiredMethod on newly overloaded valueOf" to 3.3 LTS

### DIFF
--- a/presentation-compiler/src/main/dotty/tools/pc/completions/Completions.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/Completions.scala
@@ -736,15 +736,18 @@ class Completions(
     defn.Object_notifyAll,
     defn.Object_notify,
     defn.Predef_undefined,
-    defn.ObjectClass.info.member(nme.wait_).symbol,
     // NOTE(olafur) IntelliJ does not complete the root package and without this filter
     // then `_root_` would appear as a completion result in the code `foobar(_<COMPLETE>)`
     defn.RootPackage,
     // NOTE(gabro) valueOf was added as a Predef member in 2.13. We filter it out since is a niche
     // use case and it would appear upon typing 'val'
-    defn.ValueOfClass.info.member(nme.valueOf).symbol,
-    defn.ScalaPredefModule.requiredMethod(nme.valueOf)
-  ).flatMap(_.alternatives.map(_.symbol)).toSet
+    defn.ValueOfClass
+  ) ++ (
+    Set(
+      defn.ObjectClass.info.member(nme.wait_),
+      defn.ScalaPredefModule.info.member(nme.valueOf)
+    ).flatMap(_.alternatives.map(_.symbol)).toSet
+  )
 
   private def isNotLocalForwardReference(sym: Symbol)(using Context): Boolean =
     !sym.isLocalToBlock ||

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
@@ -128,9 +128,6 @@ class CompletionSuite extends BaseCompletionSuite:
          |isInstanceOf[X0]: Boolean
          |synchronized[X0](x$0: X0): X0
          |toString(): String
-         |wait(): Unit
-         |wait(x$0: Long): Unit
-         |wait(x$0: Long, x$1: Int): Unit
          |""".stripMargin
     )
 


### PR DESCRIPTION
Backports #23708 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]