### PR TITLE
Backport "Fix implicit scope liftToAnchors for parameter lower bounds" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -1657,7 +1657,7 @@ object desugar {
         case pat @ Bind(nme.WILDCARD, body) =>
           val name =
             body match
-            case Typed(Ident(nme.WILDCARD), tpt) if pat.mods.is(Given) => inventGivenName(tpt)
+            case Typed(Ident(nme.WILDCARD), tpt) if pat.mods.is(Given) => inventGivenOrExtensionName(tpt)
             case _ => UniqueName.fresh()
           (cpy.Bind(pat)(name, body).withMods(pat.mods), Ident(name))
         case Bind(name, _) => (pat, Ident(name))

--- a/compiler/src/dotty/tools/dotc/transform/init/Checker.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Checker.scala
@@ -46,7 +46,7 @@ class Checker extends Phase:
     cancellable {
       val classes = traverser.getClasses()
 
-      if ctx.settings.Whas.safeInit then
+      if ctx.settings.Whas.checkInit then
         Semantic.checkClasses(classes)(using checkCtx)
     }
 

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -790,7 +790,7 @@ trait ImplicitRunInfo:
               WildcardType
             else
               seen += t
-              t.superType match
+              t.underlying match
                 case TypeBounds(lo, hi) =>
                   if lo.isBottomTypeAfterErasure then apply(hi)
                   else AndType.make(apply(lo), apply(hi))

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -53,6 +53,7 @@ import config.Config
 import transform.CheckUnused.OriginalName
 
 import scala.annotation.constructorOnly
+import scala.util.chaining.scalaUtilChainingOps
 import dotty.tools.dotc.rewrites.Rewrites
 
 object Typer {

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -132,7 +132,7 @@ class CompilationTests {
       compileFilesInDir("tests/neg-deep-subtype", allowDeepSubtypes),
       compileFilesInDir("tests/neg-custom-args/captures", defaultOptions.and("-language:experimental.captureChecking")),
       compileFile("tests/neg-custom-args/sourcepath/outer/nested/Test1.scala", defaultOptions.and("-sourcepath", "tests/neg-custom-args/sourcepath")),
-      compileDir("tests/neg-custom-args/sourcepath2/hi", defaultOptions.and("-sourcepath", "tests/neg-custom-args/sourcepath2", "-Werror")),
+      compileDir("tests/neg-custom-args/sourcepath2/hi", defaultOptions.and("-sourcepath", "tests/neg-custom-args/sourcepath2", "-Xfatal-warnings")),
       compileList("duplicate source", List(
         "tests/neg-custom-args/toplevel-samesource/S.scala",
         "tests/neg-custom-args/toplevel-samesource/nested/S.scala"),
@@ -214,7 +214,7 @@ class CompilationTests {
     compileFilesInDir("tests/init/neg", options).checkExpectedErrors()
     compileFilesInDir("tests/init/warn", defaultOptions.and("-Ysafe-init")).checkWarnings()
     compileFilesInDir("tests/init/pos", options).checkCompile()
-    compileFilesInDir("tests/init/crash", options.without("-Werror")).checkCompile()
+    compileFilesInDir("tests/init/crash", options.without("-Xfatal-warnings")).checkCompile()
     // The regression test for i12128 has some atypical classpath requirements.
     // The test consists of three files: (a) Reflect_1  (b) Macro_2  (c) Test_3
     // which must be compiled separately. In addition:
@@ -223,7 +223,7 @@ class CompilationTests {
     //   - the output from (a) _must not_ be on the classpath while compiling (c)
     locally {
       val i12128Group = TestGroup("checkInit/i12128")
-      val i12128Options = options.without("-Werror")
+      val i12128Options = options.without("-Xfatal-warnings")
       val outDir1 = defaultOutputDir + i12128Group + "/Reflect_1/i12128/Reflect_1"
       val outDir2 = defaultOutputDir + i12128Group + "/Macro_2/i12128/Macro_2"
 
@@ -242,7 +242,7 @@ class CompilationTests {
      * an error when reading the files' TASTy trees. */
     locally {
       val tastyErrorGroup = TestGroup("checkInit/tasty-error/val-or-defdef")
-      val tastyErrorOptions = options.without("-Werror")
+      val tastyErrorOptions = options.without("-Xfatal-warnings")
 
       val classA0 = defaultOutputDir + tastyErrorGroup + "/A/v0/A"
       val classA1 = defaultOutputDir + tastyErrorGroup + "/A/v1/A"
@@ -265,7 +265,7 @@ class CompilationTests {
      * an error when reading the files' TASTy trees. This fact is demonstrated by the compilation of Main. */
     locally {
       val tastyErrorGroup = TestGroup("checkInit/tasty-error/typedef")
-      val tastyErrorOptions = options.without("-Werror").without("-Ycheck:all")
+      val tastyErrorOptions = options.without("-Xfatal-warnings").without("-Ycheck:all")
 
       val classC = defaultOutputDir + tastyErrorGroup + "/C/typedef/C"
       val classA0 = defaultOutputDir + tastyErrorGroup + "/A/v0/A"

--- a/tests/neg/i23119.check
+++ b/tests/neg/i23119.check
@@ -9,8 +9,8 @@
   |          given myGiven: Option[List[String]]  // define an instance
   |          given myGiven @ Option[List[String]] // as a pattern variable
 -- [E161] Naming Error: tests/neg/i23119.scala:18:8 --------------------------------------------------------------------
-18 |  given [A] => List[A] = ??? // error
-   |  ^^^^^^^^^^^^^^^^^^^^^^^^^^
+18 |  given [A]: List[A] = ??? // error
+   |  ^^^^^^^^^^^^^^^^^^^^^^^^
    |  given_List_A is already defined as given instance given_List_A
    |
    |  Provide an explicit, unique name to given definitions,

--- a/tests/neg/i23119.scala
+++ b/tests/neg/i23119.scala
@@ -14,6 +14,6 @@
 //  duplicate pattern variable: given_Option_List
 
 def also =
-  given [A] => List[A] = ???
-  given [A] => List[A] = ??? // error
+  given [A]: List[A] = ???
+  given [A]: List[A] = ??? // error
   ()

--- a/tests/neg/i23832b.check
+++ b/tests/neg/i23832b.check
@@ -1,5 +1,5 @@
 -- [E120] Naming Error: tests/neg/i23832b.scala:9:8 --------------------------------------------------------------------
-9 |  given [A] => Special[Option[A]] = ??? // error
+9 |  given [A]: Special[Option[A]] = ??? // error
   |        ^
   |        Conflicting definitions:
   |        final lazy given val given_Special_Option: Special[Option[Long]] in object syntax at line 8 and

--- a/tests/neg/i23832b.scala
+++ b/tests/neg/i23832b.scala
@@ -6,4 +6,4 @@ trait Special[A]
 
 object syntax:
   given Special[Option[Long]] = ???
-  given [A] => Special[Option[A]] = ??? // error
+  given [A]: Special[Option[A]] = ??? // error

--- a/tests/pos/i21951b.scala
+++ b/tests/pos/i21951b.scala
@@ -1,0 +1,12 @@
+
+class A
+object A:
+  given A = ???
+
+class B[X]
+object B:
+  given g[T]: B[T] = ???
+
+object Test:
+  def foo[X >: A] = summon[X] // was error
+  def bar[F[T] >: B[T]] = summon[F[Int]] // was error


### PR DESCRIPTION
Backports #23679 to the 3.3.7.

PR submitted by the release tooling.