### PR TITLE
Backport "Use upper bound of abstract types in exhaustivity checking" to 3.3 LTS

### DIFF
--- a/tests/pos/i23620.scala
+++ b/tests/pos/i23620.scala
@@ -1,0 +1,18 @@
+trait Foo
+trait Bar
+
+type FooOrBar = FooOrBar.Type
+object FooOrBar:
+  opaque type Type <: (Foo | Bar) = Foo | Bar
+
+  def bar: FooOrBar = new Bar {}
+
+trait Buz
+
+@main def main =
+  val p: FooOrBar | Buz = FooOrBar.bar
+
+  p match
+    case _: Foo => println("foo")
+    case _: Buz => println("buz")
+    case _: Bar => println("bar")

--- a/tests/warn/i23620b.check
+++ b/tests/warn/i23620b.check
@@ -1,0 +1,24 @@
+-- [E029] Pattern Match Exhaustivity Warning: tests/warn/i23620b.scala:20:2 --------------------------------------------
+20 |  p match // warn
+   |  ^
+   |  match may not be exhaustive.
+   |
+   |  It would fail on pattern case: _: Bar
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E029] Pattern Match Exhaustivity Warning: tests/warn/i23620b.scala:23:2 --------------------------------------------
+23 |  p2 match { // warn
+   |  ^^
+   |  match may not be exhaustive.
+   |
+   |  It would fail on pattern case: _: Bar
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E029] Pattern Match Exhaustivity Warning: tests/warn/i23620b.scala:37:2 --------------------------------------------
+37 |  x match // warn
+   |  ^
+   |  match may not be exhaustive.
+   |
+   |  It would fail on pattern case: B
+   |
+   | longer explanation available when compiling with `-explain`

--- a/tests/warn/i23620b.scala
+++ b/tests/warn/i23620b.scala
@@ -1,0 +1,38 @@
+trait Foo
+trait Bar
+
+type FooOrBar = FooOrBar.Type
+object FooOrBar:
+  opaque type Type <: (Foo | Bar) = Foo | Bar
+
+  def bar: FooOrBar = new Bar {}
+
+type OnlyFoo = OnlyFoo.Type
+object OnlyFoo:
+  opaque type Type <: (Foo | Bar) = Foo
+
+  def foo: OnlyFoo = new Foo {}
+
+@main def main =
+  val p: FooOrBar= FooOrBar.bar
+  val p2: OnlyFoo = OnlyFoo.foo
+
+  p match // warn
+    case _: Foo => println("foo")
+
+  p2 match { // warn
+    case _: Foo => println("foo")
+  }
+
+sealed trait S
+trait Z
+
+case object A extends S, Z
+case object B extends S, Z
+
+trait HasT:
+  type T <: S & Z
+
+def nonExhaustive(h: HasT, x: h.T) =
+  x match // warn
+    case A => ()

--- a/tests/warn/i24246.check
+++ b/tests/warn/i24246.check
@@ -1,0 +1,8 @@
+-- [E029] Pattern Match Exhaustivity Warning: tests/warn/i24246.scala:8:2 ----------------------------------------------
+8 |  x match { // warn
+  |  ^
+  |  match may not be exhaustive.
+  |
+  |  It would fail on pattern case: ZZ
+  |
+  | longer explanation available when compiling with `-explain`

--- a/tests/warn/i24246.scala
+++ b/tests/warn/i24246.scala
@@ -1,0 +1,10 @@
+trait X
+
+sealed trait Y
+case object YY extends Y, X
+case object ZZ extends Y, X
+
+def foo[A <: X & Y](x: A): Unit =
+  x match { // warn
+    case YY => ()
+  }


### PR DESCRIPTION
Backports #23909 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]