### PR TITLE
Backport "Ignore warnings when compiletime.testing is imported" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
@@ -473,10 +473,12 @@ object CheckUnused:
         if inliners == 0
           && languageImport(imp.expr).isEmpty
           && !imp.isGeneratedByEnum
-          && !imp.isCompiletimeTesting
           && !ctx.owner.name.isReplWrapperName
         then
-          imps.put(imp, ())
+          if imp.isCompiletimeTesting then
+            isNullified = true
+          else
+            imps.put(imp, ())
       case tree: Bind =>
         if !tree.name.isInstanceOf[DerivedName] && !tree.name.is(WildcardParamName) then
           if tree.hasAttachment(NoWarn) then
@@ -506,6 +508,9 @@ object CheckUnused:
         asss.addOne(sym)
       else
         refs.addOne(sym)
+
+    // currently compiletime.testing is completely erased, so ignore the unit
+    var isNullified = false
   end RefInfos
 
   // Names are resolved by definitions and imports, which have four precedence levels:
@@ -520,7 +525,7 @@ object CheckUnused:
       inline def weakerThan(q: Precedence): Boolean = p > q
       inline def isNone: Boolean = p == NoPrecedence
 
-  def reportUnused()(using Context): Unit =
+  def reportUnused()(using Context): Unit = if !refInfos.isNullified then
     for (msg, pos, origin) <- warnings do
       if origin.isEmpty then report.warning(msg, pos)
       else report.warning(msg, pos, origin)

--- a/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
@@ -473,6 +473,7 @@ object CheckUnused:
         if inliners == 0
           && languageImport(imp.expr).isEmpty
           && !imp.isGeneratedByEnum
+          && !imp.isCompiletimeTesting
           && !ctx.owner.name.isReplWrapperName
         then
           imps.put(imp, ())
@@ -1002,6 +1003,10 @@ object CheckUnused:
     /** Generated import of cases from enum companion. */
     def isGeneratedByEnum: Boolean =
       imp.symbol.exists && imp.symbol.owner.is(Enum, butNot = Case)
+
+    /** No mechanism for detection yet. */
+    def isCompiletimeTesting: Boolean =
+      imp.expr.symbol == defn.CompiletimeTestingPackage//.moduleClass
 
   extension (pos: SrcPos)
     def isZeroExtentSynthetic: Boolean = pos.span.isSynthetic && pos.span.isZeroExtent

--- a/tests/warn/i21805.scala
+++ b/tests/warn/i21805.scala
@@ -1,4 +1,4 @@
-//> using options -Wunused:imports
+//> using options -Wunused:all
 
 def i23967: Boolean = {
   //import scala.compiletime.testing.typeCheckErrors
@@ -12,8 +12,8 @@ package c:
   class C(i: Int)
 
 package q:
-  import c.* // warn should be nowarn
-  import p.* // warn should be nowarn
+  import c.* // nowarn, unit is nullified
+  import p.* // nowarn
   import scala.compiletime.testing.*
   def test() = typeCheckErrors("""println(C("hello, world"))""")
   def ok() = typeChecks("println(code)")

--- a/tests/warn/i21805.scala
+++ b/tests/warn/i21805.scala
@@ -2,7 +2,7 @@
 
 def i23967: Boolean = {
   //import scala.compiletime.testing.typeCheckErrors
-  import scala.compiletime.testing.* // warn
+  import scala.compiletime.testing.* // nowarn
   typeChecks("2 + 2")
 }
 
@@ -21,10 +21,10 @@ package q:
 
 package i23967b:
   package ok:
-    import scala.compiletime.testing.* // warn
+    import scala.compiletime.testing.* // nowarn
     def test() = typeChecks("42 + 27")
   package nok:
-    import scala.compiletime.testing.typeChecks // warn
+    import scala.compiletime.testing.typeChecks // nowarn
     def test() = typeChecks("42 + 27")
 
 @main def Test = println:

--- a/tests/warn/i21805.scala
+++ b/tests/warn/i21805.scala
@@ -1,0 +1,31 @@
+//> using options -Wunused:imports
+
+def i23967: Boolean = {
+  //import scala.compiletime.testing.typeCheckErrors
+  import scala.compiletime.testing.* // warn
+  typeChecks("2 + 2")
+}
+
+package p:
+  val code = """"hello, world""""
+package c:
+  class C(i: Int)
+
+package q:
+  import c.* // warn should be nowarn
+  import p.* // warn should be nowarn
+  import scala.compiletime.testing.*
+  def test() = typeCheckErrors("""println(C("hello, world"))""")
+  def ok() = typeChecks("println(code)")
+  inline def f(inline i: Int) = 42 + i
+
+package i23967b:
+  package ok:
+    import scala.compiletime.testing.* // warn
+    def test() = typeChecks("42 + 27")
+  package nok:
+    import scala.compiletime.testing.typeChecks // warn
+    def test() = typeChecks("42 + 27")
+
+@main def Test = println:
+  q.f(27)


### PR DESCRIPTION
Backports #24036 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]