### PR TITLE
Backport "Compute the right span for abstract error messages" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -311,6 +311,15 @@ object RefChecks {
 
     val mixinOverrideErrors = new mutable.ListBuffer[MixinOverrideError]()
 
+    /** Returns a `SourcePosition` containing the full span (with the correct
+     *  end) of the class name. */
+    def clazzNamePos =
+      if clazz.name == tpnme.ANON_CLASS then
+        clazz.srcPos
+      else
+        val clazzNameEnd = clazz.srcPos.span.start + clazz.name.stripModuleClassSuffix.lastPart.length
+        clazz.srcPos.sourcePos.copy(span = clazz.srcPos.span.withEnd(clazzNameEnd))
+
     def printMixinOverrideErrors(): Unit =
       mixinOverrideErrors.toList match {
         case Nil =>
@@ -843,7 +852,7 @@ object RefChecks {
         checkNoAbstractDecls(clazz)
 
       if (abstractErrors.nonEmpty)
-        report.error(abstractErrorMessage, clazz.srcPos)
+        report.error(abstractErrorMessage, clazzNamePos)
 
       checkMemberTypesOK()
       checkCaseClassInheritanceInvariant()

--- a/tests/neg/i10666.check
+++ b/tests/neg/i10666.check
@@ -1,6 +1,6 @@
 -- Error: tests/neg/i10666.scala:8:6 -----------------------------------------------------------------------------------
 8 |class Bar extends Foo { // error
-  |      ^
+  |      ^^^
   |      class Bar needs to be abstract, since def foo[T <: B](tx: T): Unit in trait Foo is not defined 
   |      (Note that
   |       parameter T in def foo[T <: B](tx: T): Unit in trait Foo does not match

--- a/tests/neg/i12828.check
+++ b/tests/neg/i12828.check
@@ -1,6 +1,6 @@
 -- Error: tests/neg/i12828.scala:7:7 -----------------------------------------------------------------------------------
 7 |object Baz extends Bar[Int] // error: not implemented
-  |       ^
+  |       ^^^
   |       object creation impossible, since def foo(x: A): Unit in trait Foo is not defined 
   |       (Note that
   |        parameter A in def foo(x: A): Unit in trait Foo does not match

--- a/tests/neg/i13466.check
+++ b/tests/neg/i13466.check
@@ -1,6 +1,6 @@
 -- Error: tests/neg/i13466.scala:9:6 -----------------------------------------------------------------------------------
 9 |given none: SomeTrait[Finally] with {} // error
-  |      ^
+  |      ^^^^
   |      object creation impossible, since:
   |      it has 3 unimplemented members.
   |      /** As seen from module class none$, the missing signatures are as follows.

--- a/tests/neg/i19731.check
+++ b/tests/neg/i19731.check
@@ -1,10 +1,10 @@
 -- Error: tests/neg/i19731.scala:4:6 -----------------------------------------------------------------------------------
 4 |class F1 extends Foo: // error
-  |      ^
+  |      ^^
   |      class F1 needs to be abstract, since def foo(): Unit in class F1 is not defined 
 -- Error: tests/neg/i19731.scala:7:6 -----------------------------------------------------------------------------------
 7 |class F2 extends Foo: // error
-  |      ^
+  |      ^^
   |      class F2 needs to be abstract, since:
   |      it has 2 unimplemented members.
   |      /** As seen from class F2, the missing signatures are as follows.
@@ -14,7 +14,7 @@
   |        def foo(x: Int): Unit = ???
 -- Error: tests/neg/i19731.scala:16:6 ----------------------------------------------------------------------------------
 16 |class B1 extends Bar: // error
-   |      ^
+   |      ^^
    |      class B1 needs to be abstract, since:
    |      it has 2 unimplemented members.
    |      /** As seen from class B1, the missing signatures are as follows.

--- a/tests/neg/i21335.check
+++ b/tests/neg/i21335.check
@@ -1,8 +1,8 @@
 -- Error: tests/neg/i21335.scala:7:6 -----------------------------------------------------------------------------------
 7 |class Z1 extends Bar1 // error
-  |      ^
+  |      ^^
   |      class Z1 needs to be abstract, since override def bar(): Bar1 in trait Bar1 is not defined 
 -- Error: tests/neg/i21335.scala:12:6 ----------------------------------------------------------------------------------
 12 |class Z2 extends Bar2 // error
-   |      ^
+   |      ^^
    |      class Z2 needs to be abstract, since def bar(): Bar2 in trait Bar2 is not defined 

--- a/tests/neg/i22941.check
+++ b/tests/neg/i22941.check
@@ -1,0 +1,4 @@
+-- Error: tests/neg/i22941.scala:4:6 -----------------------------------------------------------------------------------
+4 |class Baz extends Foo: // error
+  |      ^^^
+  |      class Baz needs to be abstract, since def bar: String in trait Foo is not defined 

--- a/tests/neg/i22941.scala
+++ b/tests/neg/i22941.scala
@@ -1,0 +1,5 @@
+trait Foo:
+  def bar: String
+
+class Baz extends Foo: // error
+  val a = "hello"

--- a/tests/neg/i9329.check
+++ b/tests/neg/i9329.check
@@ -1,5 +1,5 @@
 -- Error: tests/neg/i9329.scala:8:6 ------------------------------------------------------------------------------------
 8 |class GrandSon extends Son // error
-  |      ^
+  |      ^^^^^^^^
   |class GrandSon needs to be abstract, since def name: String in trait Parent is not defined 
   |(The class implements abstract override def name: String in trait Son but that definition still needs an implementation)

--- a/tests/neg/targetName-override.check
+++ b/tests/neg/targetName-override.check
@@ -15,5 +15,5 @@
    |        method ++ of type (xs: Alpha[String]): Alpha[String] misses a target name annotation @targetName(append)
 -- Error: tests/neg/targetName-override.scala:14:6 ---------------------------------------------------------------------
 14 |class Beta extends Alpha[String] {  // error: needs to be abstract
-   |      ^
+   |      ^^^^
    |class Beta needs to be abstract, since there is a deferred declaration of method foo in class Alpha of type (x: String): String which is not implemented in a subclass


### PR DESCRIPTION
Backports #23853 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]