### PR TITLE
Backport "Presentation compiler: propagate isDebug timeout check to all tests" to 3.3 LTS

### DIFF
--- a/presentation-compiler/test/dotty/tools/pc/base/BasePCSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/base/BasePCSuite.scala
@@ -32,7 +32,7 @@ object TestResources:
 @RunWith(classOf[ReusableClassRunner])
 abstract class BasePCSuite extends PcAssertions:
   val completionItemPriority: CompletionItemPriority = (_: String) => 0
-  private val isDebug = ManagementFactory.getRuntimeMXBean.getInputArguments.toString.contains("-agentlib:jdwp")
+  protected val isDebug = ManagementFactory.getRuntimeMXBean.getInputArguments.toString.contains("-agentlib:jdwp")
 
   val tmp = Files.createTempDirectory("stable-pc-tests")
   val executorService: ScheduledExecutorService =
@@ -58,8 +58,8 @@ abstract class BasePCSuite extends PcAssertions:
       .withCompletionItemPriority(completionItemPriority)
       .newInstance("", myclasspath.asJava, scalacOpts.asJava)
 
-  protected def config: PresentationCompilerConfig =
-    PresentationCompilerConfigImpl().copy(snippetAutoIndent = false, timeoutDelay = if isDebug then 3600 else 5)
+  protected def config: PresentationCompilerConfigImpl =
+    PresentationCompilerConfigImpl().copy(snippetAutoIndent = false, timeoutDelay = if isDebug then 3600 else 10)
 
   private def inspectDialect(filename: String, code: String) =
     val file = tmp.resolve(filename)

--- a/presentation-compiler/test/dotty/tools/pc/tests/CompilerCachingSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/CompilerCachingSuite.scala
@@ -30,7 +30,7 @@ class CompilerCachingSuite extends BasePCSuite:
       case pc: ScalaPresentationCompiler =>
         val compilations = pc.compilerAccess.withNonInterruptableCompiler(-1, EmptyCancelToken) { driver =>
           driver.compiler().currentCtx.runId
-        }(emptyQueryContext).get(timeout.length, timeout.unit)
+        }(using emptyQueryContext).get(timeout.length, timeout.unit)
         assertEquals(expected, compilations, s"Expected $expected compilations but got $compilations")
       case _ => throw IllegalStateException("Presentation compiler should always be of type of ScalaPresentationCompiler")
 
@@ -39,7 +39,7 @@ class CompilerCachingSuite extends BasePCSuite:
       case pc: ScalaPresentationCompiler =>
         pc.compilerAccess.withNonInterruptableCompiler(null, EmptyCancelToken) { driver =>
           driver.compiler().currentCtx
-        }(emptyQueryContext).get(timeout.length, timeout.unit)
+        }(using emptyQueryContext).get(timeout.length, timeout.unit)
       case _ => throw IllegalStateException("Presentation compiler should always be of type of ScalaPresentationCompiler")
 
   private def emptyQueryContext = PcQueryContext(None, () => "")(using EmptyReportContext())
@@ -133,7 +133,7 @@ class CompilerCachingSuite extends BasePCSuite:
     checkCompilationCount(6)
 
 
-  private val testFunctions: List[OffsetParams => CompletableFuture[_]] = List(
+  private val testFunctions: List[OffsetParams => CompletableFuture[?]] = List(
     presentationCompiler.complete(_),
     presentationCompiler.convertToNamedArguments(_, Collections.emptyList()),
     presentationCompiler.autoImports("a", _, false),

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionCancelSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionCancelSuite.scala
@@ -24,9 +24,9 @@ import org.junit.Test
 
 class CompletionCancelSuite extends BaseCompletionSuite:
 
-  override protected def config: PresentationCompilerConfig =
-    PresentationCompilerConfigImpl().copy(
-      // to make "break-compilation" test faster
+  override def config: PresentationCompilerConfigImpl =
+    if isDebug then super.config else super.config.copy(
+      // to make "break-compilation" test faster when run outside a debugger
       timeoutDelay = 5
     )
 

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionCaseSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionCaseSuite.scala
@@ -11,8 +11,8 @@ class CompletionCaseSuite extends BaseCompletionSuite:
 
   def paramHint: Option[String] = Some("param-hint")
 
-  override def config: PresentationCompilerConfig =
-    PresentationCompilerConfigImpl().copy(
+  override def config: PresentationCompilerConfigImpl =
+    super.config.copy(
       _parameterHintsCommand = paramHint
     )
 

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionOverrideConfigSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionOverrideConfigSuite.scala
@@ -10,8 +10,8 @@ import org.junit.Test
 
 class CompletionOverrideConfigSuite extends BaseCompletionSuite:
 
-  override def config: PresentationCompilerConfig =
-    PresentationCompilerConfigImpl().copy(
+  override def config: PresentationCompilerConfigImpl =
+    super.config.copy(
       _symbolPrefixes = Map(
         "a/Weekday." -> "w",
         "java/util/function/" -> "f"

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionPatternSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionPatternSuite.scala
@@ -11,8 +11,8 @@ class CompletionPatternSuite extends BaseCompletionSuite:
 
   def paramHint: Option[String] = Some("param-hint")
 
-  override def config: PresentationCompilerConfig =
-    PresentationCompilerConfigImpl().copy(
+  override def config: PresentationCompilerConfigImpl =
+    super.config.copy(
       _parameterHintsCommand = paramHint
     )
 

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSnippetNegSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSnippetNegSuite.scala
@@ -9,8 +9,8 @@ import org.junit.Test
 
 class CompletionSnippetNegSuite extends BaseCompletionSuite:
 
-  override def config: PresentationCompilerConfig =
-    PresentationCompilerConfigImpl(
+  override def config: PresentationCompilerConfigImpl =
+    super.config.copy(
       isCompletionSnippetsEnabled = false
     )
 

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionWithoutDetailsSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionWithoutDetailsSuite.scala
@@ -9,8 +9,8 @@ import org.junit.Test
 
 class CompletionWithoutDetailsSuite extends BaseCompletionSuite:
 
-  override def config: PresentationCompilerConfig =
-    PresentationCompilerConfigImpl().copy(
+  override def config: PresentationCompilerConfigImpl =
+    super.config.copy(
       isDetailIncludedInLabel = false
     )
 

--- a/presentation-compiler/test/dotty/tools/pc/tests/hover/HoverPlainTextSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/hover/HoverPlainTextSuite.scala
@@ -11,8 +11,8 @@ import scala.meta.pc.PresentationCompilerConfig
 
 class HoverPlainTextSuite extends BaseHoverSuite:
 
-  override protected def config: PresentationCompilerConfig =
-    PresentationCompilerConfigImpl().copy(
+  override def config: PresentationCompilerConfigImpl =
+    super.config.copy(
       snippetAutoIndent = false,
       hoverContentType = ContentType.PLAINTEXT
     )


### PR DESCRIPTION
Backports #25068 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]