### PR TITLE
Backport "Use a better span for an anonymous class" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -981,7 +981,11 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
           typedAhead(parent, tree => inferTypeParams(typedType(tree), pt))
         val anon = tpnme.ANON_CLASS
         val clsDef = TypeDef(anon, templ1).withFlags(Final | Synthetic)
-        typed(cpy.Block(tree)(clsDef :: Nil, New(Ident(anon), Nil)), pt)
+        typed(
+          cpy.Block(tree)(
+            clsDef :: Nil,
+            New(Ident(anon), Nil).withSpan(tree.span)),
+          pt)
       case _ =>
         var tpt1 = typedType(tree.tpt)
         val tsym = tpt1.tpe.underlyingClassRef(refinementOK = false).typeSymbol

--- a/tests/neg/6570-1.check
+++ b/tests/neg/6570-1.check
@@ -1,14 +1,14 @@
--- [E007] Type Mismatch Error: tests/neg/6570-1.scala:23:27 ------------------------------------------------------------
+-- [E007] Type Mismatch Error: tests/neg/6570-1.scala:23:14 ------------------------------------------------------------
 23 |  def thing = new Trait1 {} // error
-   |                           ^
-   |                           Found:    Object with Trait1 {...}
-   |                           Required: N[Box[Int & String]]
+   |              ^^^^^^^^^^^^^
+   |              Found:    Object with Trait1 {...}
+   |              Required: N[Box[Int & String]]
    |
-   |                           Note: a match type could not be fully reduced:
+   |              Note: a match type could not be fully reduced:
    |
-   |                             trying to reduce  N[Box[Int & String]]
-   |                             failed since selector Box[Int & String]
-   |                             is uninhabited (there are no values of that type).
+   |                trying to reduce  N[Box[Int & String]]
+   |                failed since selector Box[Int & String]
+   |                is uninhabited (there are no values of that type).
    |
    | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg/6570-1.scala:36:54 ------------------------------------------------------------


### PR DESCRIPTION
Backports #24640 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]