### PR TITLE
Backport "Fix opaque types displayed as `Nothing & Any` in hover and signature help" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/coverage/Coverage.scala
+++ b/compiler/src/dotty/tools/dotc/coverage/Coverage.scala
@@ -8,7 +8,7 @@ import java.nio.file.Path
 class Coverage:
   private val statementsById = new mutable.LongMap[Statement](256)
 
-  private var _nextStatementId: Int = 1
+  private var _nextStatementId: Int = 0
 
   def nextStatementId(): Int = _nextStatementId
   def setNextStatementId(id: Int): Unit = _nextStatementId = id

--- a/compiler/src/dotty/tools/dotc/coverage/Location.scala
+++ b/compiler/src/dotty/tools/dotc/coverage/Location.scala
@@ -46,5 +46,5 @@ object Location:
       s"$packageName.$className",
       classType,
       methodName,
-      source.file.absolute.jpath
+      source.file.absolute.jpath.nn
     )

--- a/compiler/src/dotty/tools/dotc/transform/InstrumentCoverage.scala
+++ b/compiler/src/dotty/tools/dotc/transform/InstrumentCoverage.scala
@@ -71,7 +71,7 @@ class InstrumentCoverage extends MacroTransform with IdentityDenotTransformer:
     coverageExcludeClasslikePatterns = ctx.settings.coverageExcludeClasslikes.value.map(_.r.pattern)
     coverageExcludeFilePatterns = ctx.settings.coverageExcludeFiles.value.map(_.r.pattern)
 
-    ctx.base.coverage.nn.removeStatementsFromFile(ctx.compilationUnit.source.file.absolute.jpath)
+    ctx.base.coverage.nn.removeStatementsFromFile(ctx.compilationUnit.source.file.absolute.jpath.nn)
     ctx.base.coverage.nn.setNextStatementId(previousCoverage.nextStatementId())
 
     super.run
@@ -276,7 +276,7 @@ class InstrumentCoverage extends MacroTransform with IdentityDenotTransformer:
 
     override def transform(tree: Tree)(using Context): Tree =
       val path = tree.sourcePos.source.file.absolute.jpath
-      lastCompiledFiles += path.toString
+      if path != null then lastCompiledFiles += path.toString
 
       inContext(transformCtx(tree)) { // necessary to position inlined code properly
         tree match

--- a/compiler/src/dotty/tools/dotc/util/Signatures.scala
+++ b/compiler/src/dotty/tools/dotc/util/Signatures.scala
@@ -244,7 +244,7 @@ object Signatures {
         findCurrentParamIndex(untpdArgs, span, alternativeSymbol.paramSymss(safeParamssListIndex).length - 1)
 
       val pre = treeQualifier(fun)
-      val alternativesWithTypes = alternatives.map(_.asSeenFrom(pre.tpe.widenTermRefExpr))
+      val alternativesWithTypes = alternatives.map(_.asSeenFrom(pre.tpe))
       val alternativeSignatures = alternativesWithTypes
         .flatMap(toApplySignature(_, findOutermostCurriedApply(untpdPath), safeParamssListIndex))
 

--- a/compiler/src/dotty/tools/io/AbstractFile.scala
+++ b/compiler/src/dotty/tools/io/AbstractFile.scala
@@ -116,7 +116,7 @@ abstract class AbstractFile extends Iterable[AbstractFile] {
   }
 
   /** Returns the underlying Path if any and null otherwise. */
-  def jpath: JPath
+  def jpath: JPath | Null
 
   /** An underlying source, if known.  Mostly, a zip/jar file. */
   def underlyingSource: Option[AbstractFile] = None

--- a/compiler/test-resources/repl-macros/i15104c
+++ b/compiler/test-resources/repl-macros/i15104c
@@ -1,6 +1,6 @@
 scala> import scala.quoted._
 scala> def macroImpl(using Quotes) = Expr(1)
-def macroImpl(using x$1: Quotes): scala.quoted.Expr[Int]
+def macroImpl(using x$1: Quotes): Expr[Int]
 scala> inline def foo = ${ macroImpl }
 def foo: Int
 scala> foo

--- a/compiler/test-resources/repl-macros/i5551
+++ b/compiler/test-resources/repl-macros/i5551
@@ -1,8 +1,6 @@
 scala> import scala.quoted._
 scala> def assertImpl(expr: Expr[Boolean])(using q: Quotes) = '{ if !($expr) then throw new AssertionError("failed assertion")}
-def assertImpl
-  (expr: Expr[Boolean])
-    (using q: Quotes): Expr[Unit]
+def assertImpl(expr: Expr[Boolean])(using q: Quotes): Expr[Unit]
 scala>   inline def assert(expr: => Boolean): Unit =  ${ assertImpl('{expr}) }
 def assert(expr: => Boolean): Unit
 

--- a/compiler/test-resources/repl/i10355
+++ b/compiler/test-resources/repl/i10355
@@ -1,9 +1,5 @@
 scala> import scala.quoted._
 scala> def foo(expr: Expr[Any])(using Quotes) = expr match { case '{ $x: t } => '{ $x: Any } }
-def foo
-  (expr: Expr[Any])
-    (using x$2: Quotes): Expr[Any]
+def foo(expr: Expr[Any])(using x$2: Quotes): Expr[Any]
 scala> def bar(expr: Expr[Any])(using Quotes) = expr match { case '{ $x: t } => '{ val a: t = ??? ; ???} }
-def bar
-  (expr: Expr[Any])
-    (using x$2: Quotes): Expr[Nothing]
+def bar(expr: Expr[Any])(using x$2: Quotes): Expr[Nothing]

--- a/presentation-compiler/src/main/dotty/tools/pc/utils/InteractiveEnrichments.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/utils/InteractiveEnrichments.scala
@@ -303,7 +303,7 @@ object InteractiveEnrichments extends CommonMtagsEnrichments:
     def seenFrom(sym: Symbol)(using Context): (Type, Symbol) =
       try
         val pre = tree.qual
-        val denot = sym.denot.asSeenFrom(pre.typeOpt.widenTermRefExpr)
+        val denot = sym.denot.asSeenFrom(pre.typeOpt)
         (denot.info, sym.withUpdatedTpe(denot.info))
       catch case NonFatal(e) => (sym.info, sym)
 

--- a/presentation-compiler/test/dotty/tools/pc/tests/hover/HoverDefnSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/hover/HoverDefnSuite.scala
@@ -260,7 +260,7 @@ class HoverDefnSuite extends BaseHoverSuite:
     check(
       """|
          |@ma@@in
-         |def example() = 
+         |def example() =
          |    println("test")
          |""".stripMargin,
       """|```scala
@@ -272,7 +272,7 @@ class HoverDefnSuite extends BaseHoverSuite:
       check(
         """|
           |@ma@@in
-          |def example() = 
+          |def example() =
           |    List("test")
           |""".stripMargin,
         """|```scala
@@ -284,7 +284,7 @@ class HoverDefnSuite extends BaseHoverSuite:
       check(
         """|
           |@ma@@in
-          |def example() = 
+          |def example() =
           |    Array("test")
           |""".stripMargin,
         """|```scala
@@ -296,10 +296,21 @@ class HoverDefnSuite extends BaseHoverSuite:
       check(
         """|
           |@ma@@in
-          |def example() = 
+          |def example() =
           |    Array(1, 2)
           |""".stripMargin,
         """|```scala
           |def this(): main
           |```""".stripMargin.hover
+      )
+
+  @Test def `opaque-type-method` =
+      check(
+        """|object History {
+           |  opaque type Builder[A] = String
+           |  def <<bui@@ld>>(b: Builder[Unit]): Int = ???
+           |}
+           |""".stripMargin,
+        """|def build(b: Builder[Unit]): Int
+           |""".stripMargin.hover
       )

--- a/presentation-compiler/test/dotty/tools/pc/tests/hover/HoverTermSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/hover/HoverTermSuite.scala
@@ -870,3 +870,18 @@ class HoverTermSuite extends BaseHoverSuite:
          |""".stripMargin,
       "val aa: Int".hover
     )
+
+  @Test def `opaque-type-method-call` =
+    check(
+      """|object History {
+         |  opaque type Builder[A] = String
+         |  def emptyBuilder: Builder[Unit] = ""
+         |  def build(b: Builder[Unit]): Int = ???
+         |}
+         |object Main {
+         |  <<History.bui@@ld(History.emptyBuilder)>>
+         |}
+         |""".stripMargin,
+      """|def build(b: Builder[Unit]): Int
+         |""".stripMargin.hover
+    )

--- a/presentation-compiler/test/dotty/tools/pc/tests/signaturehelp/SignatureHelpSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/signaturehelp/SignatureHelpSuite.scala
@@ -1576,7 +1576,7 @@ class SignatureHelpSuite extends BaseSignatureHelpSuite:
         |""".stripMargin,
       "foo[K, V](): Unit"
     )
-  
+
   @Test def `proper-param-list-after-param-empty-list` =
     check(
       """
@@ -1626,3 +1626,17 @@ class SignatureHelpSuite extends BaseSignatureHelpSuite:
     )
 
 
+  @Test def `opaque-type-parameter` =
+    check(
+      """|object History {
+         |  opaque type Builder[A] = String
+         |  def build(b: Builder[Unit]): Int = ???
+         |}
+         |object Main {
+         |  History.build(@@)
+         |}
+         |""".stripMargin,
+      """|build(b: Builder[Unit]): Int
+         |      ^^^^^^^^^^^^^^^^
+         |""".stripMargin
+    )

--- a/staging/test-resources/repl-staging/i6007
+++ b/staging/test-resources/repl-staging/i6007
@@ -1,9 +1,9 @@
 scala> import scala.quoted._
 scala> import quoted.staging.{Compiler => StagingCompiler, _}
 scala> implicit def compiler: StagingCompiler = StagingCompiler.make(getClass.getClassLoader)
-def compiler: scala.quoted.staging.Compiler
+def compiler: StagingCompiler
 scala> def v(using Quotes) = '{ (if true then Some(1) else None).map(v => v+1) }
-def v(using x$1: scala.quoted.Quotes): scala.quoted.Expr[Option[Int]]
+def v(using x$1: Quotes): Expr[Option[Int]]
 scala> scala.quoted.staging.withQuotes(v.show)
 val res0: String = (if (true) scala.Some.apply[scala.Int](1) else scala.None).map[scala.Int](((v: scala.Int) => v.+(1)))
 scala> scala.quoted.staging.run(v)

--- a/staging/test-resources/repl-staging/i6263
+++ b/staging/test-resources/repl-staging/i6263
@@ -1,9 +1,9 @@
 scala> import quoted._
 scala> import quoted.staging.{Compiler => StagingCompiler, _}
 scala> implicit def compiler: StagingCompiler = StagingCompiler.make(getClass.getClassLoader)
-def compiler: scala.quoted.staging.Compiler
+def compiler: StagingCompiler
 scala> def fn[T : Type](v : T) = println("ok")
-def fn[T](v: T)(implicit evidence$1: scala.quoted.Type[T]): Unit
+def fn[T](v: T)(implicit evidence$1: Type[T]): Unit
 scala> withQuotes { fn("foo") }
 ok
 scala> withQuotes { fn((1,2)) }


### PR DESCRIPTION
Backports #24921 to the 3.3.7.

PR submitted by the release tooling.