### PR TITLE
Backport "feat(pc): add closing labels inlay hints" to 3.3 LTS

### DIFF
--- a/presentation-compiler/test/dotty/tools/pc/base/BaseInlayHintsSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/base/BaseInlayHintsSuite.scala
@@ -15,7 +15,8 @@ class BaseInlayHintsSuite extends BasePCSuite:
       base: String,
       expected: String,
       kind: Option[Int] = None,
-      hintsInPatternMatch: Boolean = false
+      hintsInPatternMatch: Boolean = false,
+      closingLabels: Boolean = false
   ): Unit =
     def pkgWrap(text: String) =
       if text.contains("package") then text
@@ -38,7 +39,7 @@ class BaseInlayHintsSuite extends BasePCSuite:
       implicitConversions = true,
       namedParameters = true,
       hintsInPatternMatch = hintsInPatternMatch,
-      closingLabels = false
+      closingLabels = closingLabels
     )
 
     val inlayHints = presentationCompiler

--- a/presentation-compiler/test/dotty/tools/pc/tests/inlayHints/InlayHintsSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/inlayHints/InlayHintsSuite.scala
@@ -1721,4 +1721,57 @@ class InlayHintsSuite extends BaseInlayHintsSuite {
         |}
         |""".stripMargin
     )
+
+  @Test def `closing-labels-1` =
+    check(
+      """|object Main{
+         |  def bestNumber: Int = {
+         |    234
+         |  }
+         |}
+         |""".stripMargin,
+      """|object Main{
+         |  def bestNumber: Int = {
+         |    234
+         |  }/*bestNumber*/
+         |}/*Main*/
+         |""".stripMargin,
+      closingLabels = true
+    )
+
+  @Test def `closing-labels-weird-formatting` =
+    check(
+      """|object Main{
+         |  def bestNumber: Int = {
+         |    def greatNumber: Long = {
+         |      3
+         |    }234}
+         |}
+         |""".stripMargin,
+      """|object Main{
+         |  def bestNumber: Int = {
+         |    def greatNumber: Long = {
+         |      3
+         |    }/*greatNumber*/234}/*bestNumber*/
+         |}/*Main*/
+         |""".stripMargin,
+      closingLabels = true
+    )
+
+  @Test def `closing-labels-inferred-type` =
+    check(
+      """|object Main{
+         |  def bestNumber = {
+         |    234
+         |  }
+         |}
+         |""".stripMargin,
+      """|object Main{
+         |  def bestNumber/*: Int<<scala/Int#>>*/ = {
+         |    234
+         |  }/*bestNumber*/
+         |}/*Main*/
+         |""".stripMargin,
+      closingLabels = true
+    )
 }


### PR DESCRIPTION
Backports #25178 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]