### PR TITLE
Backport "Warn if type argument was inferred as union type" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/Compiler.scala
+++ b/compiler/src/dotty/tools/dotc/Compiler.scala
@@ -34,7 +34,9 @@ class Compiler {
   protected def frontendPhases: List[List[Phase]] =
     List(new Parser) ::             // Compiler frontend: scanner, parser
     List(new TyperPhase) ::         // Compiler frontend: namer, typer
-    List(CheckUnused.PostTyper(), CheckShadowing()) :: // Check for unused, shadowed elements
+    List(new WInferUnion,           // Check for type arguments inferred as union types
+         CheckUnused.PostTyper(),   // Check for unused
+         CheckShadowing()) ::       // Check for shadowed elements
     List(new YCheckPositions) ::    // YCheck positions
     List(new sbt.ExtractDependencies) :: // Sends information on classes' dependencies to sbt via callbacks
     List(new semanticdb.ExtractSemanticDB.ExtractSemanticInfo) :: // Extract info into .semanticdb files

--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -177,6 +177,7 @@ private sealed trait WarningSettings:
   private val WtoStringInterpolated = BooleanSetting("-Wtostring-interpolated", "Warn a standard interpolator used toString on a reference type.")
   private val WrecurseWithDefault = BooleanSetting("-Wrecurse-with-default", "Warn when a method calls itself with a default argument.")
   private val WwrongArrow = BooleanSetting("-Wwrong-arrow", "Warn if function arrow was used instead of context literal ?=>.")
+  private val WinferUnion = BooleanSetting("-Winfer-union", "Warn if type argument was inferred as union type.")
   private val Wunused: Setting[List[ChoiceWithHelp[String]]] = MultiChoiceHelpSetting(
     name = "-Wunused",
     helpArg = "warning",
@@ -291,6 +292,7 @@ private sealed trait WarningSettings:
     def recurseWithDefault(using Context): Boolean = allOr(WrecurseWithDefault)
     def checkInit(using Context): Boolean = allOr(YcheckInit)
     def wrongArrow(using Context): Boolean = allOr(WwrongArrow)
+    def inferUnion(using Context): Boolean = allOr(WinferUnion)
 
 /** -X "Extended" or "Advanced" settings */
 private sealed trait XSettings:

--- a/compiler/src/dotty/tools/dotc/transform/WInferUnion.scala
+++ b/compiler/src/dotty/tools/dotc/transform/WInferUnion.scala
@@ -1,0 +1,32 @@
+package dotty.tools.dotc.transform
+
+import dotty.tools.dotc.ast.tpd
+import dotty.tools.dotc.ast.tpd.InferredTypeTree
+import dotty.tools.dotc.core.Contexts.{Context, ctx}
+import dotty.tools.dotc.core.Decorators.em
+import dotty.tools.dotc.core.Types.OrType
+import dotty.tools.dotc.report
+import dotty.tools.dotc.transform.MegaPhase.MiniPhase
+
+class WInferUnion extends MiniPhase {
+
+  override def phaseName: String = WInferUnion.name
+
+  override def description: String = WInferUnion.description
+
+  override def isEnabled(using Context): Boolean = ctx.settings.Whas.inferUnion
+
+  override def transformTypeApply(tree: tpd.TypeApply)(using Context): tpd.Tree =
+    val inferredOrTypes = tree.args.find: tpt =>
+      tpt.isInstanceOf[InferredTypeTree] && tpt.tpe.stripTypeVar.isInstanceOf[OrType]
+    inferredOrTypes.foreach: tpt =>
+      report.warning(
+        em"""|A type argument was inferred to be union type ${tpt.tpe.stripTypeVar}
+             |This may indicate a programming error.
+             |""", tpt.srcPos)
+    tree
+}
+
+object WInferUnion:
+  val name = "Winfer-union"
+  val description = "check for type arguments inferred as union types"

--- a/tests/warn/infer-or-type.check
+++ b/tests/warn/infer-or-type.check
@@ -1,0 +1,10 @@
+-- Warning: tests/warn/infer-or-type.scala:6:18 ------------------------------------------------------------------------
+6 |  val _ = List(1).contains("") // warn
+  |          ^^^^^^^^^^^^^^^^
+  |          A type argument was inferred to be union type Int | String
+  |          This may indicate a programming error.
+-- Warning: tests/warn/infer-or-type.scala:7:10 ------------------------------------------------------------------------
+7 |  val _ = Pair(1, "") // warn
+  |          ^^^^
+  |          A type argument was inferred to be union type Int | String
+  |          This may indicate a programming error.

--- a/tests/warn/infer-or-type.scala
+++ b/tests/warn/infer-or-type.scala
@@ -1,0 +1,8 @@
+//> using options -Winfer-union
+
+case class Pair[A](x: A, y: A)
+
+def test = {
+  val _ = List(1).contains("") // warn
+  val _ = Pair(1, "") // warn
+}


### PR DESCRIPTION
Backports #24258 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]