### PR TITLE
Backport "Fix crash in Selectable unapply with custom applyDynamic" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Dynamic.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Dynamic.scala
@@ -43,9 +43,9 @@ object DynamicUnapply {
   def unapply(tree: tpd.Tree): Option[List[tpd.Tree]] = tree match
     case TypeApply(Select(qual, name), _) if name == nme.asInstanceOfPM =>
       unapply(qual)
-    case Apply(Apply(Select(selectable, fname), Literal(Constant(name)) :: ctag :: Nil), _ :: implicits)
+    case Apply(Apply(Select(selectable, fname), Literal(Constant(name)) :: restArgs), _ :: implicits)
     if fname == nme.applyDynamic && (name == "unapply" || name == "unapplySeq") =>
-      Some(selectable :: ctag :: implicits)
+      Some(selectable :: (restArgs ::: implicits))
     case _ =>
       None
 }

--- a/tests/neg/i24168.scala
+++ b/tests/neg/i24168.scala
@@ -1,0 +1,12 @@
+trait Generic extends Selectable:
+  def applyDynamic(name: String)(args: Any*): Any = ()
+
+val foo: Generic {
+  def unapply(x: Int): Option[Unit]
+} = new Generic:
+  def unapply(x: Int): Option[Unit] = Some(())
+
+def x =
+  42 match
+    case foo(()) => println("lol") // error
+


### PR DESCRIPTION
Backports #24343 to the 3.3.7.

PR submitted by the release tooling.
