### PR TITLE
Backport "chore: add regression test for #8581" to 3.3 LTS

### DIFF
--- a/tests/pos/i8581/Macro_1.scala
+++ b/tests/pos/i8581/Macro_1.scala
@@ -1,0 +1,11 @@
+import scala.quoted.*
+
+case class Position()
+object Position {
+  implicit inline def here: Position = ${ genPosition }
+
+  private def genPosition(using Quotes): Expr[Position] = {
+    val lineNo: Int = quotes.reflect.Position.ofMacroExpansion.startLine
+    '{ Position() }
+  }
+}

--- a/tests/pos/i8581/Test_2.scala
+++ b/tests/pos/i8581/Test_2.scala
@@ -1,0 +1,16 @@
+import scala.concurrent.duration.FiniteDuration
+import scala.language.implicitConversions
+import scala.reflect.ClassTag
+
+class AnyShouldWrapper[T]
+
+class Test {
+  implicit def convertToAnyShouldWrapper[T](o: T)(implicit pos: Position): AnyShouldWrapper[T] = ???
+
+  def expectMsgType[T](implicit t: ClassTag[T]): T = ???
+  def expectMsgType[T](max: FiniteDuration)(implicit t: ClassTag[T]): T = ???
+
+  def test(): Unit = {
+    expectMsgType[Int]: AnyShouldWrapper[Int]
+  }
+}


### PR DESCRIPTION
Backports #24666 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]