### PR TITLE
Backport "Find annotation args in inline expansion" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/BCodeHelpers.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeHelpers.scala
@@ -315,9 +315,8 @@ trait BCodeHelpers extends BCodeIdiomatic {
               case e => List(e)
             }
           }
-          for(arg <- flatArgs) {
+          for arg <- flatArgs do
             emitArgument(arrAnnotV, null, arg, bcodeStore)(innerClasesStore)
-          }
           arrAnnotV.visitEnd()
   /*
         case sb @ ScalaSigBytes(bytes) =>
@@ -337,6 +336,9 @@ trait BCodeHelpers extends BCodeIdiomatic {
           val desc = innerClasesStore.typeDescriptor(typ) // the class descriptor of the nested annotation class
           val nestedVisitor = av.visitAnnotation(name, desc)
           emitAssocs(nestedVisitor, assocs, bcodeStore)(innerClasesStore)
+
+        case Inlined(_, _, expansion) =>
+          emitArgument(av, name, arg = expansion, bcodeStore)(innerClasesStore)
 
         case t =>
           report.error(em"Annotation argument is not a constant", t.sourcePos)

--- a/tests/pos/i24894a/Bar_1.scala
+++ b/tests/pos/i24894a/Bar_1.scala
@@ -1,0 +1,10 @@
+object Bar {
+  import quoted.*
+
+  inline transparent def bar(): Array[String] = ${ macroBar() }
+  def macroBar()(using Quotes): Expr[Array[String]] = {
+    val l = Range(0, 200, 10).map(_.toString).map(Expr(_)).toList
+    '{ Array[String](${ Varargs(l) }*) }
+    //'{ Array[String]("hello", "world") }
+  }
+}

--- a/tests/pos/i24894a/Foo_2.scala
+++ b/tests/pos/i24894a/Foo_2.scala
@@ -1,0 +1,2 @@
+@Param(Bar.bar()) class Foo
+@Param(Array("hi", "bi")) class Baz

--- a/tests/pos/i24894a/Param.java
+++ b/tests/pos/i24894a/Param.java
@@ -1,0 +1,15 @@
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Inherited
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Param {
+
+    String[] value();
+
+}

--- a/tests/pos/i24894b/Bar_1.scala
+++ b/tests/pos/i24894b/Bar_1.scala
@@ -1,0 +1,9 @@
+object Bar {
+  import quoted.*
+
+  transparent inline def bar(): String = ${ macroBar() }
+  def macroBar()(using Quotes): Expr[String] = {
+    val s = "hello".reverse
+    Expr(s)
+  }
+}

--- a/tests/pos/i24894b/Foo_2.scala
+++ b/tests/pos/i24894b/Foo_2.scala
@@ -1,0 +1,1 @@
+@Deprecated(since = Bar.bar()) class Foo

--- a/tests/pos/i24894c/OutputTimeUnit.java
+++ b/tests/pos/i24894c/OutputTimeUnit.java
@@ -1,0 +1,18 @@
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+@Inherited
+@Target({ElementType.METHOD,ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface OutputTimeUnit {
+
+    /**
+     * @return Time unit to use.
+     */
+    TimeUnit value();
+
+}

--- a/tests/pos/i24894c/i21881.scala
+++ b/tests/pos/i24894c/i21881.scala
@@ -1,0 +1,11 @@
+class C:
+
+  //final val Seconds = java.util.concurrent.TimeUnit.SECONDS
+  //inline val Seconds = java.util.concurrent.TimeUnit.SECONDS // not a literal
+  inline transparent def Seconds = java.util.concurrent.TimeUnit.SECONDS
+
+  @OutputTimeUnit(Seconds)
+  def f(): Unit = ()
+
+  @OutputTimeUnit(java.util.concurrent.TimeUnit.SECONDS)
+  def ok(): Unit = ()


### PR DESCRIPTION
Backports #24895 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]