### PR TITLE
Backport "Bump actions/download-artifact from 4 to 5" to 3.3 LTS

### DIFF
--- a/.github/workflows/publish-chocolatey.yml
+++ b/.github/workflows/publish-chocolatey.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Fetch the Chocolatey package from GitHub
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: scala.nupkg
       - name: Publish the package to Chocolatey

--- a/.github/workflows/test-chocolatey.yml
+++ b/.github/workflows/test-chocolatey.yml
@@ -35,7 +35,7 @@ jobs:
           distribution: temurin
           java-version: ${{ inputs.java-version }}
       - name: Download the 'nupkg' from GitHub Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: scala.nupkg
           path: ${{ env.CHOCOLATEY-REPOSITORY }}


### PR DESCRIPTION
Backports #23711 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]