### PR TITLE
Backport "fix: go to definition and hover for named args in pattern match" to 3.3 LTS

### DIFF
--- a/presentation-compiler/test/dotty/tools/pc/tests/definition/PcDefinitionSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/definition/PcDefinitionSuite.scala
@@ -639,3 +639,34 @@ class PcDefinitionSuite extends BasePcDefinitionSuite:
          |    export scala.collection.immutable.V/*scala/collection/immutable/Vector. Vector.scala*/@@ector
          |""".stripMargin
     )
+
+  @Test def i7763 =
+    check(
+      """|case class MyItem(<<name>>: String)
+         |
+         |def handle(item: MyItem) =
+         |  item match {
+         |    case MyItem(na@@me = n2) => println(n2)
+         |  }
+         |""".stripMargin
+    )
+
+  @Test def `i7763-neg` =
+    check(
+      """|object MyItem:
+        |  def unapply(name: String): Option[Int] = ???
+        |
+        |def handle(item: String) =
+        |  item match {
+        |    case MyItem(na@@me = n2) => println(n2)
+        |  }
+        |""".stripMargin
+    )
+
+  @Test def `i7763-apply` =
+    check(
+      """|case class MyItem(<<name>>: String)
+         |
+         |def handle(item: String) = MyItem(na@@me = item)
+         |""".stripMargin
+    )

--- a/presentation-compiler/test/dotty/tools/pc/tests/hover/HoverTermSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/hover/HoverTermSuite.scala
@@ -870,3 +870,15 @@ class HoverTermSuite extends BaseHoverSuite:
          |""".stripMargin,
       "val aa: Int".hover
     )
+
+  @Test def i7763 =
+    check(
+      """|case class MyItem(name: String)
+         |
+         |def handle(item: MyItem) =
+         |  item match {
+         |    case MyItem(na@@me = n2) => println(n2)
+         |  }
+         |""".stripMargin,
+      "val name: String".hover
+    )


### PR DESCRIPTION
Backports #23956 to the 3.3.7.

PR submitted by the release tooling.