### PR TITLE
Backport "improvement: Additional way of defining ENABLE_BSP_ALL_PROJECTS" to 3.3 LTS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,6 @@ docs/_spec/.jekyll-metadata
 
 # scaladoc related
 scaladoc/output/
+
+# only used in local development
+.enable_bsp_all_projects

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -413,7 +413,10 @@ object Build {
     "scala2-library-tasty"
   )
 
-  val enableBspAllProjects = sys.env.get("ENABLE_BSP_ALL_PROJECTS").map(_.toBoolean).getOrElse(false)
+  val enableBspAllProjects = sys.env.get("ENABLE_BSP_ALL_PROJECTS").map(_.toBoolean).getOrElse{
+    val enableBspAllProjectsFile = file(".enable_bsp_all_projects")
+    enableBspAllProjectsFile.exists()
+  }
 
   // Settings used when compiling dotty with a non-bootstrapped dotty
   lazy val commonBootstrappedSettings = commonDottySettings ++ Seq(


### PR DESCRIPTION
Backports #24122 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]