### PR TITLE
Backport "bugfix: inline value false-positive shadowing with lambda params" to 3.3 LTS

### DIFF
--- a/presentation-compiler/test/dotty/tools/pc/tests/edit/InlineValueSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/edit/InlineValueSuite.scala
@@ -497,6 +497,21 @@ class InlineValueSuite extends BaseCodeActionSuite with CommonMtagsEnrichments:
          |""".stripMargin
     )
 
+  @Test def `lambda-param-no-shadow` =
+    checkEdit(
+      """|object Main {
+         |  def test(x: Int) = {
+         |    val pq = List(1, 2, 3).map(x => x + 1)
+         |    <<pq>>.sum
+         |  }
+         |}""".stripMargin,
+      """|object Main {
+         |  def test(x: Int) = {
+         |    List(1, 2, 3).map(x => x + 1).sum
+         |  }
+         |}""".stripMargin
+    )
+
   def checkEdit(
       original: String,
       expected: String,


### PR DESCRIPTION
Backports #25140 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]