### PR TITLE
Backport "More descriptive "not found" message when type/term exists with the expected term/type name" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/DidYouMean.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/DidYouMean.scala
@@ -5,7 +5,7 @@ package reporting
 import core.*
 import Contexts.*
 import Decorators.*, Symbols.*, Names.*, Types.*, Flags.*
-import typer.ProtoTypes.{FunProto, SelectionProto}
+import typer.ProtoTypes.SelectionProto
 
 /** A utility object to support "did you mean" hinting */
 object DidYouMean:
@@ -100,7 +100,7 @@ object DidYouMean:
         else (dist(j - 1)(i) min dist(j)(i - 1) min dist(j - 1)(i - 1)) + 1
     dist(s2.length)(s1.length)
 
-  /** List of possible candidate names with their Levenstein distances
+  /** List of possible candidate names with their Levenshtein distances
    *  to the name `from` of the missing member.
    *  @param maxDist  Maximal number of differences to be considered for a hint
    *                  A distance qualifies if it is at most `maxDist`, shorter than

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -19,7 +19,7 @@ import config.{Feature, ScalaVersion}
 import transform.patmat.Space
 import transform.patmat.SpaceEngine
 import typer.ErrorReporting.{err, matchReductionAddendum, substitutableTypeSymbolsInScope}
-import typer.ProtoTypes.{ViewProto, SelectionProto, FunProto}
+import typer.ProtoTypes.{ViewProto, FunProto}
 import typer.Implicits.*
 import typer.Inferencing
 import scala.util.control.NonFatal
@@ -34,7 +34,6 @@ import cc.CaptureSet.IdentityCaptRefMap
 import dotty.tools.dotc.rewrites.Rewrites.ActionPatch
 import dotty.tools.dotc.util.Spans.Span
 import dotty.tools.dotc.util.SourcePosition
-import scala.jdk.CollectionConverters.*
 import dotty.tools.dotc.util.SourceFile
 import DidYouMean.*
 
@@ -271,13 +270,18 @@ class MissingIdent(tree: untpd.Ident, treeKind: String, val name: Name, proto: T
 extends NotFoundMsg(MissingIdentID) {
   def msg(using Context) =
     val missing = name.show
-    val addendum =
-      didYouMean(
-        inScopeCandidates(name.isTypeName, isApplied = proto.isInstanceOf[FunProto], rootImportOK = true)
-          .closestTo(missing),
-        proto, "")
-
-    i"Not found: $treeKind$name$addendum"
+    // If we're looking for a term or type X and a type or term X respectively is in scope, don't emit "Not found: X" as that's confusing for beginners
+    val wrongKind = inScopeCandidates(!name.isTypeName, isApplied = proto.isInstanceOf[FunProto], rootImportOK = true).closestTo(missing, maxDist = 0)
+    if wrongKind.nonEmpty then
+      if name.isTypeName then
+        val extra = if wrongKind.exists(_._2.sym.denot.is(Module)) then f" - did you mean $name.type?" else ""
+        i"Expected a type, but found a term: $name$extra"
+      else
+        i"Expected a term, but found a type: $name"
+    else
+      val candidates = inScopeCandidates(name.isTypeName, isApplied = proto.isInstanceOf[FunProto], rootImportOK = true).closestTo(missing)
+      val addendum = didYouMean(candidates, proto, "")
+      i"Not found: $treeKind$name$addendum"
   def explain(using Context) = {
     i"""|Each identifier in Scala needs a matching declaration. There are two kinds of
         |identifiers: type identifiers and value identifiers. Value identifiers are introduced
@@ -289,7 +293,8 @@ extends NotFoundMsg(MissingIdentID) {
         |
         |Possible reasons why no matching declaration was found:
         | - The declaration or the use is mis-spelt.
-        | - An import is missing."""
+        | - An import is missing.
+        | - The declaration exists but refers to a type in a context where a term is expected, or vice-versa."""
   }
 }
 

--- a/tests/neg/notfound-term-but-type.check
+++ b/tests/neg/notfound-term-but-type.check
@@ -1,0 +1,6 @@
+-- [E006] Not Found Error: tests/neg/notfound-term-but-type.scala:1:22 -------------------------------------------------
+1 |def test[T] = println(T) // error
+  |                      ^
+  |                      Expected a term, but found a type: T
+  |
+  | longer explanation available when compiling with `-explain`

--- a/tests/neg/notfound-term-but-type.scala
+++ b/tests/neg/notfound-term-but-type.scala
@@ -1,0 +1,1 @@
+def test[T] = println(T) // error

--- a/tests/neg/notfound-type-but-term.check
+++ b/tests/neg/notfound-type-but-term.check
@@ -1,0 +1,6 @@
+-- [E006] Not Found Error: tests/neg/notfound-type-but-term.scala:3:12 -------------------------------------------------
+3 |def test(): O = ??? // error
+  |            ^
+  |            Expected a type, but found a term: O - did you mean O.type?
+  |
+  | longer explanation available when compiling with `-explain`

--- a/tests/neg/notfound-type-but-term.scala
+++ b/tests/neg/notfound-type-but-term.scala
@@ -1,0 +1,3 @@
+object O
+
+def test(): O = ??? // error

--- a/tests/neg/yimports-order.check
+++ b/tests/neg/yimports-order.check
@@ -1,7 +1,7 @@
 -- [E006] Not Found Error: tests/neg/yimports-order.scala:9:16 ---------------------------------------------------------
 9 |      def f() = Map("hello" -> "world") // error // error
   |                ^^^
-  |                Not found: Map
+  |                Expected a term, but found a type: Map
   |
   | longer explanation available when compiling with `-explain`
 -- [E008] Not Found Error: tests/neg/yimports-order.scala:9:28 ---------------------------------------------------------


### PR DESCRIPTION
Backports #24959 to the 3.3.7.

PR submitted by the release tooling.