### PR TITLE
Backport "Cast inline call results to result type, not method type" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/inlines/Inlines.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inlines.scala
@@ -566,12 +566,13 @@ object Inlines:
             val withAdjustedThisTypes = if call.symbol.is(Macro) then fixThisTypeModuleClassReferences(unpacked) else unpacked
             (call.tpe & withAdjustedThisTypes, withAdjustedThisTypes != unpacked)
           else (call.tpe, false)
+        val resultType = target.widenIfUnstable
         if forceCast then
           // we need to force the cast for issues with ThisTypes, as ensureConforms will just
           // check subtyping and then choose not to cast, leaving the previous, incorrect type
-          inlined.cast(target)
+          inlined.cast(resultType)
         else
-          inlined.ensureConforms(target)
+          inlined.ensureConforms(resultType)
           // Make sure that the sealing with the declared type
           // is type correct. Without it we might get problems since the
           // expression's type is the opaque alias but the call's type is

--- a/tests/pos/i25091.scala
+++ b/tests/pos/i25091.scala
@@ -1,0 +1,22 @@
+transparent trait VersionComponent[T]:
+    protected def minimumValue: Int
+    inline def minimum: T = wrap(minimumValue)
+    inline def reset: T = minimum
+    inline def wrap(value: Int): T
+    inline def unwrap(value: T): Int
+
+opaque type MajorVersion = Int
+object MajorVersion extends  VersionComponent[MajorVersion]:
+    protected inline def minimumValue: Int = 0
+    inline def wrap(value: Int): MajorVersion = value
+    inline def unwrap(mv: MajorVersion): Int = mv
+
+case class Version(major: MajorVersion)
+object Version:
+  trait Increment[F]:
+    extension (v: Version) def increment: Version
+
+  object Increment:
+    given Increment[MajorVersion]:
+      extension (v: Version)
+        inline def increment: Version = Version(MajorVersion.reset)

--- a/tests/pos/i25091b.scala
+++ b/tests/pos/i25091b.scala
@@ -1,0 +1,15 @@
+object Test:
+  trait VersionComponent[T]:
+      inline def minimum: T = wrap(42)
+      inline def wrap(value: Int): T
+
+  opaque type MajorVersionType = Int
+  object MajorVersion extends VersionComponent[MajorVersionType]:
+      inline def wrap(value: Int): MajorVersionType = value
+      inline def reset: MajorVersionType = minimum
+
+  trait Increment[F]:
+    def increment: MajorVersionType
+
+  class MyIncrement extends Increment[MajorVersionType]:
+    inline def increment: MajorVersionType = MajorVersion.reset


### PR DESCRIPTION
Backports #25111 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]