### PR TITLE
Backport "Fix "Regression in zio/zio-schema for typer/implicit resolution"" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -6605,7 +6605,10 @@ object Types extends TypeUtils {
         case tp: TypeRef if tp.info.isTypeAlias =>
           apply(n, tp.superType)
         case tp: TypeParamRef =>
-          apply(n, TypeComparer.bounds(tp))
+          val bounds = TypeComparer.bounds(tp)
+          val loSize = apply(n, bounds.lo)
+          val hiSize = apply(n, bounds.hi)
+          hiSize max loSize
         case tp: LazyRef =>
           if seen.contains(tp) then n
           else

--- a/tests/pos/i24007.scala
+++ b/tests/pos/i24007.scala
@@ -1,0 +1,33 @@
+sealed trait CaseSet:
+  type EnumType
+
+object CaseSet {
+  def caseOf[A, Z >: A]: Cons[A, Empty[Z], Z] = ???
+  type Aux[EnumType0] = CaseSet { type EnumType = EnumType0 }
+
+  final class Empty[Z] extends CaseSet:
+    type EnumType = Z
+
+  final class Cons[A, +T <: CaseSet.Aux[Z], Z](head: A, tail: T) extends CaseSet:
+    type EnumType = Z
+    def ++[That](that: That)(implicit append: Append[Z, Cons[A, T, Z], That]): append.Out = ???
+}
+
+sealed trait Append[EnumType, -Left, -Right]:
+  type Out <: CaseSet.Aux[EnumType]
+
+object Append:
+  type WithOut[EnumType, Left, Right, Out0] = Append[EnumType, Left, Right] { type Out = Out0 }
+
+  implicit def AppendCons[A, Z, T <: CaseSet.Aux[Z], That <: CaseSet.Aux[Z]](implicit
+      append: Append[Z, T, That]
+  ): Append.WithOut[Z, CaseSet.Cons[A, T, Z], That, CaseSet.Cons[A, append.Out, Z]] = ???
+
+  implicit def AppendEmptyLeft[T <: CaseSet.Aux[Z], Z]: Append.WithOut[Z, CaseSet.Empty[Z], T, T] =
+    ???
+
+object Test:
+  type UnionValue = Int | Boolean | String
+  val _ = CaseSet.caseOf[Int, UnionValue] ++
+      CaseSet.caseOf[Boolean, UnionValue] ++
+      CaseSet.caseOf[String, UnionValue]


### PR DESCRIPTION
Backports #24156 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]