### PR TITLE
Backport "Unused lint ignores args to ctor of enclosing class" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
@@ -120,6 +120,13 @@ class CheckUnused private (phaseMode: PhaseMode, suffix: String) extends MiniPha
         if fun.symbol.is(Module) && defn.isTupleClass(fun.symbol.companionClass) then
           args.foreach(_.withAttachment(ForArtifact, ()))
       case _ =>
+    else if !tree.tpe.isInstanceOf[MethodOrPoly] then
+      val f = funPart(tree)
+      if f.symbol.isConstructor then
+        f match
+        case Select(_: New, nme.CONSTRUCTOR) if ctx.outersIterator.exists(_.owner eq f.symbol.owner) =>
+          ignoreArgsOfSelfConstruction(tree, f.symbol)
+        case _ =>
     ctx
   override def transformApply(tree: Apply)(using Context): tree.type =
     // check for multiversal equals
@@ -983,6 +990,13 @@ object CheckUnused:
           case _ =>
           traverseChildren(tree)
       relaxer.traverse(tree)
+
+  def ignoreArgsOfSelfConstruction(tree: Apply, ctor: Symbol)(using Context): Unit =
+    val pars = ctor.denot.paramSymss.flatten.iterator.filter(_.isTerm)
+    val args = allTermArguments(tree)
+    for (par, arg) <- pars.zip(args) do
+      if arg.symbol.is(ParamAccessor) && arg.symbol.name == par.name && arg.symbol.owner == ctor.owner then
+        arg.putAttachment(Ignore, ())
 
   extension (nm: Name)
     inline def exists(p: Name => Boolean): Boolean = nm.ne(nme.NO_NAME) && p(nm)

--- a/tests/warn/i24698.scala
+++ b/tests/warn/i24698.scala
@@ -1,0 +1,22 @@
+//> using options -Wunused:all
+
+trait TC[X] {
+  def notTrivial: Int
+}
+
+class C[T: TC]() { // warn implicit TC used only for new instance of owner
+  def mod: C[T] = new C
+}
+
+class D(val i: Int):
+  def this(s: String) = this(s.toInt) // not new
+
+class E[T](tc: TC[T]): // warn
+  def mod: E[T] = new E(tc)
+
+class F[T: TC](i: Int): // warn // warn
+  def mod: F[T] = new F(i)
+
+class G(i: Int): // warn
+  class Inner(i: Int):
+    def g = new G(i)


### PR DESCRIPTION
Backports #24768 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]