### PR TITLE
Backport "fix: do not allow `@targetName` on primary constructor too" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2613,6 +2613,10 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
     if sym.isConstructor then
       if sym.is(Inline) then
         report.error("constructors cannot be `inline`", ddef)
+
+      if sym.targetName != sym.name then
+        report.error(em"@targetName annotation may not be used on a constructor", ddef.srcPos)
+
       if sym.isPrimaryConstructor then
         if sym.owner.is(Case) then
           for
@@ -2622,9 +2626,6 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
             if defn.isContextFunctionType(param.tpt.tpe) then
               report.error("case class element cannot be a context function", param.srcPos)
       else
-        if sym.targetName != sym.name then
-          report.error(em"@targetName annotation may not be used on a constructor", ddef.srcPos)
-
         for params <- paramss1; param <- params do
           checkRefsLegal(param, sym.owner, (name, sym) => sym.is(TypeParam), "secondary constructor")
 

--- a/tests/neg/i24681.check
+++ b/tests/neg/i24681.check
@@ -1,0 +1,4 @@
+-- Error: tests/neg/i24681.scala:3:9 -----------------------------------------------------------------------------------
+3 |class Foo @targetName("bla") () // error
+  |         ^^^^^^^^^^^^^^^^^^^^^^
+  |         @targetName annotation may not be used on a constructor

--- a/tests/neg/i24681.scala
+++ b/tests/neg/i24681.scala
@@ -1,0 +1,3 @@
+import scala.annotation.targetName
+
+class Foo @targetName("bla") () // error


### PR DESCRIPTION
Backports #24682 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]