### PR TITLE
Backport "Never widen constant type on selector type in matches" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -1142,7 +1142,7 @@ object desugar {
     }
   }
 
-  /** The selector of a match, which depends of the given `checkMode`.
+  /** The selector of a match, which depends on the given `checkMode`.
    *  @param  sel  the original selector
    *  @return if `checkMode` is
    *           - None              :  sel @unchecked

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1788,7 +1788,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
         val sel1 = typedExpr(tree.selector)
         val rawSelectorTpe = fullyDefinedType(sel1.tpe, "pattern selector", tree.srcPos)
         val selType = rawSelectorTpe match
-          case c: ConstantType if tree.isInline => c
+          case c: ConstantType => c
           case otherTpe => otherTpe.widen
 
         /** Does `tree` has the same shape as the given match type?

--- a/language-server/test/dotty/tools/languageserver/CompletionTest.scala
+++ b/language-server/test/dotty/tools/languageserver/CompletionTest.scala
@@ -1485,8 +1485,8 @@ class CompletionTest {
           |  1 match { case foo if fo${m1} => }
           |  1 match { case foo => fo${m2} }
           """
-      .completion(m1, Set(("foo", Field, "Int")))
-      .completion(m2, Set(("foo", Field, "Int")))
+      .completion(m1, Set(("foo", Field, "(1 : Int)")))
+      .completion(m2, Set(("foo", Field, "(1 : Int)")))
   }
 
   @Test def patternGuardCompletionsUnApply: Unit = {

--- a/presentation-compiler/test/dotty/tools/pc/tests/edit/InsertInferredTypeSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/edit/InsertInferredTypeSuite.scala
@@ -355,7 +355,7 @@ class InsertInferredTypeSuite extends BaseCodeActionSuite:
       """|object A{
          |  val list = 1 match {
          |    case 2 => "Two!"
-         |    case otherDigit: Int => "Not two!"
+         |    case otherDigit: 1 => "Not two!"
          |  }
          |}""".stripMargin
     )

--- a/tests/pos/match-constant-type.scala
+++ b/tests/pos/match-constant-type.scala
@@ -1,0 +1,3 @@
+object Test {
+  ("a": "a") match { case a => Set.empty["a"] + a }
+}


### PR DESCRIPTION
Backports #25197 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]