### PR TITLE
Backport "Fix false exhaustivity warning for seq match" to 3.3 LTS

### DIFF
--- a/tests/pos/i23928.scala
+++ b/tests/pos/i23928.scala
@@ -1,0 +1,5 @@
+object Test {
+  Nil match {
+    case Seq(xs*) => 42
+  }
+}


### PR DESCRIPTION
Backports #23968 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]