### PR TITLE
Backport "chore: add regression test for #24460" to 3.3 LTS

### DIFF
--- a/tests/neg/i24460.check
+++ b/tests/neg/i24460.check
@@ -1,0 +1,18 @@
+-- Error: tests/neg/i24460.scala:12:20 ---------------------------------------------------------------------------------
+ 12 |  val _ = singletons[A, (A.A1.type, A.A2.type, A.A3.type)] // error
+    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |          cannot reduce summonFrom with
+    |           patterns :  case given ev @ _:ValueOf[(test.A.A1 : test.A) & test.A]
+    |-------------------------------------------------------------------------------------------------------------------
+    |Inline stack trace
+    |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    |This location contains code that was inlined from Predef.scala:156
+156 |  inline def valueOf[T]: T = summonFrom {
+    |                             ^
+157 |    case ev: ValueOf[T] => ev.value
+158 |  }
+    |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    |This location contains code that was inlined from Predef.scala:156
+  7 |      case _: (h *: t) => valueOf[`h` & T] +: singletons[T, t]
+    |                          ^^^^^^^^^^^^^^^^
+     -------------------------------------------------------------------------------------------------------------------

--- a/tests/neg/i24460.scala
+++ b/tests/neg/i24460.scala
@@ -1,0 +1,13 @@
+import scala.compiletime.{erasedValue, summonFrom}
+
+object test {
+  private inline def singletons[T, Elem <: Tuple]: Seq[T] =
+    inline erasedValue[Elem] match {
+      case _: EmptyTuple => Seq.empty
+      case _: (h *: t) => valueOf[`h` & T] +: singletons[T, t]
+    }
+
+  enum A { case A1, A2, A3 }
+
+  val _ = singletons[A, (A.A1.type, A.A2.type, A.A3.type)] // error
+}


### PR DESCRIPTION
Backports #24480 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]