### PR TITLE
Backport "fix: make vals created in desugaring of n-ary lambdas non-synthetic" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -1526,7 +1526,6 @@ object desugar {
           ValDef(param.name, param.tpt, selector(idx))
             .withSpan(param.span)
             .withAttachment(UntupledParam, ())
-            .withFlags(Synthetic)
       }
     Function(param :: Nil, Block(vdefs, body))
   }

--- a/presentation-compiler/src/main/dotty/tools/pc/PcConvertToNamedLambdaParameters.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/PcConvertToNamedLambdaParameters.scala
@@ -120,7 +120,7 @@ object PcConvertToNamedLambdaParameters:
   }
 
   def isWildcardParam(param: tpd.ValDef)(using Context): Boolean =
-    param.name.toString.startsWith("_$") && param.symbol.is(Flags.Synthetic)
+    param.name.toString.startsWith("_$")
 
   def findParamReferencePosition(param: tpd.ValDef, lambda: tpd.Tree)(using Context): Option[SourcePosition] =
     var pos: Option[SourcePosition] = None

--- a/presentation-compiler/test/dotty/tools/pc/tests/hover/HoverTermSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/hover/HoverTermSuite.scala
@@ -6,6 +6,18 @@ import org.junit.Test
 
 class HoverTermSuite extends BaseHoverSuite:
 
+  @Test def `n-ary lamba` =
+    check(
+      """|object testRepor {
+         |  val listOfTuples = List(1 -> 1, 2 -> 2, 3 -> 3)
+         |
+         |  listOfTuples.map((k@@ey, value) => key + value)
+         |}
+         |""".stripMargin,
+      """|val key: Int
+         |""".stripMargin.hover
+    )
+
   @Test def `map` =
     check(
       """object a {


### PR DESCRIPTION
Backports #23896 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]