### PR TITLE
Backport "Work around `sbt#8376` and re-enable shapeless-3 community build" to 3.3 LTS

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1946,7 +1946,7 @@ object Build {
     publishConfiguration ~= (_.withOverwrite(true)),
     publishLocalConfiguration ~= (_.withOverwrite(true)),
     projectID ~= {id =>
-      val line = "scala.versionLine" -> versionLine
+      val line = "info.scala.versionLine" -> versionLine
       id.withExtraAttributes(id.extraAttributes + line)
     },
     Test / publishArtifact := false,


### PR DESCRIPTION
Backports #24709 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]