### PR TITLE
Backport "Register no elements for lint after inlining" to 3.3 LTS

### DIFF
--- a/tests/warn/i24265.scala
+++ b/tests/warn/i24265.scala
@@ -1,0 +1,10 @@
+//> using options -Wall -Werror
+
+object test {
+  inline def f(testFun: => Any) = testFun
+
+  f {
+    val i = 1
+    summon[i.type <:< Int]
+  }
+}


### PR DESCRIPTION
Backports #24279 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]