### PR TITLE
Backport "Deduplicate patches before applying them to sources" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/rewrites/Rewrites.scala
+++ b/compiler/src/dotty/tools/dotc/rewrites/Rewrites.scala
@@ -43,8 +43,8 @@ object Rewrites {
       pbuf.filterInPlace(x => !p(x.span))
 
     def apply(cs: Array[Char]): Array[Char] = {
-      val delta = pbuf.map(_.delta).sum
-      val patches = pbuf.toList.sortBy(_.span.start)
+      val patches = pbuf.toList.distinct.sortBy(_.span.start)
+      val delta = patches.map(_.delta).sum
       if (patches.nonEmpty)
         patches.reduceLeft {(p1, p2) =>
           assert(p1.span.end <= p2.span.start, s"overlapping patches in $source: $p1 and $p2")

--- a/tests/rewrites/i24213.check
+++ b/tests/rewrites/i24213.check
@@ -1,0 +1,5 @@
+def Test =
+  try ()
+  catch {
+    case x: Throwable if x.getMessage `contains` "error" => ???
+  }

--- a/tests/rewrites/i24213.scala
+++ b/tests/rewrites/i24213.scala
@@ -1,0 +1,5 @@
+def Test =
+  try ()
+  catch {
+    case x: Throwable if x.getMessage contains "error" => ???
+  }


### PR DESCRIPTION
Backports #24215 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]