### PR TITLE
[CI] Use repo.scala-lang to check if nightlies are published

### DIFF
--- a/project/scripts/is-version-published.sh
+++ b/project/scripts/is-version-published.sh
@@ -30,7 +30,7 @@ binaryVersion="${ver%%.*}"
 artifactId="scala3-compiler_$binaryVersion"
 pom="$artifactId-$ver.pom"
 
-maven_url=https://repo1.maven.org/maven2/org/scala-lang/$artifactId/$ver/$pom
+maven_url=https://repo.scala-lang.org/artifactory/maven-nightlies/org/scala-lang/$artifactId/$ver/$pom
 
 echo "Checking whether $ver is published"
 echo "at $maven_url"


### PR DESCRIPTION
Fixes check executed for nightly builds - the main repo checkouts this repository, and uses is-version-published.sh defined in here. Becouse it was unsychronized it tried to check in the repo1.maven.org even though artifacts are pushed to repo.scala-lang.org