### PR TITLE
Backport "Regression test #16004" to 3.3 LTS

### DIFF
--- a/compiler/test/dotty/tools/dotc/reporting/TestReporter.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/TestReporter.scala
@@ -36,7 +36,7 @@ extends Reporter with UniqueMessagePositions with HideNonSensicalMessages with M
   final def messages: Iterator[String] = _messageBuf.iterator
 
   protected final val _consoleBuf = new StringWriter
-  protected final val _consoleReporter = new ConsoleReporter(null, new PrintWriter(_consoleBuf)):
+  protected final val _consoleReporter = new ConsoleReporter(scala.Console.in, new PrintWriter(_consoleBuf)):
     override protected def renderPath(file: AbstractFile): String = TestReporter.renderPath(file)
 
   final def consoleOutput: String = _consoleBuf.toString
@@ -123,7 +123,7 @@ object TestReporter {
 
   def logPath: String = {
     initLog()
-    outFile.getCanonicalPath
+    outFile.getCanonicalPath.nn
   }
 
   def reporter(ps: PrintStream, logLevel: Int): TestReporter =
@@ -160,7 +160,7 @@ object TestReporter {
       Properties.rerunFailed &&
         failedTestsFile.exists() &&
         failedTestsFile.isFile
-    )(readAllLines(failedTestsFile.toPath).asScala.toList)
+    )(readAllLines(failedTestsFile.toPath).nn.asScala.toList)
 
   def writeFailedTests(tests: List[String]): Unit =
     initLog()
@@ -169,7 +169,7 @@ object TestReporter {
 
   def renderPath(file: AbstractFile): String =
     if JFile.separatorChar == '\\' then
-      file.path.replace('\\', '/')
+      file.path.replace('\\', '/').nn
     else
       file.path
 }

--- a/compiler/test/dotty/tools/vulpix/VulpixUnitTests.scala
+++ b/compiler/test/dotty/tools/vulpix/VulpixUnitTests.scala
@@ -79,7 +79,7 @@ class VulpixUnitTests:
     compileFile("tests/vulpix-tests/unit/deadlock.scala", defaultOptions).expectFailure.checkRuns()
 
   @test def badJava: Unit =
-    assertThrows[AssertionError](_.getMessage.contains("java compilation failed")):
+    assertThrows[AssertionError](_.getMessage.nn.contains("java compilation failed")):
       compileFile("tests/vulpix-tests/unit/BadJava.java", defaultOptions)
         .suppressAllOutput
         .checkCompile()
@@ -87,7 +87,7 @@ class VulpixUnitTests:
   @test def runTimeout: Unit =
     val fileName = s"tests/vulpix-tests/unit/timeout.scala"
     val expect = """(?m).*test '.+' timed out.*"""
-    assertThrows[AssertionError](_.getMessage.linesIterator.toList.last.matches(expect)):
+    assertThrows[AssertionError](_.getMessage.nn.linesIterator.toList.last.matches(expect)):
       compileFile(fileName, defaultOptions)
         .suppressAllOutput
         .checkRuns()

--- a/tests/pos/i16004.scala
+++ b/tests/pos/i16004.scala
@@ -1,0 +1,33 @@
+
+import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration._
+
+trait Resource[F[_], A]
+trait IO[A]
+
+trait Cache[F[_], K, V]
+
+object Cache {
+
+  final case class Config(expireAfterRead: FiniteDuration)
+
+  def expiring[F[_], K, V](
+      expireAfter: FiniteDuration
+  ): Resource[F, Cache[F, K, V]] = ???
+
+  def expiring[F[_], K, V](
+      config: Config,
+      partitions: Option[Int] = None
+  ): Resource[F, Cache[F, K, V]] = ???
+
+  /* Without partitions being specified, error is yielded */
+
+  val notCompiling = expiring[IO, Int, Int](
+    config = Config(expireAfterRead = 1.minute)
+  )
+
+  val compiling = expiring[IO, Int, Int](
+    config = Config(expireAfterRead = 1.minute),
+    partitions = None
+  )
+}


### PR DESCRIPTION
Backports #24086 to the 3.3.7.

PR submitted by the release tooling.