### PR TITLE
Backport "Drill through type lambda for tree symbol" to 3.3 LTS

### DIFF
--- a/tests/warn/i23694.scala
+++ b/tests/warn/i23694.scala
@@ -1,0 +1,27 @@
+//> using options -Wunused:privates
+
+trait A:
+  def get: Any = new A.C // select has type [T] =>> C[T]
+  def cc: Any = new A.CC // select has type CC
+
+object A:
+  private class C[T]
+  private type CC[T] = C[T]
+
+trait B:
+  def get: Any = new B.C
+
+object B:
+  private class C
+
+// duplicate issue #23960
+package net.marek.tyre.automaton:
+
+  private[tyre] class TyreCompiler[IN <: Tuple, R]:
+    private def compile[IS <: Tuple, T](xs: List[T]): String = xs match // warn
+      case _: List[t] =>
+        Loop[IS, t](null.asInstanceOf[t]).build
+    private class Loop[IS <: Tuple, T](
+      val i: T,
+    ):
+      def build = "27"


### PR DESCRIPTION
Backports #23699 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]