### PR TITLE
Backport "Fix printing references to nested objects" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -104,8 +104,17 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
   override def toTextRef(tp: SingletonType): Text = controlled {
     tp match {
       case tp: ThisType if !printDebug =>
-        if (tp.cls.isAnonymousClass) keywordStr("this")
-        if (tp.cls.is(ModuleClass)) fullNameString(tp.cls.sourceModule)
+        val cls = tp.cls
+        if cls.isAnonymousClass then
+          keywordStr("this")
+        else if cls.is(ModuleClass) then
+          if cls.isStatic then
+            fullNameString(tp.cls.sourceModule)
+          else cls.owner.thisType match
+            case tp: SingletonType =>
+              toTextRef(tp) ~ "." ~ nameString(cls)
+            case _ => // owner is a term, just print the name
+              nameString(cls)
         else super.toTextRef(tp)
       case tp: TermRef if !printDebug =>
         if tp.symbol.is(Package) then fullNameString(tp.symbol)

--- a/tests/neg-custom-args/captures/nested-objects-printing.check
+++ b/tests/neg-custom-args/captures/nested-objects-printing.check
@@ -1,0 +1,7 @@
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/nested-objects-printing.scala:4:19 -----------------------
+4 |      val x: Int = B.this // error, was "found: (B: A.B.type)", should be "found: (B: B.type)"
+  |                   ^^^^^^
+  |                   Found:    (B : B.type)
+  |                   Required: Int
+  |
+  | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/nested-objects-printing.scala
+++ b/tests/neg-custom-args/captures/nested-objects-printing.scala
@@ -1,0 +1,4 @@
+object A:
+  def f =
+    object B:
+      val x: Int = B.this // error, was "found: (B: A.B.type)", should be "found: (B: B.type)"


### PR DESCRIPTION
Backports #25086 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]