### PR TITLE
Backport "Fix inconsistent `typeSize` calculation for `TupleN` vs recursive pair encodings" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -6595,6 +6595,8 @@ object Types extends TypeUtils {
     var seen = util.HashSet[Type](initialCapacity = 8)
     def apply(n: Int, tp: Type): Int =
       tp match {
+        case tp: AppliedType if defn.isTupleNType(tp) =>
+          foldOver(n + 1, tp.toNestedPairs)
         case tp: AppliedType =>
           val tpNorm = tp.tryNormalize
           if tpNorm.exists then apply(n, tpNorm)

--- a/compiler/test/dotty/tools/dotc/core/TypesTest.scala
+++ b/compiler/test/dotty/tools/dotc/core/TypesTest.scala
@@ -1,0 +1,18 @@
+package dotty.tools.dotc.core
+
+import dotty.tools.DottyTest
+import dotty.tools.dotc.core.Symbols.defn
+import dotty.tools.dotc.core.TypeOps
+
+import org.junit.Test
+import org.junit.Assert.assertEquals
+
+class TypesTest extends DottyTest:
+
+  @Test def tuple3TypeSize =
+    val tpe = defn.TupleType(3).nn.appliedTo(List(defn.IntType, defn.BooleanType, defn.DoubleType))
+    assertEquals(3, tpe.typeSize)
+
+  @Test def tuple3ConsTypeSize =
+    val tpe = TypeOps.nestedPairs(List(defn.IntType, defn.BooleanType, defn.DoubleType))
+    assertEquals(3, tpe.typeSize)

--- a/compiler/test/dotty/tools/dotc/typer/DivergenceChecker.scala
+++ b/compiler/test/dotty/tools/dotc/typer/DivergenceChecker.scala
@@ -50,8 +50,8 @@ class DivergenceCheckerTests extends DottyTest {
           1,
           1,
           1,
-          3,
-          5
+          4,
+          6
         )
 
         tpes.lazyZip(expectedSizes).lazyZip(expectedCoveringSets).foreach {


### PR DESCRIPTION
Backports #24743 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]