### PR TITLE
Backport "Exclude XRayModeHint for synthetics" to 3.3 LTS

### DIFF
--- a/presentation-compiler/src/main/dotty/tools/pc/PcInlayHintsProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/PcInlayHintsProvider.scala
@@ -526,17 +526,17 @@ object XRayModeHint:
         anotherTree
          .innerSelect()
          */
-        case a @ Apply(inner, _)
-            if inner.sourcePos.exists && !isParentOnSameLine && !isParentApply &&
-              endsInSimpleSelect(a) && isEndOfLine(tree.sourcePos) =>
-          Some((a.tpe.widen.deepDealiasAndSimplify, tree.sourcePos))
+        case apply @ Apply(inner, _)
+            if !apply.span.isZeroExtent && inner.sourcePos.exists && !isParentOnSameLine &&
+            !isParentApply && endsInSimpleSelect(apply) && isEndOfLine(tree.sourcePos) =>
+          Some((apply.tpe.widen.deepDealiasAndSimplify, tree.sourcePos))
         /*
         innerTree
          .select
          */
         case select @ Select(innerTree, _)
-            if innerTree.sourcePos.exists && !isParentOnSameLine && !isParentApply &&
-              isEndOfLine(tree.sourcePos) =>
+            if !select.span.isZeroExtent && innerTree.sourcePos.exists &&
+            !isParentOnSameLine && !isParentApply && isEndOfLine(tree.sourcePos) =>
           Some((select.tpe.widen.deepDealiasAndSimplify, tree.sourcePos))
         case _ => None
     else None

--- a/presentation-compiler/test/dotty/tools/pc/tests/inlayHints/InlayHintsSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/inlayHints/InlayHintsSuite.scala
@@ -1634,4 +1634,23 @@ class InlayHintsSuite extends BaseInlayHintsSuite {
          |""".stripMargin
     )
 
+  @Test def `xray-metals-i7999` =
+    check(
+      """|object Main{
+         |   case class User(
+         |      name: String = {
+         |         Map.toString
+         |      }
+         |   )
+         |}
+         |""".stripMargin,
+      """|object Main{
+         |   case class User(
+         |      name: String = {
+         |         Map.toString
+         |      }
+         |   )
+         |}
+         |""".stripMargin
+    )
 }


### PR DESCRIPTION
Backports #24722 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]