### PR TITLE
Backport "Parameter name can be masked in import" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
@@ -357,6 +357,7 @@ class CheckUnused private (phaseMode: PhaseMode, suffix: String) extends MiniPha
           if matches then sel else loop(sels)
         case nil => null
       loop(info.selectors)
+    end matchingSelector
 
     def checkMember(ctxsym: Symbol): Boolean =
       ctxsym.isClass && sym.owner.isClass
@@ -380,38 +381,37 @@ class CheckUnused private (phaseMode: PhaseMode, suffix: String) extends MiniPha
       val cur = ctxs.next()
       if cur.owner.userSymbol == sym && !sym.is(Package) then
         enclosed = true // found enclosing definition, don't record the reference
-      if isLocal then
-        if cur.owner eq sym.owner then
-          done = true // for local def, just checking that it is not enclosing
-      else
-        if cur.isImportContext then
-          val sel = matchingSelector(cur.importInfo.nn)
-          if sel != null then
-            if cur.importInfo.nn.isRootImport then
-              if precedence.weakerThan(OtherUnit) then
-                precedence = OtherUnit
-                candidate = cur
-                importer = sel
-              done = true
-            else if sel.isWildcard then
-              if precedence.weakerThan(Wildcard) then
-                precedence = Wildcard
-                candidate = cur
-                importer = sel
-            else
-              if precedence.weakerThan(NamedImport) then
-                precedence = NamedImport
-                candidate = cur
-                importer = sel
-        else if checkMember(cur.owner) then
-          if sym.is(Package) || sym.srcPos.sourcePos.source == ctx.source then
-            precedence = Definition
-            candidate = cur
-            importer = null // ignore import in same scope; we can't check nesting level
+      if cur.isImportContext then
+        val sel = matchingSelector(cur.importInfo.nn)
+        if sel != null then
+          if cur.importInfo.nn.isRootImport then
+            if precedence.weakerThan(OtherUnit) then
+              precedence = OtherUnit
+              candidate = cur
+              importer = sel
             done = true
-          else if precedence.weakerThan(OtherUnit) then
-            precedence = OtherUnit
-            candidate = cur
+          else if sel.isWildcard then
+            if precedence.weakerThan(Wildcard) then
+              precedence = Wildcard
+              candidate = cur
+              importer = sel
+          else
+            if precedence.weakerThan(NamedImport) then
+              precedence = NamedImport
+              candidate = cur
+              importer = sel
+      else if isLocal then
+        if cur.owner eq sym.owner then
+          done = true // local def or param
+      else if checkMember(cur.owner) then
+        if sym.is(Package) || sym.srcPos.sourcePos.source == ctx.source then
+          precedence = Definition
+          candidate = cur
+          importer = null // ignore import in same scope; we can't check nesting level
+          done = true
+        else if precedence.weakerThan(OtherUnit) then
+          precedence = OtherUnit
+          candidate = cur
     end while
     // record usage and possibly an import
     if !enclosed then

--- a/tests/warn/i24633.scala
+++ b/tests/warn/i24633.scala
@@ -1,0 +1,20 @@
+//> using options -Werror -Wunused:imports
+
+object foo {
+  val min = 0
+  val max = 1
+}
+
+def test(max: Int) = {
+  import foo.{max as _, *}
+  s"$min - $max"
+}
+
+def local =
+  val max = 42
+  import foo.{max as _, *}
+  s"$min - $max"
+
+class Limit(max: Int):
+  import foo.{max as _, *}
+  def test = s"$min - $max"


### PR DESCRIPTION
Backports #24635 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]