### PR TITLE
Backport "Make containsOuterRefsAnywhere follow aliases" to 3.3 LTS

### DIFF
--- a/tests/pos/i25185.scala
+++ b/tests/pos/i25185.scala
@@ -1,0 +1,11 @@
+package example
+
+class A {
+  type B = Int
+
+  object B {
+    inline def f1(x: Int): B = x
+  }
+
+  def x1 = B.f1(2)
+}


### PR DESCRIPTION
Backports #25214 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]