### PR TITLE
Backport "Accommodate adapted Scala 2 annotation value" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Annotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Annotations.scala
@@ -38,7 +38,7 @@ object Annotations {
       if (i < args.length) Some(args(i)) else None
     }
     def argumentConstant(i: Int)(using Context): Option[Constant] =
-      for (case ConstantType(c) <- argument(i) map (_.tpe.widenTermRefExpr.normalized)) yield c
+      for case ConstantType(c) <- argument(i).map(stripCast(_).tpe.widenTermRefExpr.normalized) yield c
 
     def argumentConstantString(i: Int)(using Context): Option[String] =
       for (case Constant(s: String) <- argumentConstant(i)) yield s

--- a/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
@@ -973,14 +973,14 @@ class Scala2Unpickler(bytes: Array[Byte], classRoot: ClassDenotation, moduleClas
   /** Read an annotation argument, which is pickled either
    *  as a Constant or a Tree.
    */
-  protected def readAnnotArg(i: Int)(using Context): untpd.Tree = untpd.TypedSplice(bytes(index(i)) match
+  protected def readAnnotArg(i: Int)(using Context): untpd.Tree = untpd.TypedSplice:
+    bytes(index(i)) match
     case TREE => at(i, () => readTree())
     case _ => at(i, () =>
       readConstant() match
         case c: Constant => Literal(c)
         case tp: TermRef => ref(tp)
     )
-  )
 
   /** Read a ClassfileAnnotArg (argument to a classfile annotation)
    */

--- a/compiler/src/dotty/tools/dotc/transform/Erasure.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Erasure.scala
@@ -563,9 +563,9 @@ object Erasure {
           report.error(msg, tree.srcPos)
         tree.symbol.getAnnotation(defn.CompileTimeOnlyAnnot) match
           case Some(annot) =>
-            val message = annot.argumentConstant(0) match
-              case Some(c) =>
-                c.stringValue.toMessage
+            val message = annot.argumentConstantString(0) match
+              case Some(msg) =>
+                msg.toMessage
               case _ =>
                 em"""Reference to ${tree.symbol.showLocated} should not have survived,
                     |it should have been processed and eliminated during expansion of an enclosing macro or term erasure."""

--- a/tests/neg/no-unit.check
+++ b/tests/neg/no-unit.check
@@ -1,0 +1,14 @@
+-- [E190] Potential Issue Warning: tests/neg/no-unit.scala:7:2 ---------------------------------------------------------
+7 |  Unit // error
+  |  ^^^^
+  |  Discarded non-Unit value of type object Unit. Add `: Unit` to discard silently.
+  |
+  | longer explanation available when compiling with `-explain`
+-- Error: tests/neg/no-unit.scala:1:8 ----------------------------------------------------------------------------------
+1 |val u = Unit // error
+  |        ^^^^
+  |        `Unit` companion object is not allowed in source; instead, use `()` for the unit value
+-- Error: tests/neg/no-unit.scala:7:2 ----------------------------------------------------------------------------------
+7 |  Unit // error
+  |  ^^^^
+  |  `Unit` companion object is not allowed in source; instead, use `()` for the unit value

--- a/tests/neg/no-unit.scala
+++ b/tests/neg/no-unit.scala
@@ -1,0 +1,7 @@
+val u = Unit // error
+
+inline def a(inline f: Unit ?=> Unit): Unit = f(using ())
+
+def s5bug = a:
+  print(2)
+  Unit // error

--- a/tests/neg/serialversionuid-not-const.scala
+++ b/tests/neg/serialversionuid-not-const.scala
@@ -1,6 +1,6 @@
 @SerialVersionUID(13l.toLong) class C1 extends Serializable // error
 @SerialVersionUID(13l) class C2 extends Serializable // OK
-@SerialVersionUID(13.asInstanceOf[Long]) class C3 extends Serializable // error
+@SerialVersionUID(13.asInstanceOf[Long]) class C3 extends Serializable // OK was error
 @SerialVersionUID(Test.bippy) class C4 extends Serializable // error
 
 object Test {


### PR DESCRIPTION
Backports #17516 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]