### PR TITLE
Backport "Move second CheckUnused after pattern matcher" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/Compiler.scala
+++ b/compiler/src/dotty/tools/dotc/Compiler.scala
@@ -10,6 +10,7 @@ import Phases.Phase
 import transform.*
 import backend.jvm.{CollectSuperCalls, GenBCode}
 import localopt.StringInterpolatorOpt
+import semanticdb.ExtractSemanticDB.{ExtractSemanticInfo, AppendDiagnostics as AppendSemanticDiagnostics}
 
 /** The central class of the dotc compiler. The job of a compiler is to create
  *  runs, which process given `phases` in a given `rootContext`.
@@ -39,7 +40,7 @@ class Compiler {
          CheckShadowing()) ::       // Check for shadowed elements
     List(new YCheckPositions) ::    // YCheck positions
     List(new sbt.ExtractDependencies) :: // Sends information on classes' dependencies to sbt via callbacks
-    List(new semanticdb.ExtractSemanticDB.ExtractSemanticInfo) :: // Extract info into .semanticdb files
+    List(ExtractSemanticInfo()) ::  // Extract info into .semanticdb files
     List(new PostTyper) ::          // Additional checks and cleanups after type checking
     List(new sjs.PrepJSInterop) ::  // Additional checks and transformations for Scala.js (Scala.js only)
     List(new sbt.ExtractAPI) ::     // Sends a representation of the API of classes to sbt via callbacks
@@ -54,7 +55,6 @@ class Compiler {
     List(new Staging) ::            // Check staging levels and heal staged types
     List(new Splicing) ::           // Replace level 1 splices with holes
     List(new PickleQuotes) ::       // Turn quoted trees into explicit run-time data structures
-    List(new CheckUnused.PostInlining) ::  // Check for unused elements
     Nil
 
   /** Phases dealing with the transformation from pickled trees to backend trees */
@@ -71,7 +71,6 @@ class Compiler {
          new ExpandSAMs,             // Expand single abstract method closures to anonymous classes
          new ElimRepeated,           // Rewrite vararg parameters and arguments
          new RefChecks) ::           // Various checks mostly related to abstract members and overriding
-    List(new semanticdb.ExtractSemanticDB.AppendDiagnostics) :: // Attach warnings to extracted SemanticDB and write to .semanticdb file
     List(new init.Checker) ::        // Check initialization of objects
     List(new ProtectedAccessors,     // Add accessors for protected members
          new ExtensionMethods,       // Expand methods of value classes with extension methods
@@ -87,6 +86,8 @@ class Compiler {
     List(new TestRecheck) ::         // Test only: run rechecker, enabled under -Yrecheck-test
     List(new CheckCaptures.Pre) ::   // Preparations for check captures phase, enabled under captureChecking
     List(new CheckCaptures) ::       // Check captures, enabled under captureChecking
+    List(CheckUnused.PostPatMat()) :: // Check for unused elements and report
+    List(AppendSemanticDiagnostics()) :: // Attach warnings to extracted SemanticDB and write to .semanticdb file
     List(new ElimOpaque,             // Turn opaque into normal aliases
          new sjs.ExplicitJSClasses,  // Make all JS classes explicit (Scala.js only)
          new ExplicitOuter,          // Add accessors to outer classes from nested ones.

--- a/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
@@ -20,7 +20,7 @@ import dotty.tools.dotc.report
 import dotty.tools.dotc.reporting.{CodeAction, Diagnostic, UnusedSymbol}
 import dotty.tools.dotc.rewrites.Rewrites.ActionPatch
 import dotty.tools.dotc.transform.MegaPhase.MiniPhase
-import dotty.tools.dotc.typer.{ImportInfo, Typer}
+import dotty.tools.dotc.typer.{ImportInfo, Typer, TyperPhase}
 import dotty.tools.dotc.typer.Deriving.OriginalTypeClass
 import dotty.tools.dotc.typer.Implicits.{ContextualImplicits, RenamedImplicitRef}
 import dotty.tools.dotc.util.{Property, Spans, SrcPos}, Spans.Span
@@ -40,6 +40,12 @@ class CheckUnused private (phaseMode: PhaseMode, suffix: String) extends MiniPha
   override def phaseName: String = s"checkUnused$suffix"
 
   override def description: String = "check for unused elements"
+
+  override def runsAfter = Set:
+    phaseMode match
+    case PhaseMode.Aggregate => TyperPhase.name
+    case PhaseMode.Resolve => Inlining.name
+    case PhaseMode.Report => PatternMatcher.name
 
   override def isEnabled(using Context): Boolean = ctx.settings.WunusedHas.any
 
@@ -471,8 +477,9 @@ end CheckUnused
 object CheckUnused:
 
   enum PhaseMode:
-    case Aggregate
-    case Report
+    case Aggregate // new defs are considered
+    case Resolve   // no new defs, only additional references
+    case Report    // report when done
 
   val refInfosKey = Property.StickyKey[RefInfos]
 
@@ -493,9 +500,11 @@ object CheckUnused:
   /** Tree is an inlined parameter. */
   val InlinedParameter = Property.StickyKey[Unit]
 
-  class PostTyper extends CheckUnused(PhaseMode.Aggregate, "PostTyper")
+  def PostTyper() = CheckUnused(PhaseMode.Aggregate, "PostTyper")
 
-  class PostInlining extends CheckUnused(PhaseMode.Report, "PostInlining")
+  def PostInlining() = CheckUnused(PhaseMode.Resolve, "PostInlining")
+
+  def PostPatMat() = CheckUnused(PhaseMode.Report, "PostPatMat")
 
   class RefInfos:
     val defs = mutable.Set.empty[(Symbol, SrcPos)]    // definitions
@@ -571,8 +580,9 @@ object CheckUnused:
       inline def isNone: Boolean = p == NoPrecedence
 
   def reportUnused()(using Context): Unit = if !refInfos.isNullified then
-    for (msg, pos, origin) <- warnings do
-      report.warning(msg, pos, origin)
+    atPhaseBeforeTransforms:
+      for (msg, pos, origin) <- warnings do
+        report.warning(msg, pos, origin)
 
   type MessageInfo = (UnusedSymbol, SrcPos, String) // string is origin or empty
 

--- a/compiler/test/dotty/tools/utils.scala
+++ b/compiler/test/dotty/tools/utils.scala
@@ -87,7 +87,7 @@ private val toolArg = raw"(?://|/\*| \*) ?(?i:(${ToolName.values.mkString("|")})
 // ================================================================================================
 
 /** Directive to specify to vulpix the options to pass to Dotty */
-private val directiveOptionsArg = raw"//> using options (.*)".r.unanchored
+private val directiveOptionsArg = raw"//> using option(?:s)? (.*)".r.unanchored
 private val directiveJavacOptions = raw"//> using javacOpt (.*)".r.unanchored
 private val directiveTargetOptions = raw"//> using target.platform (jvm|scala-js)".r.unanchored
 private val directiveUnsupported = raw"//> using (scala) (.*)".r.unanchored

--- a/tests/semanticdb/metac.expect
+++ b/tests/semanticdb/metac.expect
@@ -5305,7 +5305,7 @@ Text => empty
 Language => Scala
 Symbols => 50 entries
 Occurrences => 78 entries
-Diagnostics => 6 entries
+Diagnostics => 5 entries
 Synthetics => 2 entries
 
 Symbols:
@@ -5446,7 +5446,6 @@ Diagnostics:
 [9:42..9:43): [warning] unused explicit parameter
 [21:11..21:12): [warning] unused explicit parameter
 [24:24..24:27): [warning] unused pattern variable
-[25:27..25:28): [warning] unused pattern variable
 
 Synthetics:
 [23:6..23:10):List => *.unapplySeq[Nothing]

--- a/tests/warn/i15503d.scala
+++ b/tests/warn/i15503d.scala
@@ -121,3 +121,6 @@ class `i22743 lazy vals are defs`:
   lazy val (i, s) = f // no warn because def is neither local nor private
   val (j, t) = f // existing no warn for val with attachment
   private lazy val (k, u) = f // warn // warn a warning so nice, they warn it twice
+
+def `i25100 type vars are also pat vars` =
+  ??? match { case _: List[t] => ??? }

--- a/tests/warn/i15503i.scala
+++ b/tests/warn/i15503i.scala
@@ -1,4 +1,4 @@
-//> using options -Wunused:all -Ystop-after:checkUnusedPostInlining
+//> using options -Wunused:all -Wconf:name=InlinedAnonClassWarning:s
 
 import collection.mutable.{Map => MutMap} // warn
 import collection.mutable.Set // warn

--- a/tests/warn/i25100.scala
+++ b/tests/warn/i25100.scala
@@ -1,0 +1,20 @@
+//> using option -language:strictEquality
+//> using option -Wunused:all
+
+case class Foo(value: String)
+case object Bar
+
+object Import {
+  given CanEqual[Foo | Bar.type, Foo | Bar.type] = CanEqual.derived
+}
+
+@main
+def main(): Unit = {
+  import Import.given
+  val i: Foo | Bar.type = Foo("Foo")
+
+  i match {
+    case i: Foo => println("i is a Foo")
+    case Bar => println("i is a Long")
+  }
+}


### PR DESCRIPTION
Backports #25114 to the 3.3.7.

PR submitted by the release tooling.
[skip ci]