### PR TITLE
Backport "Fix #24207: Cleanup the type of `UnApply` trees in posttyper" to 3.3 LTS

### DIFF
--- a/tests/pos/i24207.scala
+++ b/tests/pos/i24207.scala
@@ -1,0 +1,12 @@
+class Generator:
+  private def generateTable(table: Table) =
+    val (ownRelations, _) = calculateOwnRelations(table)
+    ownRelations
+
+  private def calculateOwnRelations(table: Table) =
+    val ownRelations = table.relations.filter(_.association.isDefined)
+    (ownRelations, Nil)
+
+case class Table(relations: Seq[TableRelation])
+case class TableRelation(association: Option[Association])
+trait Association


### PR DESCRIPTION
Backports #24259 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]