### PR TITLE
Backport "Lint enum case in outer context" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
@@ -181,7 +181,7 @@ class CheckUnused private (phaseMode: PhaseMode, suffix: String) extends MiniPha
     if !tree.symbol.is(Deferred) && tree.rhs.symbol != defn.Predef_undefined then
       register(tree)
     relax(tree.rhs, tree.tpt.tpe)
-    ctx
+    if tree.symbol.isAllOf(EnumCase) then ctx.outer else ctx
   override def transformValDef(tree: ValDef)(using Context): tree.type =
     traverseAnnotations(tree.symbol)
     if tree.name.startsWith("derived$") && tree.hasType then
@@ -210,6 +210,8 @@ class CheckUnused private (phaseMode: PhaseMode, suffix: String) extends MiniPha
       refInfos.inliners -= 1
     tree
 
+  override def prepareForTypeDef(tree: TypeDef)(using Context): Context =
+    if tree.symbol.isAllOf(EnumCase) then ctx.outer else ctx
   override def transformTypeDef(tree: TypeDef)(using Context): tree.type =
     traverseAnnotations(tree.symbol)
     if !tree.symbol.is(Param) then // type parameter to do?

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/MatchCaseCompletions.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/MatchCaseCompletions.scala
@@ -134,7 +134,7 @@ object CaseKeywordCompletion:
                 ),
                 Nil,
                 range = Some(completionPos.toEditRange),
-                command = Option(config.parameterHintsCommand()).flatMap(_.asScala),
+                command = Option(config.parameterHintsCommand()).flatMap(_.nn.asScala),
               )
             )
           else Nil

--- a/tests/warn/i24646.scala
+++ b/tests/warn/i24646.scala
@@ -1,0 +1,13 @@
+//> using options -Wunused:all
+
+import Test.OnlyFirst
+import Test.OnlyThird
+
+enum Test:
+  case First extends Test with OnlyFirst
+  case Second extends Test
+  case Third(s: String) extends Test with OnlyThird
+
+object Test:
+  sealed trait OnlyFirst
+  sealed trait OnlyThird


### PR DESCRIPTION
Backports #24652 to the 3.3.7.

PR submitted by the release tooling.