### PR TITLE
Backport "Use enclosing enclosingInlineds for empty call" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
@@ -59,7 +59,7 @@ class CheckUnused private (phaseMode: PhaseMode, suffix: String) extends MiniPha
     if tree.symbol.exists then
       // if in an inline expansion, resolve at summonInline (synthetic pos) or in an enclosing call site
       val resolving =
-           tree.srcPos.isUserCode
+           tree.srcPos.isUserCode(using if tree.hasAttachment(InlinedParameter) then ctx.outer else ctx)
         || tree.srcPos.isZeroExtentSynthetic // take as summonInline
       if !ignoreTree(tree) then
         def loopOverPrefixes(prefix: Type, depth: Int): Unit =
@@ -160,6 +160,10 @@ class CheckUnused private (phaseMode: PhaseMode, suffix: String) extends MiniPha
     case _ =>
     tree
 
+  override def prepareForInlined(tree: Inlined)(using Context): Context =
+    if tree.inlinedFromOuterScope then
+      tree.expansion.putAttachment(InlinedParameter, ())
+    ctx
   override def transformInlined(tree: Inlined)(using Context): tree.type =
     transformAllDeep(tree.call)
     tree
@@ -466,6 +470,9 @@ object CheckUnused:
 
   /** Tree is LHS of Assign. */
   val AssignmentTarget = Property.StickyKey[Unit]
+
+  /** Tree is an inlined parameter. */
+  val InlinedParameter = Property.StickyKey[Unit]
 
   class PostTyper extends CheckUnused(PhaseMode.Aggregate, "PostTyper")
 
@@ -1035,7 +1042,7 @@ object CheckUnused:
     def isUserCode(using Context): Boolean =
       val inlineds = enclosingInlineds // per current context
          inlineds.isEmpty
-      || inlineds.last.srcPos.sourcePos.contains(pos.sourcePos)
+      || inlineds.exists(_.srcPos.sourcePos.contains(pos.sourcePos)) // include intermediate inlinings or quotes
 
   extension [A <: AnyRef](arr: Array[A])
     // returns `until` if not satisfied

--- a/tests/warn/i24248/lib.scala
+++ b/tests/warn/i24248/lib.scala
@@ -1,0 +1,18 @@
+
+import scala.quoted.*
+
+trait Thing
+object Stuff:
+  given Thing()
+
+object lib:
+  inline def m: Thing = ${ mImpl[Thing] }
+
+  def mImpl[T](using Quotes, Type[T]): Expr[T] =
+    import quotes.reflect.*
+    val thing = Implicits.search(TypeRepr.of[T]) match
+      case iss: ImplicitSearchSuccess => iss.tree.asExprOf[T]
+    '{
+      val res = $thing
+      res
+    }

--- a/tests/warn/i24248/test.scala
+++ b/tests/warn/i24248/test.scala
@@ -1,0 +1,6 @@
+//> using options -Werror -Wunused:all
+
+import Stuff.given
+
+@main def test = println:
+  lib.m


### PR DESCRIPTION
Backports #24281 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]