### PR TITLE
Backport "Skip tests with no sources such as .scala-build dir" to 3.3 LTS

### DIFF
--- a/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
+++ b/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
@@ -208,7 +208,8 @@ trait ParallelTesting extends RunnerOrchestration:
     def sourceFiles = compilationGroups.map(_._2).flatten.toArray
   }
 
-  protected def shouldSkipTestSource(testSource: TestSource): Boolean = false
+  protected def shouldSkipTestSource(testSource: TestSource): Boolean =
+    testSource.sourceFiles.length == 0
 
   protected def shouldReRun(testSource: TestSource): Boolean =
     failedTests.forall(rerun => testSource match {

--- a/sjs-compiler-tests/test/scala/dotty/tools/dotc/ScalaJSCompilationTests.scala
+++ b/sjs-compiler-tests/test/scala/dotty/tools/dotc/ScalaJSCompilationTests.scala
@@ -39,6 +39,7 @@ class ScalaJSCompilationTests extends ParallelTesting {
 
   override protected def shouldSkipTestSource(testSource: TestSource): Boolean =
     testSource.allToolArgs.get(ToolName.ScalaJS).exists(_.contains("--skip"))
+    || super.shouldSkipTestSource(testSource)
 
   override def runMain(classPath: String, toolArgs: ToolArgs)(implicit summaryReport: SummaryReporting): Status =
     import scala.concurrent.ExecutionContext.Implicits.global


### PR DESCRIPTION
Backports #25173 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]