### PR TITLE
Backport "chore(deps): bump actions/setup-java from 4 to 5" to 3.3 LTS

### DIFF
--- a/.github/workflows/build-sdk.yml
+++ b/.github/workflows/build-sdk.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: ${{ inputs.java-version }}

--- a/.github/workflows/language-reference.yaml
+++ b/.github/workflows/language-reference.yaml
@@ -31,7 +31,7 @@ jobs:
           ssh-key: ${{ secrets.DOCS_KEY }}
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: 17

--- a/.github/workflows/scaladoc.yaml
+++ b/.github/workflows/scaladoc.yaml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: 17
@@ -79,7 +79,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: 17

--- a/.github/workflows/test-chocolatey.yml
+++ b/.github/workflows/test-chocolatey.yml
@@ -30,7 +30,7 @@ jobs:
   test:
     runs-on: windows-latest
     steps:
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: ${{ inputs.java-version }}


### PR DESCRIPTION
Backports #23812 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]