### PR TITLE
Backport "Inlining interpolated variables" to 3.3 LTS

### DIFF
--- a/presentation-compiler/test/dotty/tools/pc/tests/edit/InlineValueSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/edit/InlineValueSuite.scala
@@ -509,6 +509,111 @@ class InlineValueSuite extends BaseCodeActionSuite with CommonMtagsEnrichments:
          |  def test(x: Int) = {
          |    List(1, 2, 3).map(x => x + 1).sum
          |  }
+			|}""".stripMargin
+    )
+
+  @Test def `check-interpolates-string-properly` =
+    checkEdit(
+      """|object Main {
+         |  def f(): Unit = {
+         |    val x = "hi"
+         |    println(s"${<<x>>}!")
+         |  }
+         |}""".stripMargin,
+      """|object Main {
+         |  def f(): Unit = {
+         |    println(s"${"hi"}!")
+         |  }
+         |}""".stripMargin
+    )
+
+  @Test def `check-interpolates-expression-properly` =
+    checkEdit(
+      """|object Main {
+         |  def f(y: Int): Unit = {
+         |    val x = 1 + y
+         |    println(s"${<<x>>}$y")
+         |  }
+         |}""".stripMargin,
+      """|object Main {
+         |  def f(y: Int): Unit = {
+         |    println(s"${1 + y}$y")
+         |  }
+         |}""".stripMargin
+    )
+
+  @Test def `check-interpolation-no-unneeded-curly-braces` =
+    checkEdit(
+      """|object Main {
+         |  def f(y: Int): Unit = {
+         |    val x = y
+         |    println(s"${<<x>>}$y")
+         |  }
+         |}""".stripMargin,
+      """|object Main {
+         |  def f(y: Int): Unit = {
+         |    println(s"${y}$y")
+         |  }
+         |}""".stripMargin
+    )
+
+  @Test def `check-interpolation-no-extra-curly-braces` =
+    checkEdit(
+      """|object Main {
+         |  def f(y: Int): Unit = {
+         |    val x = y + 1
+         |    println(s"${<<x>>}$y")
+         |  }
+         |}""".stripMargin,
+      """|object Main {
+         |  def f(y: Int): Unit = {
+         |    println(s"${y + 1}$y")
+         |  }
+         |}""".stripMargin
+    )
+
+  @Test def `check-interpolation-inlining-inside-curly-exp-does-not-add-curly` =
+    checkEdit(
+      """|object Main {
+         |  def f(y: Int): Unit = {
+         |    val x = y - 1
+         |    println(s"${<<x>> - y}")
+         |  }
+         |}""".stripMargin,
+      """|object Main {
+         |  def f(y: Int): Unit = {
+         |    println(s"${(y - 1) - y}")
+         |  }
+         |}""".stripMargin
+    )
+
+  @Test def `check-interpolation-inlining-within-curly-exp-adds-brackets` =
+    checkEdit(
+      """|object Main {
+         |  def f(y: Int): Unit = {
+         |    val x = y - 1
+         |    println(s"${y - <<x>>}")
+         |  }
+         |}""".stripMargin,
+      """|object Main {
+         |  def f(y: Int): Unit = {
+         |    println(s"${y - (y - 1)}")
+         |  }
+         |}""".stripMargin
+    )
+
+  @Test def `check-interpolation-dollar-sign-variable` =
+    checkEdit(
+      """|object Main {
+         |  def f(y: Int): Unit = {
+         |    val `$x` = y + 1
+         |    println(s"${<<`$x`>>}$y")
+         |  }
+         |}""".stripMargin,
+      """|object Main {
+         |  def f(y: Int): Unit = {
+         |    println(s"${y + 1}$y")
+         |  }
          |}""".stripMargin
     )
 


### PR DESCRIPTION
Backports #25144 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]