### PR TITLE
Backport "Remove pipes from multi-line REPL prompts" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/repl/JLineTerminal.scala
+++ b/compiler/src/dotty/tools/repl/JLineTerminal.scala
@@ -37,7 +37,7 @@ class JLineTerminal extends java.io.Closeable {
     else str
   protected def promptStr = "scala"
   private def prompt(using Context)        = blue(s"\n$promptStr> ")
-  private def newLinePrompt(using Context) = blue("     | ")
+  private def newLinePrompt(using Context) = "       "
 
   /** Blockingly read line from `System.in`
    *


### PR DESCRIPTION
Backports #24307 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]