### PR TITLE
Backport "bugfix: Make sure that we can query tree.source" to 3.3 LTS

### DIFF
--- a/presentation-compiler/src/main/dotty/tools/pc/utils/InteractiveEnrichments.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/utils/InteractiveEnrichments.scala
@@ -313,7 +313,7 @@ object InteractiveEnrichments extends CommonMtagsEnrichments:
         case Select(_, name: TermName) if infixNames(name) => false
         case Select(This(_), _) => false
         // is a select statement without a dot `qual.name`
-        case sel @ Select(qual, _) if !sel.symbol.is(Synthetic) =>
+        case sel @ Select(qual, _) if !sel.symbol.is(Synthetic) && sel.nameSpan.start < tree.source.length =>
           val source = tree.source
           !(qual.span.end until sel.nameSpan.start)
             .map(source.apply)


### PR DESCRIPTION
Backports #24123 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]