### PR TITLE
Backport "Bump actions/upload-artifact from 4 to 5" to 3.3 LTS

### DIFF
--- a/.github/workflows/build-chocolatey.yml
+++ b/.github/workflows/build-chocolatey.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Build the Chocolatey package (.nupkg)
         run: choco pack ./pkgs/chocolatey/scala.nuspec --out ./pkgs/chocolatey
       - name: Upload the Chocolatey package to GitHub
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: scala.nupkg
           path: ./pkgs/chocolatey/scala.${{ inputs.version }}.nupkg

--- a/.github/workflows/build-sdk.yml
+++ b/.github/workflows/build-sdk.yml
@@ -45,7 +45,7 @@ jobs:
         run : ./project/scripts/sbt dist/pack
 
       - name: Upload zip archive to GitHub Artifact (universal)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         id  : universal
         with:
           path: ./dist/target/pack/*


### PR DESCRIPTION
Backports #24268 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]