### PR TITLE
Backport "Test hover on backticked identifiers with whitespace" to 3.3 LTS

### DIFF
--- a/presentation-compiler/test/dotty/tools/pc/tests/hover/HoverDefnSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/hover/HoverDefnSuite.scala
@@ -314,3 +314,12 @@ class HoverDefnSuite extends BaseHoverSuite:
       """|def build(b: Builder[Unit]): Int
            |""".stripMargin.hover
     )
+
+  @Test def `backticked` =
+    check(
+      """|object A {
+         |  <<val `foo @@ bar` = 123>>
+         |}
+         |""".stripMargin,
+      "val `foo  bar`: Int".hover
+    )


### PR DESCRIPTION
Backports #25142 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]