### PR TITLE
Backport "Upgrade ASM to 9.9 for JDK 26 support" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/BackendUtils.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BackendUtils.scala
@@ -187,6 +187,7 @@ object BackendUtils {
     22 -> asm.Opcodes.V22,
     23 -> asm.Opcodes.V23,
     24 -> asm.Opcodes.V24,
-    25 -> asm.Opcodes.V25
+    25 -> asm.Opcodes.V25,
+    26 -> asm.Opcodes.V26,
   )
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -670,7 +670,7 @@ object Build {
 
       // get libraries onboard
       libraryDependencies ++= Seq(
-        "org.scala-lang.modules" % "scala-asm" % "9.8.0-scala-1", // used by the backend
+        "org.scala-lang.modules" % "scala-asm" % "9.9.0-scala-1", // used by the backend
         Dependencies.compilerInterface,
         "org.jline" % "jline-reader" % "3.29.0",   // used by the REPL
         "org.jline" % "jline-terminal" % "3.29.0",


### PR DESCRIPTION
Backports #24430 to the 3.3.7.

PR submitted by the release tooling.