### PR TITLE
Backport "Fix #24456: Cleanup the info of a Bind symbol in posttyper" to 3.3 LTS

### DIFF
--- a/tests/pos-custom-args/captures/i24456.scala
+++ b/tests/pos-custom-args/captures/i24456.scala
@@ -1,0 +1,14 @@
+// Similar to i24207
+
+class Generator:
+  private def generateTable(table: Table) =
+    val (ownRelations, unusedTerm) = calculateOwnRelations(table)
+    None
+
+  private def calculateOwnRelations(table: Table) =
+    val ownRelations = table.relations.filter(_.association.isDefined)
+    (ownRelations, Nil)
+
+case class Table(relations: Seq[TableRelation])
+case class TableRelation(association: Option[Association])
+trait Association

--- a/tests/pos/i24456.scala
+++ b/tests/pos/i24456.scala
@@ -1,0 +1,14 @@
+// Similar to i24207
+
+class Generator:
+  private def generateTable(table: Table) =
+    val (ownRelations, unusedTerm) = calculateOwnRelations(table)
+    None
+
+  private def calculateOwnRelations(table: Table) =
+    val ownRelations = table.relations.filter(_.association.isDefined)
+    (ownRelations, Nil)
+
+case class Table(relations: Seq[TableRelation])
+case class TableRelation(association: Option[Association])
+trait Association


### PR DESCRIPTION
Backports #24490 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]