### PR TITLE
Backport "chore: add regression test for #8194" to 3.3 LTS

### DIFF
--- a/tests/neg/i8194.check
+++ b/tests/neg/i8194.check
@@ -1,0 +1,12 @@
+-- [E173] Reference Error: tests/neg/i8194.scala:5:22 ------------------------------------------------------------------
+5 |@main def main = Test.foo // error
+  |                 ^^^^^^^^
+  |   class A cannot be accessed as a member of (Test : Test.type) from the top-level definitions in package <empty>.
+  |     private class A can only be accessed from object Test.
+  |---------------------------------------------------------------------------------------------------------------------
+  |Inline stack trace
+  |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  |This location contains code that was inlined from i8194.scala:3
+3 |  inline def foo: Int = A().test
+  |                        ^
+   ---------------------------------------------------------------------------------------------------------------------

--- a/tests/neg/i8194.scala
+++ b/tests/neg/i8194.scala
@@ -1,0 +1,5 @@
+object Test {
+  private class A() { def test = 42 }
+  inline def foo: Int = A().test
+}
+@main def main = Test.foo // error


### PR DESCRIPTION
Backports #24655 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]