### PR TITLE
Backport "fix: emit deprecation warnings when a symbol is annotated by a deprecated annotation" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/CrossVersionChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/CrossVersionChecks.scala
@@ -37,6 +37,11 @@ class CrossVersionChecks extends MiniPhase:
       for annot <- sym.annotations if annot.symbol.isExperimental do
         Feature.checkExperimentalDef(annot.symbol, annot.tree)
 
+  private def checkDeprecatedAnnots(sym: Symbol)(using Context): Unit =
+    if sym.exists then
+      for annot <- sym.annotations if annot.symbol.isDeprecated do
+        checkDeprecatedRef(annot.symbol, annot.tree.srcPos)
+
   /** If @migration is present (indicating that the symbol has changed semantics between versions),
    *  emit a warning.
    */
@@ -85,16 +90,19 @@ class CrossVersionChecks extends MiniPhase:
   override def transformValDef(tree: ValDef)(using Context): ValDef =
     checkDeprecatedOvers(tree)
     checkExperimentalAnnots(tree.symbol)
+    checkDeprecatedAnnots(tree.symbol)
     tree
 
   override def transformDefDef(tree: DefDef)(using Context): DefDef =
     checkDeprecatedOvers(tree)
     checkExperimentalAnnots(tree.symbol)
+    checkDeprecatedAnnots(tree.symbol)
     tree
 
   override def transformTypeDef(tree: TypeDef)(using Context): TypeDef =
     // TODO do we need to check checkDeprecatedOvers(tree)?
     checkExperimentalAnnots(tree.symbol)
+    checkDeprecatedAnnots(tree.symbol)
     tree
 
   override def transformTemplate(tree: tpd.Template)(using Context): tpd.Tree =

--- a/tests/warn/i23905.check
+++ b/tests/warn/i23905.check
@@ -1,0 +1,17 @@
+
+-- Deprecation Warning: tests/warn/i23905/Test_2.scala:3:0 -------------------------------------------------------------
+3 |@DeprecatedAnnotation // warn
+  |^^^^^^^^^^^^^^^^^^^^^
+  |class DeprecatedAnnotation is deprecated
+-- Deprecation Warning: tests/warn/i23905/Test_2.scala:6:0 -------------------------------------------------------------
+6 |@DeprecatedAnnotation // warn
+  |^^^^^^^^^^^^^^^^^^^^^
+  |class DeprecatedAnnotation is deprecated
+-- Deprecation Warning: tests/warn/i23905/Test_2.scala:9:0 -------------------------------------------------------------
+9 |@DeprecatedAnnotation // warn
+  |^^^^^^^^^^^^^^^^^^^^^
+  |class DeprecatedAnnotation is deprecated
+-- Deprecation Warning: tests/warn/i23905/Test_2.scala:12:0 ------------------------------------------------------------
+12 |@DeprecatedAnnotation // warn
+   |^^^^^^^^^^^^^^^^^^^^^
+   |class DeprecatedAnnotation is deprecated

--- a/tests/warn/i23905/Annot_1.scala
+++ b/tests/warn/i23905/Annot_1.scala
@@ -1,0 +1,2 @@
+@deprecated
+class DeprecatedAnnotation extends annotation.StaticAnnotation

--- a/tests/warn/i23905/Test_2.scala
+++ b/tests/warn/i23905/Test_2.scala
@@ -1,0 +1,13 @@
+//> using options -deprecation
+
+@DeprecatedAnnotation // warn
+object Test1
+
+@DeprecatedAnnotation // warn
+class Test2
+
+@DeprecatedAnnotation // warn
+def Test3 = ???
+
+@DeprecatedAnnotation // warn
+val Test4 = ???


### PR DESCRIPTION
Backports #23906 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]