### PR TITLE
Backport "Bump coursier/cache-action from 7 to 8" to 3.3 LTS

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -800,7 +800,6 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: coursier/cache-action@v7
-      - uses: VirtusLab/scala-cli-setup@v1.12.1
+      - uses: coursier/cache-action@v8
+      - uses: VirtusLab/scala-cli-setup@v1.12.2
       - run: scala-cli format --check
-


### PR DESCRIPTION
Backports #25220 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]