### PR TITLE
Backport "Fix negative activeParameter in signature help" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/util/Signatures.scala
+++ b/compiler/src/dotty/tools/dotc/util/Signatures.scala
@@ -162,7 +162,9 @@ object Signatures {
     val typeName = fun.symbol.name.show
     val typeParams = fun.symbol.typeRef.typeParams.map(_.paramName.show).map(TypeParam.apply(_))
     val denot = fun.denot.asSingleDenotation
-    val activeParameter = findCurrentParamIndex(types, span, typeParams.length - 1)
+    val activeParameter =
+      val index = findCurrentParamIndex(types, span, typeParams.length - 1)
+      if index == -1 then 0 else index
 
     val signature = Signature(typeName, List(typeParams), Some(typeName) , None, Some(denot))
     (activeParameter, 0, List(signature))
@@ -248,9 +250,14 @@ object Signatures {
       val alternativeSignatures = alternativesWithTypes
         .flatMap(toApplySignature(_, findOutermostCurriedApply(untpdPath), safeParamssListIndex))
 
+      val totalParamCount = alternativeSymbol.paramSymss.foldLeft(0)(_ + _.length)
       val finalParamIndex =
-        if currentParamsIndex == -1 then -1
-        else previousArgs + currentParamsIndex
+        val index = if currentParamsIndex == -1 then previousArgs
+                    else previousArgs + currentParamsIndex
+        // Ensure activeParameter is non-negative (LSP requirement)
+        // For empty parameter lists, allow index to equal totalParamCount
+        // so presentation compiler can skip highlighting
+        index max 0
       (finalParamIndex, alternativeIndex, alternativeSignatures)
     else
       (0, 0, Nil)
@@ -317,7 +324,9 @@ object Signatures {
     val paramTypes = extractParamTypess(resultType, denot, patterns.size).flatten.map(stripAllAnnots)
     val paramNames = extractParamNamess(resultType, denot).flatten
 
-    val activeParameter = findCurrentParamIndex(patterns, span, paramTypes.length - 1)
+    val activeParameter =
+      val index = findCurrentParamIndex(patterns, span, paramTypes.length - 1)
+      if index == -1 then 0 else index
     val unapplySignature = toUnapplySignature(denot.asSingleDenotation, paramNames, paramTypes).toList
 
     (activeParameter, 0, unapplySignature)

--- a/language-server/test/dotty/tools/languageserver/SignatureHelpTest.scala
+++ b/language-server/test/dotty/tools/languageserver/SignatureHelpTest.scala
@@ -124,7 +124,7 @@ class SignatureHelpTest {
           |object O {
           |  Foo(5).method($m1)
           |}"""
-      .signatureHelp(m1, List(testSig), Some(0), -1)
+      .signatureHelp(m1, List(testSig), Some(0), 0)
   }
 
   @Test def unapplyBooleanReturn: Unit = {
@@ -136,7 +136,7 @@ class SignatureHelpTest {
           |    case s @ Even(${m1}) => println(s"s has an even number of characters")
           |    case s               => println(s"s has an odd number of characters")
           """
-      .signatureHelp(m1, Nil, Some(0), -1)
+      .signatureHelp(m1, Nil, Some(0), 0)
   }
 
   @Test def unapplyCustomClass: Unit = {

--- a/presentation-compiler/test/dotty/tools/pc/base/BaseSignatureHelpSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/base/BaseSignatureHelpSuite.scala
@@ -43,7 +43,7 @@ abstract class BaseSignatureHelpSuite extends BasePCSuite:
         out
           .append(signature.getLabel)
           .append("\n")
-        if (result.getActiveSignature == i && result.getActiveParameter != null && result.getActiveParameter() >= 0 && signature.getParameters.size() > 0) {
+        if (result.getActiveSignature == i && result.getActiveParameter != null && result.getActiveParameter() >= 0 && result.getActiveParameter() < signature.getParameters.size()) {
           val param = signature.getParameters.get(result.getActiveParameter)
           val label = param.getLabel.getLeft()
           /* We need to find the label of the active parameter and show ^ at that spot


### PR DESCRIPTION
Backports #24945 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]