### PR TITLE
Backport "Extend copyright into 2026" to 3.3 LTS

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,6 +1,6 @@
 Scala 3 (https://www.scala-lang.org)
-Copyright 2012-2025 EPFL
-Copyright 2012-2025 Lightbend, Inc. dba Akka
+Copyright 2012-2026 EPFL
+Copyright 2012-2026 Lightbend, Inc. dba Akka
 
 Licensed under the Apache License, Version 2.0 (the "License"):
 http://www.apache.org/licenses/LICENSE-2.0

--- a/pkgs/chocolatey/scala.nuspec
+++ b/pkgs/chocolatey/scala.nuspec
@@ -13,7 +13,7 @@
     <projectSourceUrl>https://github.com/scala/scala3</projectSourceUrl>
     <projectUrl>https://scala-lang.org/</projectUrl>
     <bugTrackerUrl>https://github.com/scala/scala3/issues</bugTrackerUrl>
-    <copyright>© 2002-2025, LAMP/EPFL</copyright>
+    <copyright>© 2002-2026, LAMP/EPFL</copyright>
     <iconUrl>https://cdn.jsdelivr.net/gh/scala/scala3@a046b0014ffd9536144d67a48f8759901b96d12f/pkgs/chocolatey/icon.svg</iconUrl>
     <licenseUrl>https://github.com/scala/scala3/blob/main/LICENSE</licenseUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>


### PR DESCRIPTION
Backports #24927 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]