### PR TITLE
Backport "pc: completions - do not add `[]` for `... derives TC@@`" to 3.3 LTS

### DIFF
--- a/presentation-compiler/src/main/dotty/tools/pc/completions/Completions.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/Completions.scala
@@ -74,7 +74,15 @@ class Completions(
       case tpe :: (appl: AppliedTypeTree) :: _ if appl.tpt == tpe => false
       case sel  :: (funSel @ Select(fun, name)) :: (appl: GenericApply) :: _
         if appl.fun == funSel && sel == fun => false
-      case _ => true)
+      case _ => true) &&
+      (adjustedPath match
+        /* In case of `class X derives TC@@` we shouldn't add `[]` 
+         */
+        case Ident(_) :: (templ: untpd.DerivingTemplate) :: _ =>
+          val pos = completionPos.toSourcePosition
+          !templ.derived.exists(_.sourcePos.contains(pos))
+        case _ => true
+      )
 
   private lazy val isNew: Boolean = Completion.isInNewContext(adjustedPath)
 

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
@@ -2238,3 +2238,11 @@ class CompletionSuite extends BaseCompletionSuite:
         |""".stripMargin,
       "asTerm: Term"
     )
+  
+  @Test def `derives-no-square-brackets` =
+    check(
+      """
+        |case class Miau(y: Int) derives Ordering, CanEqu@@
+        |""".stripMargin,
+      "CanEqual scala"
+    )


### PR DESCRIPTION
Backports #23811 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]