### PR TITLE
Backport "Avoid NPE when calling hashCode on a value class wrapping null" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/BCodeHelpers.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeHelpers.scala
@@ -299,7 +299,7 @@ trait BCodeHelpers extends BCodeIdiomatic {
         // Check if the symbol's pre-erasure type was a singleton of a Java enum value.
         case t: tpd.RefTree if atPhase(erasurePhase) {
           t.symbol.info.finalResultType match
-            case tr: TermRef => tr.termSymbol.owner.linkedClass.isAllOf(JavaEnum)
+            case tr: TermRef => tr.termSymbol.owner.linkedClass.isAllOf(JavaEnumTrait)
             case _ => false
         } =>
           val enumRef = atPhase(erasurePhase)(t.symbol.info.finalResultType.asInstanceOf[TermRef])

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -698,6 +698,10 @@ class Definitions {
   @tu lazy val JavaFormattableClass: ClassSymbol = requiredClass("java.util.Formattable")
   @tu lazy val JavaRecordClass: Symbol = getClassIfDefined("java.lang.Record")
 
+  @tu lazy val JavaUtilObjectsClass: ClassSymbol = requiredModule("java.util.Objects").moduleClass.asClass
+  def Objects_hashCode(using Context): Symbol =
+    JavaUtilObjectsClass.info.member(nme.hashCode_).suchThat(_.info.firstParamTypes.length == 1).symbol
+
   @tu lazy val JavaEnumClass: ClassSymbol = {
     val cls = requiredClass("java.lang.Enum")
     // jl.Enum has a single constructor protected(name: String, ordinal: Int).

--- a/compiler/src/dotty/tools/dotc/transform/SyntheticMembers.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SyntheticMembers.scala
@@ -290,15 +290,23 @@ class SyntheticMembers(thisPhase: DenotTransformer) {
      *  class C(x: T) extends AnyVal
      *  ```
      *
-     *  gets the `hashCode` method:
-     *
+     *  gets the `hashCode` method. If the value is primitive:
      *  ```
      *  def hashCode: Int = x.hashCode()
+     *  ```
+     *  otherwise, the null-safe variant:
+     *  ```
+     *  def hashCode: Int = java.util.Objects.hashCode(x)
      *  ```
      */
     def valueHashCodeBody(using Context): Tree = {
       assert(accessors.nonEmpty)
-      ref(accessors.head).select(nme.hashCode_).ensureApplied
+      val accessor = accessors.head
+      val tp = accessor.info.finalResultType
+      if (tp.classSymbol.isPrimitiveValueClass)
+        ref(accessor).select(nme.hashCode_).ensureApplied
+      else
+        ref(defn.Objects_hashCode).appliedTo(ref(accessor))
     }
 
     /**

--- a/tests/run/t7396.scala
+++ b/tests/run/t7396.scala
@@ -1,0 +1,42 @@
+class L(val x: Int) extends AnyVal
+class M(val s: String) extends AnyVal
+class N[T](val t: T) extends AnyVal
+case class O(s: String) extends AnyVal
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    val l = new L(0)
+    assert(l.hashCode == 0)
+    assert(l.toString == "L@0")
+
+    val m = new M(null)
+    assert(m.hashCode == 0)
+    assert(m.toString == "M@0")
+    assert(m == new M(null))
+    val mm = new M("")
+    assert(mm.toString == "M@0")
+    assert(mm.hashCode == 0)
+    assert(m != mm)
+
+    val n = new N(new N(new M(null)))
+    assert(n.hashCode == 0)
+    assert(n.toString == "N@0")
+    assert(n != new N(new M(null)))
+
+    val o = O(null)
+    assert(o.hashCode == 0)
+    assert(o.toString == "O(null)")
+    assert(o == O(null))
+    val oo = O("")
+    assert(oo.hashCode == 0)
+    assert(oo.toString == "O()")
+    assert(o != oo)
+
+    val map = collection.mutable.HashMap.empty[M, Int]
+    map(m) = 1
+    map(mm) = 2
+    assert(map(m) == 1)
+    assert(map(new M(null)) == 1)
+    assert(map(new M("")) == 2)
+  }
+}


### PR DESCRIPTION
Backports #25110 to the 3.3.7.

PR submitted by the release tooling.