### PR TITLE
Backport "Make typeArgs in QuotesImpl work for AnnotatedTypes" to 3.3 LTS

### DIFF
--- a/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
+++ b/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
@@ -1829,6 +1829,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
 
         def typeArgs: List[TypeRepr] = self match
           case AppliedType(_, args) => args
+          case AnnotatedType(parent, _) => parent.typeArgs
           case _ => List.empty
       end extension
     end TypeReprMethods

--- a/tests/neg-macros/i23008.check
+++ b/tests/neg-macros/i23008.check
@@ -5,8 +5,8 @@
   |                 Exception occurred while executing macro expansion.
   |                 java.lang.IllegalArgumentException: requirement failed: value of StringConstant cannot be `null`
   |                 	at scala.Predef$.require(Predef.scala:337)
+  |                 	at scala.quoted.runtime.impl.QuotesImpl$reflect$StringConstant$.apply(QuotesImpl.scala:2424)
   |                 	at scala.quoted.runtime.impl.QuotesImpl$reflect$StringConstant$.apply(QuotesImpl.scala:2423)
-  |                 	at scala.quoted.runtime.impl.QuotesImpl$reflect$StringConstant$.apply(QuotesImpl.scala:2422)
   |                 	at scala.quoted.ToExpr$StringToExpr.apply(ToExpr.scala:80)
   |                 	at scala.quoted.ToExpr$StringToExpr.apply(ToExpr.scala:78)
   |                 	at scala.quoted.Expr$.apply(Expr.scala:70)

--- a/tests/new/test.scala
+++ b/tests/new/test.scala
@@ -1,0 +1,7 @@
+object e:
+  def foldRL(f: Int => Int)(g: String => Int) = ???
+
+
+val xs = e.foldRL(i => i + 1)(s => s.length)
+
+

--- a/tests/run-macros/i24006/Eval.scala
+++ b/tests/run-macros/i24006/Eval.scala
@@ -1,0 +1,11 @@
+
+import scala.quoted._
+
+object Eval:
+
+  inline def eval[T](x: List[T]) = ${ evalImpl[T]('x) }
+  def evalImpl[A](x: Expr[List[A]])(using Quotes): Expr[Unit] =
+    import quotes.reflect.*
+    println(x.asTerm.tpe.widen)
+    x.asTerm.tpe.widen.typeArgs.head
+    '{()}

--- a/tests/run-macros/i24006/Test.scala
+++ b/tests/run-macros/i24006/Test.scala
@@ -1,0 +1,3 @@
+import Eval.eval
+
+@main def Test() = eval(List(1) :+ 4)


### PR DESCRIPTION
Backports #24018 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]