### PR TITLE
Backport "Make opaque types decomposable" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -695,14 +695,12 @@ object SpaceEngine {
 
   extension (tp: Type)
     def isDecomposableToChildren(using Context): Boolean =
-      val sym = tp.typeSymbol  // e.g. Foo[List[Int]] = type Foo (i19275)
       val cls = tp.classSymbol // e.g. Foo[List[Int]] = class List
       tp.hasSimpleKind                  // can't decompose higher-kinded types
         && cls.is(Sealed)
         && cls.isOneOf(AbstractOrTrait) // ignore sealed non-abstract classes
         && !cls.hasAnonymousChild       // can't name anonymous classes as counter-examples
         && cls.children.nonEmpty        // can't decompose without children
-        && !sym.isOpaqueAlias           // can't instantiate subclasses to conform to an opaque type (i19275)
 
   val ListOfNoType    = List(NoType)
   val ListOfTypNoType = ListOfNoType.map(Typ(_, decomposed = true))

--- a/tests/pos/i22513.scala
+++ b/tests/pos/i22513.scala
@@ -1,0 +1,27 @@
+opaque type R[T] <: T = T
+
+object Test {
+  enum E:
+    case A(a: Int)
+
+  val v: R[E] = ???
+  v match
+    case E.A(_) =>
+}
+
+sealed trait Foo
+
+case class FooA() extends Foo
+case class FooB() extends Foo
+
+object O {
+  opaque type OpaqueFoo <: Foo = Foo
+  def fooB(): OpaqueFoo = FooB()
+}
+
+@main def main =
+  val p: O.OpaqueFoo = O.fooB()
+
+  p match
+    case _: FooA => println("fooA")
+    case _: FooB => println("fooB")


### PR DESCRIPTION
Backports #24068 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]