### PR TITLE
Backport "chore: Use numberOfWorkers instead" to 3.3 LTS

### DIFF
--- a/compiler/test/dotc/comptest.scala
+++ b/compiler/test/dotc/comptest.scala
@@ -7,7 +7,7 @@ import scala.concurrent.duration._
 object comptest extends ParallelTesting {
 
   def maxDuration = 3.seconds
-  def numberOfSlaves = 5
+  def numberOfWorkers = 5
   def safeMode = false
   def isInteractive = true
   def testFilter = Nil

--- a/compiler/test/dotty/tools/dotc/BootstrappedOnlyCompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/BootstrappedOnlyCompilationTests.scala
@@ -204,7 +204,7 @@ object BootstrappedOnlyCompilationTests extends ParallelTesting {
   // Test suite configuration --------------------------------------------------
 
   def maxDuration = 100.seconds
-  def numberOfSlaves = Runtime.getRuntime().availableProcessors()
+  def numberOfWorkers = Runtime.getRuntime().availableProcessors()
   def safeMode = Properties.testsSafeMode
   def isInteractive = SummaryReport.isInteractive
   def testFilter = Properties.testsFilter

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -322,7 +322,7 @@ object CompilationTests extends ParallelTesting {
   // Test suite configuration --------------------------------------------------
 
   def maxDuration = 45.seconds
-  def numberOfSlaves = Runtime.getRuntime().availableProcessors()
+  def numberOfWorkers = Runtime.getRuntime().availableProcessors()
   def safeMode = Properties.testsSafeMode
   def isInteractive = SummaryReport.isInteractive
   def testFilter = Properties.testsFilter

--- a/compiler/test/dotty/tools/dotc/FromTastyTests.scala
+++ b/compiler/test/dotty/tools/dotc/FromTastyTests.scala
@@ -44,7 +44,7 @@ object FromTastyTests extends ParallelTesting {
   // Test suite configuration --------------------------------------------------
 
   def maxDuration = 30.seconds
-  def numberOfSlaves = Runtime.getRuntime().availableProcessors()
+  def numberOfWorkers = Runtime.getRuntime().availableProcessors()
   def safeMode = Properties.testsSafeMode
   def isInteractive = SummaryReport.isInteractive
   def testFilter = Properties.testsFilter

--- a/compiler/test/dotty/tools/dotc/IdempotencyTests.scala
+++ b/compiler/test/dotty/tools/dotc/IdempotencyTests.scala
@@ -72,7 +72,7 @@ object IdempotencyTests extends ParallelTesting {
   // Test suite configuration --------------------------------------------------
 
   def maxDuration = 30.seconds
-  def numberOfSlaves = 5
+  def numberOfWorkers = 5
   def safeMode = Properties.testsSafeMode
   def isInteractive = SummaryReport.isInteractive
   def testFilter = Properties.testsFilter

--- a/compiler/test/dotty/tools/dotc/TastyBootstrapTests.scala
+++ b/compiler/test/dotty/tools/dotc/TastyBootstrapTests.scala
@@ -110,7 +110,7 @@ object TastyBootstrapTests extends ParallelTesting {
   // Test suite configuration --------------------------------------------------
 
   def maxDuration = 45.seconds
-  def numberOfSlaves = Runtime.getRuntime.availableProcessors()
+  def numberOfWorkers = Runtime.getRuntime.availableProcessors()
   def safeMode = Properties.testsSafeMode
   def isInteractive = SummaryReport.isInteractive
   def testFilter = Properties.testsFilter

--- a/compiler/test/dotty/tools/dotc/coverage/CoverageTests.scala
+++ b/compiler/test/dotty/tools/dotc/coverage/CoverageTests.scala
@@ -124,7 +124,7 @@ object CoverageTests extends ParallelTesting:
   import scala.concurrent.duration.*
 
   def maxDuration = 30.seconds
-  def numberOfSlaves = 1
+  def numberOfWorkers = 1
 
   def safeMode = Properties.testsSafeMode
   def testFilter = Properties.testsFilter

--- a/compiler/test/dotty/tools/vulpix/RunnerOrchestration.scala
+++ b/compiler/test/dotty/tools/vulpix/RunnerOrchestration.scala
@@ -15,7 +15,7 @@ import scala.concurrent.{ Await, Future }
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.collection.mutable
 
-/** Vulpix spawns JVM subprocesses (`numberOfSlaves`) in order to run tests
+/** Vulpix spawns JVM subprocesses (`numberOfWorkers`) in order to run tests
  *  without compromising the main JVM
  *
  *  These need to be orchestrated in a safe manner with a simple protocol. This
@@ -37,7 +37,7 @@ import scala.collection.mutable
 trait RunnerOrchestration {
 
   /** The maximum amount of active runners, which contain a child JVM */
-  def numberOfSlaves: Int
+  def numberOfWorkers: Int
 
   /** The maximum duration the child process is allowed to consume before
    *  getting destroyed
@@ -176,7 +176,7 @@ trait RunnerOrchestration {
     private val busyRunners = mutable.Set.empty[Runner]
 
     private def getRunner(): Runner = synchronized {
-      while (freeRunners.isEmpty && busyRunners.size >= numberOfSlaves) wait()
+      while (freeRunners.isEmpty && busyRunners.size >= numberOfWorkers) wait()
 
       val runner =
         if (freeRunners.isEmpty) new Runner(createProcess)

--- a/compiler/test/dotty/tools/vulpix/VulpixMetaTests.scala
+++ b/compiler/test/dotty/tools/vulpix/VulpixMetaTests.scala
@@ -25,7 +25,7 @@ class VulpixMetaTests {
 object VulpixMetaTests extends ParallelTesting {
   def maxDuration = 1.seconds
   // Ensure maximum reproducibility.
-  def numberOfSlaves = 1
+  def numberOfWorkers = 1
   def safeMode = false // Don't fork a new VM after each run test
   def isInteractive = false // Don't beautify output for interactive use.
   def testFilter = Nil // Run all the tests.

--- a/compiler/test/dotty/tools/vulpix/VulpixUnitTests.scala
+++ b/compiler/test/dotty/tools/vulpix/VulpixUnitTests.scala
@@ -95,7 +95,7 @@ class VulpixUnitTests:
 object VulpixUnitTests extends ParallelTesting:
   import scala.concurrent.duration.*
   def maxDuration = 3.seconds
-  def numberOfSlaves = 5
+  def numberOfWorkers = 5
   def safeMode = sys.env.get("SAFEMODE").isDefined
   def isInteractive = !sys.env.contains("DOTTY_CI_RUN")
   def testFilter = Nil

--- a/sjs-compiler-tests/test/scala/dotty/tools/dotc/ScalaJSCompilationTests.scala
+++ b/sjs-compiler-tests/test/scala/dotty/tools/dotc/ScalaJSCompilationTests.scala
@@ -19,7 +19,7 @@ class ScalaJSCompilationTests extends ParallelTesting {
   // Test suite configuration --------------------------------------------------
 
   def maxDuration = 60.seconds
-  def numberOfSlaves = 5
+  def numberOfWorkers = 5
   def safeMode = Properties.testsSafeMode
   def isInteractive = SummaryReport.isInteractive
   def testFilter = Properties.testsFilter


### PR DESCRIPTION
Backports #24338 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]