### PR TITLE
Backport "Closes #7532: Parameter hints not working for functions" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/util/Signatures.scala
+++ b/compiler/src/dotty/tools/dotc/util/Signatures.scala
@@ -379,7 +379,7 @@ object Signatures {
     case other => other.stripAnnots
 
   /**
-   * Checks if tree is valid for signatureHelp. Skipped trees are either tuple or function applies
+   * Checks if tree is valid for signatureHelp. Skips tuple apply trees
    *
    * @param tree tree to validate
    */
@@ -389,12 +389,7 @@ object Signatures {
         && tree.symbol.exists
         && ctx.definitions.isTupleClass(tree.symbol.owner.companionClass)
 
-    val isFunctionNApply =
-      tree.symbol.name == nme.apply
-        && tree.symbol.exists
-        && ctx.definitions.isFunctionSymbol(tree.symbol.owner)
-
-    !isTupleApply && !isFunctionNApply
+    !isTupleApply
 
   /**
    * Get unapply method result type omiting unknown types and another method calls.

--- a/presentation-compiler/test/dotty/tools/pc/tests/signaturehelp/SignatureHelpInterleavingSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/signaturehelp/SignatureHelpInterleavingSuite.scala
@@ -111,7 +111,9 @@ class SignatureHelpInterleavingSuite extends BaseSignatureHelpSuite:
         |  def pair[A](a: A)[B](b: B): (A, B) = (a, b)
         |  pair[Int][@@String]
       """.stripMargin,
-      ""
+      """|apply(v1: Int): Any => (Int, Any)
+         |      ^^^^^^^
+         |""".stripMargin
     )
 
   @Test def `inferred-type-param-1` =

--- a/presentation-compiler/test/dotty/tools/pc/tests/signaturehelp/SignatureHelpSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/signaturehelp/SignatureHelpSuite.scala
@@ -1252,26 +1252,6 @@ class SignatureHelpSuite extends BaseSignatureHelpSuite:
       ""
     )
 
-  // Improvement would be to create synthetic signature help showing
-  // add(x: Int)(y: Int): Int
-  @Test def `dont-show-functionN` =
-    check(
-      """|object Main:
-         |  val add = (x: Int) => (y: Int) => x + y
-         |  add(@@)
-         |""".stripMargin,
-         ""
-    )
-
-  @Test def `dont-show-functionN-2` =
-    check(
-      """|object Main:
-         |  val add = (x: Int) => (y: Int) => x + y
-         |  add(1, @@)
-         |""".stripMargin,
-         ""
-    )
-
   @Test def `type-param-start` =
     check(
       """|object Main:
@@ -1610,3 +1590,39 @@ class SignatureHelpSuite extends BaseSignatureHelpSuite:
       |            ^^^^^^
       """.stripMargin
     )
+
+  @Test def `proper-function-signature` =
+    check(
+      """
+        |object OOO {
+        |
+        |val function: (x: Int, y: String) => Unit =
+        |(_, _) =>
+        | ()
+        |
+        |function(@@, "one")
+        |}
+      """.stripMargin,
+      """|apply(v1: Int, v2: String): Unit
+         |      ^^^^^^^
+         |""".stripMargin
+    )
+
+  @Test def `proper-function-signature-with-explicit-apply` =
+    check(
+      """
+        |object OOO {
+        |
+        |val function: (x: Int, y: String) => Unit =
+        |(_, _) =>
+        | ()
+        |
+        |function.apply(@@, "one")
+        |}
+      """.stripMargin,
+      """|apply(v1: Int, v2: String): Unit
+         |      ^^^^^^^
+         |""".stripMargin
+    )
+
+


### PR DESCRIPTION
Backports #23854 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]