### PR TITLE
Backport "add regression test for #24076" to 3.3 LTS

### DIFF
--- a/tests/pos/i24076.scala
+++ b/tests/pos/i24076.scala
@@ -1,0 +1,7 @@
+transparent inline def bug(using ValueOf[1]): Int = 1
+transparent inline def foo(inline arg: Any): Any =
+  inline (arg, arg) match
+    case (_, _) =>
+    case _      =>
+  end match
+val x = foo(bug)


### PR DESCRIPTION
Backports #24181 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]