### PR TITLE
Backport "Trap Ctrl-C in the REPL: if no command is running clear the prompt, if some command is running ask for confirmation before exiting" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/repl/JLineTerminal.scala
+++ b/compiler/src/dotty/tools/repl/JLineTerminal.scala
@@ -82,6 +82,10 @@ class JLineTerminal extends java.io.Closeable {
 
   def close(): Unit = terminal.close()
 
+  /** Register a signal handler and return the previous handler */
+  def handle(signal: org.jline.terminal.Terminal.Signal, handler: org.jline.terminal.Terminal.SignalHandler): org.jline.terminal.Terminal.SignalHandler =
+    terminal.handle(signal, handler)
+
   /** Provide syntax highlighting */
   private class Highlighter(using Context) extends reader.Highlighter {
     def highlight(reader: LineReader, buffer: String): AttributedString = {

--- a/compiler/src/dotty/tools/repl/ReplDriver.scala
+++ b/compiler/src/dotty/tools/repl/ReplDriver.scala
@@ -219,7 +219,7 @@ class ReplDriver(settings: Array[String],
             if (!firstCtrlCEntered) {
               firstCtrlCEntered = true
               thread.interrupt()
-              out.println("\nInterrupting running thread, Ctrl-C again to terminate the process")
+              out.println("\nInterrupting running thread, Ctrl-C again to terminate the REPL Process")
             }else {
               out.println("\nTerminating REPL Process...")
               System.exit(130)  // Standard exit code for SIGINT

--- a/compiler/src/dotty/tools/repl/ReplDriver.scala
+++ b/compiler/src/dotty/tools/repl/ReplDriver.scala
@@ -212,7 +212,7 @@ class ReplDriver(settings: Array[String],
         // Set up interrupt handler for command execution
         var firstCtrlCEntered = false
         val thread = Thread.currentThread()
-        val signalHandler = terminal.handle(
+        val previousSignalHandler = terminal.handle(
           org.jline.terminal.Terminal.Signal.INT,
           (sig: org.jline.terminal.Terminal.Signal) => {
             val now = System.currentTimeMillis()
@@ -222,15 +222,16 @@ class ReplDriver(settings: Array[String],
               out.println("\nInterrupting running thread, Ctrl-C again to terminate the process")
             }else {
               out.println("\nTerminating REPL...")
-
               System.exit(130)  // Standard exit code for SIGINT
             }
           }
         )
 
-        val newState = interpret(res)
-        // Restore previous handler
-        terminal.handle(org.jline.terminal.Terminal.Signal.INT, signalHandler)
+        val newState =
+          try interpret(res)
+          // Restore previous handler
+          finally terminal.handle(org.jline.terminal.Terminal.Signal.INT, previousSignalHandler)
+
         loop(using newState)()
       }
     }

--- a/compiler/src/dotty/tools/repl/ReplDriver.scala
+++ b/compiler/src/dotty/tools/repl/ReplDriver.scala
@@ -219,7 +219,7 @@ class ReplDriver(settings: Array[String],
               firstCtrlCEntered = true
               thread.interrupt()
               out.println("\nInterrupting running thread, Ctrl-C again to terminate the REPL Process")
-            }else {
+            } else {
               out.println("\nTerminating REPL Process...")
               System.exit(130)  // Standard exit code for SIGINT
             }

--- a/compiler/src/dotty/tools/repl/ReplDriver.scala
+++ b/compiler/src/dotty/tools/repl/ReplDriver.scala
@@ -159,10 +159,6 @@ class ReplDriver(settings: Array[String],
       s"""Welcome to Scala $simpleVersionString ($javaVersion, Java $javaVmName).
          |Type in expressions for evaluation. Or try :help.""".stripMargin)
 
-    // Track the time of last Ctrl-C
-    var lastCtrlCTime: Long = 0L
-    val ctrlCWindowMs = 1000L  // 1 second window for double Ctrl-C
-
     /** Blockingly read a line, getting back a parse result */
     def readLine()(using state: State): ParseResult = {
       given Context = state.context
@@ -207,27 +203,27 @@ class ReplDriver(settings: Array[String],
     }
 
     @tailrec def loop(using state: State)(): State = {
+
       val res = readLine()
       if (res == Quit) state
-      else if (res == SigKill) {
-        // Ctrl-C pressed at prompt - just continue with same state (line is cleared by JLine)
-        loop(using state)()
-      } else {
+      // Ctrl-C pressed at prompt - just continue with same state (line is cleared by JLine)
+      else if (res == SigKill) loop(using state)()
+      else {
         // Set up interrupt handler for command execution
+        var firstCtrlCEntered = false
         val thread = Thread.currentThread()
         val signalHandler = terminal.handle(
           org.jline.terminal.Terminal.Signal.INT,
           (sig: org.jline.terminal.Terminal.Signal) => {
             val now = System.currentTimeMillis()
-            if (now - lastCtrlCTime < ctrlCWindowMs) {
-              // Second Ctrl-C within window - interrupt the thread
-              out.println("\nTerminating REPL...")
+            if (!firstCtrlCEntered) {
+              firstCtrlCEntered = true
               thread.interrupt()
+              out.println("\nInterrupting running thread, Ctrl-C again to terminate the process")
+            }else {
+              out.println("\nTerminating REPL...")
+
               System.exit(130)  // Standard exit code for SIGINT
-            } else {
-              // First Ctrl-C - warn user
-              lastCtrlCTime = now
-              out.println("\nPress Ctrl-C again to terminate the process")
             }
           }
         )

--- a/compiler/src/dotty/tools/repl/ReplDriver.scala
+++ b/compiler/src/dotty/tools/repl/ReplDriver.scala
@@ -159,6 +159,10 @@ class ReplDriver(settings: Array[String],
       s"""Welcome to Scala $simpleVersionString ($javaVersion, Java $javaVmName).
          |Type in expressions for evaluation. Or try :help.""".stripMargin)
 
+    // Track the time of last Ctrl-C
+    var lastCtrlCTime: Long = 0L
+    val ctrlCWindowMs = 1000L  // 1 second window for double Ctrl-C
+
     /** Blockingly read a line, getting back a parse result */
     def readLine()(using state: State): ParseResult = {
       given Context = state.context
@@ -195,16 +199,44 @@ class ReplDriver(settings: Array[String],
         val line = terminal.readLine(completer)
         ParseResult(line)
       } catch {
-        case _: EndOfFileException |
-            _: UserInterruptException => // Ctrl+D or Ctrl+C
+        case _: EndOfFileException => // Ctrl+D
           Quit
+        case _: UserInterruptException => // Ctrl+C at prompt - clear and continue
+          SigKill
       }
     }
 
     @tailrec def loop(using state: State)(): State = {
       val res = readLine()
       if (res == Quit) state
-      else loop(using interpret(res))()
+      else if (res == SigKill) {
+        // Ctrl-C pressed at prompt - just continue with same state (line is cleared by JLine)
+        loop(using state)()
+      } else {
+        // Set up interrupt handler for command execution
+        val thread = Thread.currentThread()
+        val signalHandler = terminal.handle(
+          org.jline.terminal.Terminal.Signal.INT,
+          (sig: org.jline.terminal.Terminal.Signal) => {
+            val now = System.currentTimeMillis()
+            if (now - lastCtrlCTime < ctrlCWindowMs) {
+              // Second Ctrl-C within window - interrupt the thread
+              out.println("\nTerminating REPL...")
+              thread.interrupt()
+              System.exit(130)  // Standard exit code for SIGINT
+            } else {
+              // First Ctrl-C - warn user
+              lastCtrlCTime = now
+              out.println("\nPress Ctrl-C again to terminate the process")
+            }
+          }
+        )
+
+        val newState = interpret(res)
+        // Restore previous handler
+        terminal.handle(org.jline.terminal.Terminal.Signal.INT, signalHandler)
+        loop(using newState)()
+      }
     }
 
     try runBody { loop() }

--- a/compiler/src/dotty/tools/repl/ReplDriver.scala
+++ b/compiler/src/dotty/tools/repl/ReplDriver.scala
@@ -221,7 +221,7 @@ class ReplDriver(settings: Array[String],
               thread.interrupt()
               out.println("\nInterrupting running thread, Ctrl-C again to terminate the process")
             }else {
-              out.println("\nTerminating REPL...")
+              out.println("\nTerminating REPL Process...")
               System.exit(130)  // Standard exit code for SIGINT
             }
           }

--- a/compiler/src/dotty/tools/repl/ReplDriver.scala
+++ b/compiler/src/dotty/tools/repl/ReplDriver.scala
@@ -215,7 +215,6 @@ class ReplDriver(settings: Array[String],
         val previousSignalHandler = terminal.handle(
           org.jline.terminal.Terminal.Signal.INT,
           (sig: org.jline.terminal.Terminal.Signal) => {
-            val now = System.currentTimeMillis()
             if (!firstCtrlCEntered) {
               firstCtrlCEntered = true
               thread.interrupt()


### PR DESCRIPTION
Backports #24127 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]