### PR TITLE
Backport "Add support for local coverage on and off with `// $COVERAGE-OFF$` and `// $COVERAGE-ON$`" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/InstrumentCoverage.scala
+++ b/compiler/src/dotty/tools/dotc/transform/InstrumentCoverage.scala
@@ -25,6 +25,7 @@ import localopt.StringInterpolatorOpt
 import inlines.Inlines
 import scala.util.matching.Regex
 import java.util.regex.Pattern
+import scala.annotation.internal.sharable
 
 /** Implements code coverage by inserting calls to scala.runtime.coverage.Invoker
   * ("instruments" the source code).
@@ -670,8 +671,8 @@ object InstrumentCoverage:
   val name: String = "instrumentCoverage"
   val description: String = "instrument code for coverage checking"
   val ExcludeMethodFlags: FlagSet = Artifact | Erased
-  val scoverageLocalOn: Regex = """^\s*//\s*\$COVERAGE-ON\$""".r
-  val scoverageLocalOff: Regex = """^\s*//\s*\$COVERAGE-OFF\$""".r
+  @sharable val scoverageLocalOn: Regex = """^\s*//\s*\$COVERAGE-ON\$""".r
+  @sharable val scoverageLocalOff: Regex = """^\s*//\s*\$COVERAGE-OFF\$""".r
 
   /**
    * An instrumented Tree, in 3 parts.

--- a/compiler/src/dotty/tools/dotc/transform/InstrumentCoverage.scala
+++ b/compiler/src/dotty/tools/dotc/transform/InstrumentCoverage.scala
@@ -6,6 +6,7 @@ import java.nio.file.{Files, Path}
 
 import ast.tpd.*
 import collection.mutable
+import core.Comments.Comment
 import core.Flags.*
 import core.Contexts.{Context, ctx, inContext}
 import core.DenotTransformers.IdentityDenotTransformer
@@ -42,6 +43,7 @@ class InstrumentCoverage extends MacroTransform with IdentityDenotTransformer:
 
   private var coverageExcludeClasslikePatterns: List[Pattern] = Nil
   private var coverageExcludeFilePatterns: List[Pattern] = Nil
+  private val coverageLocalExclusions: mutable.Map[String, List[Span]] = mutable.Map.empty
 
   override def runOn(units: List[CompilationUnit])(using ctx: Context): List[CompilationUnit] =
     val outputPath = ctx.settings.coverageOutputDir.value
@@ -73,6 +75,30 @@ class InstrumentCoverage extends MacroTransform with IdentityDenotTransformer:
     // Initialize coverage object
     ctx.base.coverage = Coverage()
     ctx.base.coverage.nn.setNextStatementId(previousCoverage.nextStatementId())
+
+    // Process each unit to extract local coverage exclusions from comments
+    units.foreach { unit =>
+      val excludedSpans = mutable.ListBuffer[Span]()
+      var currentStartingComment: Option[Comment] = None
+
+      unit.comments.foreach {
+        case comment if InstrumentCoverage.scoverageLocalOff.matches(comment.raw) && currentStartingComment.isEmpty =>
+          currentStartingComment = Some(comment)
+        case comment if InstrumentCoverage.scoverageLocalOn.matches(comment.raw) =>
+          currentStartingComment.foreach { start =>
+            currentStartingComment = None
+            excludedSpans += start.span.withEnd(comment.span.end)
+          }
+        case _ =>
+      }
+
+      currentStartingComment.headOption.foreach { start =>
+        excludedSpans += start.span.withEnd(unit.source.length - 1)
+      }
+
+      if excludedSpans.nonEmpty then
+        coverageLocalExclusions(unit.source.file.path) = excludedSpans.toList
+    }
 
     // Run the transformation on all units
     val result = super.runOn(units)
@@ -108,6 +134,11 @@ class InstrumentCoverage extends MacroTransform with IdentityDenotTransformer:
     coverageExcludeFilePatterns.isEmpty || !coverageExcludeFilePatterns.exists(
       _.matcher(normalizedPath).nn.matches
     )
+
+  private def isTreeExcluded(tree: Tree)(using Context): Boolean =
+    val sourceFile = ctx.source.file.path
+    coverageLocalExclusions.get(sourceFile).exists: excludedSpans =>
+      excludedSpans.exists(_.contains(tree.span))
 
   override protected def newTransformer(using Context) =
     CoverageTransformer(ctx.settings.coverageOutputDir.value)
@@ -153,7 +184,8 @@ class InstrumentCoverage extends MacroTransform with IdentityDenotTransformer:
         desc = sourceFile.content.slice(pos.start, pos.end).mkString,
         symbolName = tree.symbol.name.toSimpleName.show,
         treeName = tree.getClass.getSimpleName.nn,
-        branch
+        branch,
+        ignored = isTreeExcluded(tree)
       )
       ctx.base.coverage.nn.addStatement(statement)
       id
@@ -638,6 +670,8 @@ object InstrumentCoverage:
   val name: String = "instrumentCoverage"
   val description: String = "instrument code for coverage checking"
   val ExcludeMethodFlags: FlagSet = Artifact | Erased
+  val scoverageLocalOn: Regex = """^\s*//\s*\$COVERAGE-ON\$""".r
+  val scoverageLocalOff: Regex = """^\s*//\s*\$COVERAGE-OFF\$""".r
 
   /**
    * An instrumented Tree, in 3 parts.

--- a/tests/coverage/pos/BranchesIgnoredLocally.scala
+++ b/tests/coverage/pos/BranchesIgnoredLocally.scala
@@ -1,0 +1,27 @@
+package covtest
+
+class BranchesIgnoredLocally:
+  def coveredBranch(x: Int): String =
+    if x > 0 then "positive"
+    else "non-positive"
+
+  // $COVERAGE-OFF$
+  def ignoredBranch(x: Int): String =
+    if x > 0 then "positive"
+    else "non-positive"
+
+  def ignoredMatch(x: Int): String = x match
+    case 1 => "one"
+    case 2 => "two"
+    case _ => "other"
+
+  def ignoredTryCatch: Int =
+    try 1 / 0
+    catch
+      case _: ArithmeticException => -1
+  // $COVERAGE-ON$
+
+  def coveredMatch(x: Any): String = x match
+    case _: Int => "int"
+    case _: String => "string"
+    case _ => "other"

--- a/tests/coverage/pos/BranchesIgnoredLocally.scoverage.check
+++ b/tests/coverage/pos/BranchesIgnoredLocally.scoverage.check
@@ -1,0 +1,564 @@
+# Coverage data, format version: 3.0
+# Statement data:
+# - id
+# - source path
+# - package name
+# - class name
+# - class type (Class, Object or Trait)
+# - full class name
+# - method name
+# - start offset
+# - end offset
+# - line number
+# - symbol name
+# - tree name
+# - is branch
+# - invocations count
+# - is ignored
+# - description (can be multi-line)
+# '' sign
+# ------------------------------------------
+0
+BranchesIgnoredLocally.scala
+covtest
+BranchesIgnoredLocally
+Class
+covtest.BranchesIgnoredLocally
+coveredBranch
+92
+97
+5
+>
+Apply
+false
+0
+false
+x > 0
+
+1
+BranchesIgnoredLocally.scala
+covtest
+BranchesIgnoredLocally
+Class
+covtest.BranchesIgnoredLocally
+coveredBranch
+103
+113
+5
+<none>
+Literal
+false
+0
+false
+"positive"
+
+2
+BranchesIgnoredLocally.scala
+covtest
+BranchesIgnoredLocally
+Class
+covtest.BranchesIgnoredLocally
+coveredBranch
+103
+113
+5
+<none>
+Literal
+true
+0
+false
+"positive"
+
+3
+BranchesIgnoredLocally.scala
+covtest
+BranchesIgnoredLocally
+Class
+covtest.BranchesIgnoredLocally
+coveredBranch
+123
+137
+6
+<none>
+Literal
+false
+0
+false
+"non-positive"
+
+4
+BranchesIgnoredLocally.scala
+covtest
+BranchesIgnoredLocally
+Class
+covtest.BranchesIgnoredLocally
+coveredBranch
+123
+137
+6
+<none>
+Literal
+true
+0
+false
+"non-positive"
+
+5
+BranchesIgnoredLocally.scala
+covtest
+BranchesIgnoredLocally
+Class
+covtest.BranchesIgnoredLocally
+coveredBranch
+49
+66
+4
+coveredBranch
+DefDef
+false
+0
+false
+def coveredBranch
+
+6
+BranchesIgnoredLocally.scala
+covtest
+BranchesIgnoredLocally
+Class
+covtest.BranchesIgnoredLocally
+ignoredBranch
+204
+209
+10
+>
+Apply
+false
+0
+true
+x > 0
+
+7
+BranchesIgnoredLocally.scala
+covtest
+BranchesIgnoredLocally
+Class
+covtest.BranchesIgnoredLocally
+ignoredBranch
+215
+225
+10
+<none>
+Literal
+false
+0
+true
+"positive"
+
+8
+BranchesIgnoredLocally.scala
+covtest
+BranchesIgnoredLocally
+Class
+covtest.BranchesIgnoredLocally
+ignoredBranch
+215
+225
+10
+<none>
+Literal
+true
+0
+true
+"positive"
+
+9
+BranchesIgnoredLocally.scala
+covtest
+BranchesIgnoredLocally
+Class
+covtest.BranchesIgnoredLocally
+ignoredBranch
+235
+249
+11
+<none>
+Literal
+false
+0
+true
+"non-positive"
+
+10
+BranchesIgnoredLocally.scala
+covtest
+BranchesIgnoredLocally
+Class
+covtest.BranchesIgnoredLocally
+ignoredBranch
+235
+249
+11
+<none>
+Literal
+true
+0
+true
+"non-positive"
+
+11
+BranchesIgnoredLocally.scala
+covtest
+BranchesIgnoredLocally
+Class
+covtest.BranchesIgnoredLocally
+ignoredBranch
+161
+178
+9
+ignoredBranch
+DefDef
+false
+0
+true
+def ignoredBranch
+
+12
+BranchesIgnoredLocally.scala
+covtest
+BranchesIgnoredLocally
+Class
+covtest.BranchesIgnoredLocally
+ignoredMatch
+310
+315
+14
+<none>
+Literal
+false
+0
+true
+"one"
+
+13
+BranchesIgnoredLocally.scala
+covtest
+BranchesIgnoredLocally
+Class
+covtest.BranchesIgnoredLocally
+ignoredMatch
+307
+315
+14
+<none>
+Block
+true
+0
+true
+=> "one"
+
+14
+BranchesIgnoredLocally.scala
+covtest
+BranchesIgnoredLocally
+Class
+covtest.BranchesIgnoredLocally
+ignoredMatch
+330
+335
+15
+<none>
+Literal
+false
+0
+true
+"two"
+
+15
+BranchesIgnoredLocally.scala
+covtest
+BranchesIgnoredLocally
+Class
+covtest.BranchesIgnoredLocally
+ignoredMatch
+327
+335
+15
+<none>
+Block
+true
+0
+true
+=> "two"
+
+16
+BranchesIgnoredLocally.scala
+covtest
+BranchesIgnoredLocally
+Class
+covtest.BranchesIgnoredLocally
+ignoredMatch
+350
+357
+16
+<none>
+Literal
+false
+0
+true
+"other"
+
+17
+BranchesIgnoredLocally.scala
+covtest
+BranchesIgnoredLocally
+Class
+covtest.BranchesIgnoredLocally
+ignoredMatch
+347
+357
+16
+<none>
+Block
+true
+0
+true
+=> "other"
+
+18
+BranchesIgnoredLocally.scala
+covtest
+BranchesIgnoredLocally
+Class
+covtest.BranchesIgnoredLocally
+ignoredMatch
+253
+269
+13
+ignoredMatch
+DefDef
+false
+0
+true
+def ignoredMatch
+
+19
+BranchesIgnoredLocally.scala
+covtest
+BranchesIgnoredLocally
+Class
+covtest.BranchesIgnoredLocally
+ignoredTryCatch
+396
+401
+19
+/
+Apply
+false
+0
+true
+1 / 0
+
+20
+BranchesIgnoredLocally.scala
+covtest
+BranchesIgnoredLocally
+Class
+covtest.BranchesIgnoredLocally
+ignoredTryCatch
+396
+397
+19
+<none>
+Literal
+false
+0
+true
+1
+
+21
+BranchesIgnoredLocally.scala
+covtest
+BranchesIgnoredLocally
+Class
+covtest.BranchesIgnoredLocally
+ignoredTryCatch
+396
+401
+19
+/
+Apply
+true
+0
+true
+1 / 0
+
+22
+BranchesIgnoredLocally.scala
+covtest
+BranchesIgnoredLocally
+Class
+covtest.BranchesIgnoredLocally
+ignoredTryCatch
+449
+451
+21
+<none>
+Literal
+false
+0
+true
+-1
+
+23
+BranchesIgnoredLocally.scala
+covtest
+BranchesIgnoredLocally
+Class
+covtest.BranchesIgnoredLocally
+ignoredTryCatch
+446
+451
+21
+<none>
+Block
+true
+0
+true
+=> -1
+
+24
+BranchesIgnoredLocally.scala
+covtest
+BranchesIgnoredLocally
+Class
+covtest.BranchesIgnoredLocally
+ignoredTryCatch
+361
+380
+18
+ignoredTryCatch
+DefDef
+false
+0
+true
+def ignoredTryCatch
+
+25
+BranchesIgnoredLocally.scala
+covtest
+BranchesIgnoredLocally
+Class
+covtest.BranchesIgnoredLocally
+coveredMatch
+536
+541
+25
+<none>
+Literal
+false
+0
+false
+"int"
+
+26
+BranchesIgnoredLocally.scala
+covtest
+BranchesIgnoredLocally
+Class
+covtest.BranchesIgnoredLocally
+coveredMatch
+533
+541
+25
+<none>
+Block
+true
+0
+false
+=> "int"
+
+27
+BranchesIgnoredLocally.scala
+covtest
+BranchesIgnoredLocally
+Class
+covtest.BranchesIgnoredLocally
+coveredMatch
+564
+572
+26
+<none>
+Literal
+false
+0
+false
+"string"
+
+28
+BranchesIgnoredLocally.scala
+covtest
+BranchesIgnoredLocally
+Class
+covtest.BranchesIgnoredLocally
+coveredMatch
+561
+572
+26
+<none>
+Block
+true
+0
+false
+=> "string"
+
+29
+BranchesIgnoredLocally.scala
+covtest
+BranchesIgnoredLocally
+Class
+covtest.BranchesIgnoredLocally
+coveredMatch
+587
+594
+27
+<none>
+Literal
+false
+0
+false
+"other"
+
+30
+BranchesIgnoredLocally.scala
+covtest
+BranchesIgnoredLocally
+Class
+covtest.BranchesIgnoredLocally
+coveredMatch
+584
+594
+27
+<none>
+Block
+true
+0
+false
+=> "other"
+
+31
+BranchesIgnoredLocally.scala
+covtest
+BranchesIgnoredLocally
+Class
+covtest.BranchesIgnoredLocally
+coveredMatch
+474
+490
+24
+coveredMatch
+DefDef
+false
+0
+false
+def coveredMatch
+

--- a/tests/coverage/pos/SimpleMethodsIgnoredLocally.scala
+++ b/tests/coverage/pos/SimpleMethodsIgnoredLocally.scala
@@ -1,0 +1,29 @@
+package covtest
+
+class C:
+  def a: C = this
+  def b: Unit = return
+  def c: Unit = ()
+  def d: Int = 12
+  def e: Null = null
+
+  // $COVERAGE-OFF$
+  def block: Int =
+    "literal"
+    0
+
+  def cond: Boolean =
+    if false then true
+    else false
+
+  def partialCond: Unit =
+    if false then ()
+
+  // $COVERAGE-ON$
+
+  def new1: C = new {}
+
+  def tryCatch: Unit =
+    try ()
+    catch
+      case e: Exception => 1

--- a/tests/coverage/pos/SimpleMethodsIgnoredLocally.scoverage.check
+++ b/tests/coverage/pos/SimpleMethodsIgnoredLocally.scoverage.check
@@ -1,0 +1,530 @@
+# Coverage data, format version: 3.0
+# Statement data:
+# - id
+# - source path
+# - package name
+# - class name
+# - class type (Class, Object or Trait)
+# - full class name
+# - method name
+# - start offset
+# - end offset
+# - line number
+# - symbol name
+# - tree name
+# - is branch
+# - invocations count
+# - is ignored
+# - description (can be multi-line)
+# '' sign
+# ------------------------------------------
+0
+SimpleMethodsIgnoredLocally.scala
+covtest
+C
+Class
+covtest.C
+a
+28
+33
+4
+a
+DefDef
+false
+0
+false
+def a
+
+1
+SimpleMethodsIgnoredLocally.scala
+covtest
+C
+Class
+covtest.C
+b
+60
+66
+5
+<none>
+Literal
+false
+0
+false
+return
+
+2
+SimpleMethodsIgnoredLocally.scala
+covtest
+C
+Class
+covtest.C
+b
+46
+51
+5
+b
+DefDef
+false
+0
+false
+def b
+
+3
+SimpleMethodsIgnoredLocally.scala
+covtest
+C
+Class
+covtest.C
+c
+83
+85
+6
+<none>
+Literal
+false
+0
+false
+()
+
+4
+SimpleMethodsIgnoredLocally.scala
+covtest
+C
+Class
+covtest.C
+c
+69
+74
+6
+c
+DefDef
+false
+0
+false
+def c
+
+5
+SimpleMethodsIgnoredLocally.scala
+covtest
+C
+Class
+covtest.C
+d
+101
+103
+7
+<none>
+Literal
+false
+0
+false
+12
+
+6
+SimpleMethodsIgnoredLocally.scala
+covtest
+C
+Class
+covtest.C
+d
+88
+93
+7
+d
+DefDef
+false
+0
+false
+def d
+
+7
+SimpleMethodsIgnoredLocally.scala
+covtest
+C
+Class
+covtest.C
+e
+120
+124
+8
+<none>
+Literal
+false
+0
+false
+null
+
+8
+SimpleMethodsIgnoredLocally.scala
+covtest
+C
+Class
+covtest.C
+e
+106
+111
+8
+e
+DefDef
+false
+0
+false
+def e
+
+9
+SimpleMethodsIgnoredLocally.scala
+covtest
+C
+Class
+covtest.C
+block
+169
+178
+12
+<none>
+Literal
+false
+0
+true
+"literal"
+
+10
+SimpleMethodsIgnoredLocally.scala
+covtest
+C
+Class
+covtest.C
+block
+183
+184
+13
+<none>
+Literal
+false
+0
+true
+0
+
+11
+SimpleMethodsIgnoredLocally.scala
+covtest
+C
+Class
+covtest.C
+block
+148
+157
+11
+block
+DefDef
+false
+0
+true
+def block
+
+12
+SimpleMethodsIgnoredLocally.scala
+covtest
+C
+Class
+covtest.C
+cond
+215
+220
+16
+<none>
+Literal
+false
+0
+true
+false
+
+13
+SimpleMethodsIgnoredLocally.scala
+covtest
+C
+Class
+covtest.C
+cond
+226
+230
+16
+<none>
+Literal
+false
+0
+true
+true
+
+14
+SimpleMethodsIgnoredLocally.scala
+covtest
+C
+Class
+covtest.C
+cond
+226
+230
+16
+<none>
+Literal
+true
+0
+true
+true
+
+15
+SimpleMethodsIgnoredLocally.scala
+covtest
+C
+Class
+covtest.C
+cond
+240
+245
+17
+<none>
+Literal
+false
+0
+true
+false
+
+16
+SimpleMethodsIgnoredLocally.scala
+covtest
+C
+Class
+covtest.C
+cond
+240
+245
+17
+<none>
+Literal
+true
+0
+true
+false
+
+17
+SimpleMethodsIgnoredLocally.scala
+covtest
+C
+Class
+covtest.C
+cond
+188
+196
+15
+cond
+DefDef
+false
+0
+true
+def cond
+
+18
+SimpleMethodsIgnoredLocally.scala
+covtest
+C
+Class
+covtest.C
+partialCond
+280
+285
+20
+<none>
+Literal
+false
+0
+true
+false
+
+19
+SimpleMethodsIgnoredLocally.scala
+covtest
+C
+Class
+covtest.C
+partialCond
+291
+293
+20
+<none>
+Literal
+false
+0
+true
+()
+
+20
+SimpleMethodsIgnoredLocally.scala
+covtest
+C
+Class
+covtest.C
+partialCond
+291
+293
+20
+<none>
+Literal
+true
+0
+true
+()
+
+21
+SimpleMethodsIgnoredLocally.scala
+covtest
+C
+Class
+covtest.C
+partialCond
+293
+293
+20
+<none>
+Literal
+true
+0
+true
+
+
+22
+SimpleMethodsIgnoredLocally.scala
+covtest
+C
+Class
+covtest.C
+partialCond
+249
+264
+19
+partialCond
+DefDef
+false
+0
+true
+def partialCond
+
+23
+SimpleMethodsIgnoredLocally.scala
+covtest
+C
+Class
+covtest.C
+new1
+331
+337
+24
+<init>
+Apply
+false
+0
+false
+new {}
+
+24
+SimpleMethodsIgnoredLocally.scala
+covtest
+C
+Class
+covtest.C
+new1
+317
+325
+24
+new1
+DefDef
+false
+0
+false
+def new1
+
+25
+SimpleMethodsIgnoredLocally.scala
+covtest
+C
+Class
+covtest.C
+tryCatch
+370
+372
+27
+<none>
+Literal
+false
+0
+false
+()
+
+26
+SimpleMethodsIgnoredLocally.scala
+covtest
+C
+Class
+covtest.C
+tryCatch
+370
+372
+27
+<none>
+Literal
+true
+0
+false
+()
+
+27
+SimpleMethodsIgnoredLocally.scala
+covtest
+C
+Class
+covtest.C
+tryCatch
+410
+411
+29
+<none>
+Literal
+false
+0
+false
+1
+
+28
+SimpleMethodsIgnoredLocally.scala
+covtest
+C
+Class
+covtest.C
+tryCatch
+407
+411
+29
+<none>
+Block
+true
+0
+false
+=> 1
+
+29
+SimpleMethodsIgnoredLocally.scala
+covtest
+C
+Class
+covtest.C
+tryCatch
+341
+353
+26
+tryCatch
+DefDef
+false
+0
+false
+def tryCatch
+

--- a/tests/coverage/pos/TryInstrumentCasesIgnoredLocally.scala
+++ b/tests/coverage/pos/TryInstrumentCasesIgnoredLocally.scala
@@ -1,0 +1,73 @@
+package covtest
+
+class AllTreesIgnoredLocally:
+
+  // --- Apply ---
+  def coveredApply(x: Int): Int = x + 1
+  // $COVERAGE-OFF$
+  def ignoredApply(x: Int): Int = x + 1
+  // $COVERAGE-ON$
+
+  // --- Literal ---
+  def coveredLiteral: Int = 42
+  // $COVERAGE-OFF$
+  def ignoredLiteral: Int = 42
+  // $COVERAGE-ON$
+
+  // --- Select (parameterless method on object) ---
+  def coveredSelect(s: String): Int = s.length
+  // $COVERAGE-OFF$
+  def ignoredSelect(s: String): Int = s.length
+  // $COVERAGE-ON$
+
+  // --- Ident (local parameterless def) ---
+  def coveredIdent: Int =
+    def local: Int = 1
+    local
+  // $COVERAGE-OFF$
+  def ignoredIdent: Int =
+    def local: Int = 1
+    local
+  // $COVERAGE-ON$
+
+  // --- transformBranch (if/else) ---
+  def coveredBranch(x: Int): String =
+    if x > 0 then "pos"
+    else "neg"
+  // $COVERAGE-OFF$
+  def ignoredBranch(x: Int): String =
+    if x > 0 then "pos"
+    else "neg"
+  // $COVERAGE-ON$
+
+  // --- instrumentBody ---
+  def coveredBody: Int = 99
+  // $COVERAGE-OFF$
+  def ignoredBody: Int = 99
+  // $COVERAGE-ON$
+
+  def coveredClosureDef: Int ?=> Int =
+    99
+  // $COVERAGE-OFF$
+  def ignoredClosureDef: Int ?=> Int =
+    99
+  // $COVERAGE-ON$
+
+  def coveredClosureBody: Int ?=> Int =
+    99
+  def ignoredClosureBody: Int ?=> Int =
+  // $COVERAGE-OFF$
+    99
+  // $COVERAGE-ON$
+
+
+// --- instrumentSecondaryCtor ---
+class CoveredCtor(val x: Int):
+  def this(s: String) =
+    this(s.length)
+
+// $COVERAGE-OFF$
+class IgnoredCtor(val x: Int):
+  def this(s: String) =
+    this(s.length)
+// $COVERAGE-ON$

--- a/tests/coverage/pos/TryInstrumentCasesIgnoredLocally.scoverage.check
+++ b/tests/coverage/pos/TryInstrumentCasesIgnoredLocally.scoverage.check
@@ -1,0 +1,836 @@
+# Coverage data, format version: 3.0
+# Statement data:
+# - id
+# - source path
+# - package name
+# - class name
+# - class type (Class, Object or Trait)
+# - full class name
+# - method name
+# - start offset
+# - end offset
+# - line number
+# - symbol name
+# - tree name
+# - is branch
+# - invocations count
+# - is ignored
+# - description (can be multi-line)
+# '' sign
+# ------------------------------------------
+0
+TryInstrumentCasesIgnoredLocally.scala
+covtest
+AllTreesIgnoredLocally
+Class
+covtest.AllTreesIgnoredLocally
+coveredApply
+101
+106
+6
++
+Apply
+false
+0
+false
+x + 1
+
+1
+TryInstrumentCasesIgnoredLocally.scala
+covtest
+AllTreesIgnoredLocally
+Class
+covtest.AllTreesIgnoredLocally
+coveredApply
+69
+85
+6
+coveredApply
+DefDef
+false
+0
+false
+def coveredApply
+
+2
+TryInstrumentCasesIgnoredLocally.scala
+covtest
+AllTreesIgnoredLocally
+Class
+covtest.AllTreesIgnoredLocally
+ignoredApply
+161
+166
+8
++
+Apply
+false
+0
+true
+x + 1
+
+3
+TryInstrumentCasesIgnoredLocally.scala
+covtest
+AllTreesIgnoredLocally
+Class
+covtest.AllTreesIgnoredLocally
+ignoredApply
+129
+145
+8
+ignoredApply
+DefDef
+false
+0
+true
+def ignoredApply
+
+4
+TryInstrumentCasesIgnoredLocally.scala
+covtest
+AllTreesIgnoredLocally
+Class
+covtest.AllTreesIgnoredLocally
+coveredLiteral
+236
+238
+12
+<none>
+Literal
+false
+0
+false
+42
+
+5
+TryInstrumentCasesIgnoredLocally.scala
+covtest
+AllTreesIgnoredLocally
+Class
+covtest.AllTreesIgnoredLocally
+coveredLiteral
+210
+228
+12
+coveredLiteral
+DefDef
+false
+0
+false
+def coveredLiteral
+
+6
+TryInstrumentCasesIgnoredLocally.scala
+covtest
+AllTreesIgnoredLocally
+Class
+covtest.AllTreesIgnoredLocally
+ignoredLiteral
+287
+289
+14
+<none>
+Literal
+false
+0
+true
+42
+
+7
+TryInstrumentCasesIgnoredLocally.scala
+covtest
+AllTreesIgnoredLocally
+Class
+covtest.AllTreesIgnoredLocally
+ignoredLiteral
+261
+279
+14
+ignoredLiteral
+DefDef
+false
+0
+true
+def ignoredLiteral
+
+8
+TryInstrumentCasesIgnoredLocally.scala
+covtest
+AllTreesIgnoredLocally
+Class
+covtest.AllTreesIgnoredLocally
+coveredSelect
+401
+409
+18
+length
+Apply
+false
+0
+false
+s.length
+
+9
+TryInstrumentCasesIgnoredLocally.scala
+covtest
+AllTreesIgnoredLocally
+Class
+covtest.AllTreesIgnoredLocally
+coveredSelect
+365
+382
+18
+coveredSelect
+DefDef
+false
+0
+false
+def coveredSelect
+
+10
+TryInstrumentCasesIgnoredLocally.scala
+covtest
+AllTreesIgnoredLocally
+Class
+covtest.AllTreesIgnoredLocally
+ignoredSelect
+468
+476
+20
+length
+Apply
+false
+0
+true
+s.length
+
+11
+TryInstrumentCasesIgnoredLocally.scala
+covtest
+AllTreesIgnoredLocally
+Class
+covtest.AllTreesIgnoredLocally
+ignoredSelect
+432
+449
+20
+ignoredSelect
+DefDef
+false
+0
+true
+def ignoredSelect
+
+12
+TryInstrumentCasesIgnoredLocally.scala
+covtest
+AllTreesIgnoredLocally
+Class
+covtest.AllTreesIgnoredLocally
+local
+589
+590
+25
+<none>
+Literal
+false
+0
+false
+1
+
+13
+TryInstrumentCasesIgnoredLocally.scala
+covtest
+AllTreesIgnoredLocally
+Class
+covtest.AllTreesIgnoredLocally
+local
+572
+581
+25
+local
+DefDef
+false
+0
+false
+def local
+
+14
+TryInstrumentCasesIgnoredLocally.scala
+covtest
+AllTreesIgnoredLocally
+Class
+covtest.AllTreesIgnoredLocally
+coveredIdent
+595
+600
+26
+local
+Ident
+false
+0
+false
+local
+
+15
+TryInstrumentCasesIgnoredLocally.scala
+covtest
+AllTreesIgnoredLocally
+Class
+covtest.AllTreesIgnoredLocally
+coveredIdent
+544
+560
+24
+coveredIdent
+DefDef
+false
+0
+false
+def coveredIdent
+
+16
+TryInstrumentCasesIgnoredLocally.scala
+covtest
+AllTreesIgnoredLocally
+Class
+covtest.AllTreesIgnoredLocally
+local
+668
+669
+29
+<none>
+Literal
+false
+0
+true
+1
+
+17
+TryInstrumentCasesIgnoredLocally.scala
+covtest
+AllTreesIgnoredLocally
+Class
+covtest.AllTreesIgnoredLocally
+local
+651
+660
+29
+local
+DefDef
+false
+0
+true
+def local
+
+18
+TryInstrumentCasesIgnoredLocally.scala
+covtest
+AllTreesIgnoredLocally
+Class
+covtest.AllTreesIgnoredLocally
+ignoredIdent
+674
+679
+30
+local
+Ident
+false
+0
+true
+local
+
+19
+TryInstrumentCasesIgnoredLocally.scala
+covtest
+AllTreesIgnoredLocally
+Class
+covtest.AllTreesIgnoredLocally
+ignoredIdent
+623
+639
+28
+ignoredIdent
+DefDef
+false
+0
+true
+def ignoredIdent
+
+20
+TryInstrumentCasesIgnoredLocally.scala
+covtest
+AllTreesIgnoredLocally
+Class
+covtest.AllTreesIgnoredLocally
+coveredBranch
+784
+789
+35
+>
+Apply
+false
+0
+false
+x > 0
+
+21
+TryInstrumentCasesIgnoredLocally.scala
+covtest
+AllTreesIgnoredLocally
+Class
+covtest.AllTreesIgnoredLocally
+coveredBranch
+795
+800
+35
+<none>
+Literal
+false
+0
+false
+"pos"
+
+22
+TryInstrumentCasesIgnoredLocally.scala
+covtest
+AllTreesIgnoredLocally
+Class
+covtest.AllTreesIgnoredLocally
+coveredBranch
+795
+800
+35
+<none>
+Literal
+true
+0
+false
+"pos"
+
+23
+TryInstrumentCasesIgnoredLocally.scala
+covtest
+AllTreesIgnoredLocally
+Class
+covtest.AllTreesIgnoredLocally
+coveredBranch
+810
+815
+36
+<none>
+Literal
+false
+0
+false
+"neg"
+
+24
+TryInstrumentCasesIgnoredLocally.scala
+covtest
+AllTreesIgnoredLocally
+Class
+covtest.AllTreesIgnoredLocally
+coveredBranch
+810
+815
+36
+<none>
+Literal
+true
+0
+false
+"neg"
+
+25
+TryInstrumentCasesIgnoredLocally.scala
+covtest
+AllTreesIgnoredLocally
+Class
+covtest.AllTreesIgnoredLocally
+coveredBranch
+741
+758
+34
+coveredBranch
+DefDef
+false
+0
+false
+def coveredBranch
+
+26
+TryInstrumentCasesIgnoredLocally.scala
+covtest
+AllTreesIgnoredLocally
+Class
+covtest.AllTreesIgnoredLocally
+ignoredBranch
+881
+886
+39
+>
+Apply
+false
+0
+true
+x > 0
+
+27
+TryInstrumentCasesIgnoredLocally.scala
+covtest
+AllTreesIgnoredLocally
+Class
+covtest.AllTreesIgnoredLocally
+ignoredBranch
+892
+897
+39
+<none>
+Literal
+false
+0
+true
+"pos"
+
+28
+TryInstrumentCasesIgnoredLocally.scala
+covtest
+AllTreesIgnoredLocally
+Class
+covtest.AllTreesIgnoredLocally
+ignoredBranch
+892
+897
+39
+<none>
+Literal
+true
+0
+true
+"pos"
+
+29
+TryInstrumentCasesIgnoredLocally.scala
+covtest
+AllTreesIgnoredLocally
+Class
+covtest.AllTreesIgnoredLocally
+ignoredBranch
+907
+912
+40
+<none>
+Literal
+false
+0
+true
+"neg"
+
+30
+TryInstrumentCasesIgnoredLocally.scala
+covtest
+AllTreesIgnoredLocally
+Class
+covtest.AllTreesIgnoredLocally
+ignoredBranch
+907
+912
+40
+<none>
+Literal
+true
+0
+true
+"neg"
+
+31
+TryInstrumentCasesIgnoredLocally.scala
+covtest
+AllTreesIgnoredLocally
+Class
+covtest.AllTreesIgnoredLocally
+ignoredBranch
+838
+855
+38
+ignoredBranch
+DefDef
+false
+0
+true
+def ignoredBranch
+
+32
+TryInstrumentCasesIgnoredLocally.scala
+covtest
+AllTreesIgnoredLocally
+Class
+covtest.AllTreesIgnoredLocally
+coveredBody
+986
+988
+44
+<none>
+Literal
+false
+0
+false
+99
+
+33
+TryInstrumentCasesIgnoredLocally.scala
+covtest
+AllTreesIgnoredLocally
+Class
+covtest.AllTreesIgnoredLocally
+coveredBody
+963
+978
+44
+coveredBody
+DefDef
+false
+0
+false
+def coveredBody
+
+34
+TryInstrumentCasesIgnoredLocally.scala
+covtest
+AllTreesIgnoredLocally
+Class
+covtest.AllTreesIgnoredLocally
+ignoredBody
+1034
+1036
+46
+<none>
+Literal
+false
+0
+true
+99
+
+35
+TryInstrumentCasesIgnoredLocally.scala
+covtest
+AllTreesIgnoredLocally
+Class
+covtest.AllTreesIgnoredLocally
+ignoredBody
+1011
+1026
+46
+ignoredBody
+DefDef
+false
+0
+true
+def ignoredBody
+
+36
+TryInstrumentCasesIgnoredLocally.scala
+covtest
+AllTreesIgnoredLocally
+Class
+covtest.AllTreesIgnoredLocally
+$anonfun
+1100
+1102
+50
+<none>
+Literal
+false
+0
+false
+99
+
+37
+TryInstrumentCasesIgnoredLocally.scala
+covtest
+AllTreesIgnoredLocally
+Class
+covtest.AllTreesIgnoredLocally
+coveredClosureDef
+1059
+1080
+49
+coveredClosureDef
+DefDef
+false
+0
+false
+def coveredClosureDef
+
+38
+TryInstrumentCasesIgnoredLocally.scala
+covtest
+AllTreesIgnoredLocally
+Class
+covtest.AllTreesIgnoredLocally
+$anonfun
+1166
+1168
+53
+<none>
+Literal
+false
+0
+true
+99
+
+39
+TryInstrumentCasesIgnoredLocally.scala
+covtest
+AllTreesIgnoredLocally
+Class
+covtest.AllTreesIgnoredLocally
+ignoredClosureDef
+1125
+1146
+52
+ignoredClosureDef
+DefDef
+false
+0
+true
+def ignoredClosureDef
+
+40
+TryInstrumentCasesIgnoredLocally.scala
+covtest
+AllTreesIgnoredLocally
+Class
+covtest.AllTreesIgnoredLocally
+$anonfun
+1233
+1235
+57
+<none>
+Literal
+false
+0
+false
+99
+
+41
+TryInstrumentCasesIgnoredLocally.scala
+covtest
+AllTreesIgnoredLocally
+Class
+covtest.AllTreesIgnoredLocally
+coveredClosureBody
+1191
+1213
+56
+coveredClosureBody
+DefDef
+false
+0
+false
+def coveredClosureBody
+
+42
+TryInstrumentCasesIgnoredLocally.scala
+covtest
+AllTreesIgnoredLocally
+Class
+covtest.AllTreesIgnoredLocally
+$anonfun
+1300
+1302
+60
+<none>
+Literal
+false
+0
+true
+99
+
+43
+TryInstrumentCasesIgnoredLocally.scala
+covtest
+AllTreesIgnoredLocally
+Class
+covtest.AllTreesIgnoredLocally
+ignoredClosureBody
+1238
+1260
+58
+ignoredClosureBody
+DefDef
+false
+0
+false
+def ignoredClosureBody
+
+44
+TryInstrumentCasesIgnoredLocally.scala
+covtest
+CoveredCtor
+Class
+covtest.CoveredCtor
+<init>
+1392
+1400
+66
+<init>
+DefDef
+false
+0
+false
+def this
+
+45
+TryInstrumentCasesIgnoredLocally.scala
+covtest
+CoveredCtor
+Class
+covtest.CoveredCtor
+<init>
+1423
+1431
+67
+length
+Apply
+false
+0
+false
+s.length
+
+46
+TryInstrumentCasesIgnoredLocally.scala
+covtest
+IgnoredCtor
+Class
+covtest.IgnoredCtor
+<init>
+1485
+1493
+71
+<init>
+DefDef
+false
+0
+true
+def this
+
+47
+TryInstrumentCasesIgnoredLocally.scala
+covtest
+IgnoredCtor
+Class
+covtest.IgnoredCtor
+<init>
+1516
+1524
+72
+length
+Apply
+false
+0
+true
+s.length
+

--- a/tests/coverage/pos/WholeFileIgnoredLocally.scala
+++ b/tests/coverage/pos/WholeFileIgnoredLocally.scala
@@ -1,0 +1,15 @@
+package covtest
+
+// $COVERAGE-OFF$
+class WholeFileIgnored:
+  def f(x: Int): Int = x + 1
+
+  def g: String = "hello"
+
+  def h(x: Int): String =
+    if x > 0 then "positive"
+    else "negative"
+
+object WholeFileIgnoredObj:
+  val x = 42
+  def compute(a: Int, b: Int): Int = a + b

--- a/tests/coverage/pos/WholeFileIgnoredLocally.scoverage.check
+++ b/tests/coverage/pos/WholeFileIgnoredLocally.scoverage.check
@@ -1,0 +1,241 @@
+# Coverage data, format version: 3.0
+# Statement data:
+# - id
+# - source path
+# - package name
+# - class name
+# - class type (Class, Object or Trait)
+# - full class name
+# - method name
+# - start offset
+# - end offset
+# - line number
+# - symbol name
+# - tree name
+# - is branch
+# - invocations count
+# - is ignored
+# - description (can be multi-line)
+# '' sign
+# ------------------------------------------
+0
+WholeFileIgnoredLocally.scala
+covtest
+WholeFileIgnored
+Class
+covtest.WholeFileIgnored
+f
+82
+87
+5
++
+Apply
+false
+0
+true
+x + 1
+
+1
+WholeFileIgnoredLocally.scala
+covtest
+WholeFileIgnored
+Class
+covtest.WholeFileIgnored
+f
+61
+66
+5
+f
+DefDef
+false
+0
+true
+def f
+
+2
+WholeFileIgnoredLocally.scala
+covtest
+WholeFileIgnored
+Class
+covtest.WholeFileIgnored
+g
+107
+114
+7
+<none>
+Literal
+false
+0
+true
+"hello"
+
+3
+WholeFileIgnoredLocally.scala
+covtest
+WholeFileIgnored
+Class
+covtest.WholeFileIgnored
+g
+91
+96
+7
+g
+DefDef
+false
+0
+true
+def g
+
+4
+WholeFileIgnoredLocally.scala
+covtest
+WholeFileIgnored
+Class
+covtest.WholeFileIgnored
+h
+149
+154
+10
+>
+Apply
+false
+0
+true
+x > 0
+
+5
+WholeFileIgnoredLocally.scala
+covtest
+WholeFileIgnored
+Class
+covtest.WholeFileIgnored
+h
+160
+170
+10
+<none>
+Literal
+false
+0
+true
+"positive"
+
+6
+WholeFileIgnoredLocally.scala
+covtest
+WholeFileIgnored
+Class
+covtest.WholeFileIgnored
+h
+160
+170
+10
+<none>
+Literal
+true
+0
+true
+"positive"
+
+7
+WholeFileIgnoredLocally.scala
+covtest
+WholeFileIgnored
+Class
+covtest.WholeFileIgnored
+h
+180
+190
+11
+<none>
+Literal
+false
+0
+true
+"negative"
+
+8
+WholeFileIgnoredLocally.scala
+covtest
+WholeFileIgnored
+Class
+covtest.WholeFileIgnored
+h
+180
+190
+11
+<none>
+Literal
+true
+0
+true
+"negative"
+
+9
+WholeFileIgnoredLocally.scala
+covtest
+WholeFileIgnored
+Class
+covtest.WholeFileIgnored
+h
+118
+123
+9
+h
+DefDef
+false
+0
+true
+def h
+
+10
+WholeFileIgnoredLocally.scala
+covtest
+WholeFileIgnoredObj
+Object
+covtest.WholeFileIgnoredObj
+<init>
+230
+232
+14
+<none>
+Literal
+false
+0
+true
+42
+
+11
+WholeFileIgnoredLocally.scala
+covtest
+WholeFileIgnoredObj
+Object
+covtest.WholeFileIgnoredObj
+compute
+270
+275
+15
++
+Apply
+false
+0
+true
+a + b
+
+12
+WholeFileIgnoredLocally.scala
+covtest
+WholeFileIgnoredObj
+Object
+covtest.WholeFileIgnoredObj
+compute
+235
+246
+15
+compute
+DefDef
+false
+0
+true
+def compute
+

--- a/tests/warn/i24034/circe.scala
+++ b/tests/warn/i24034/circe.scala
@@ -50,7 +50,7 @@ object ConfiguredCodec:
   ): Expr[ConfiguredCodec[A]] = {
     mirror match {
       case '{ // LTS specific warnings
-            ${ _ }: Mirror.ProductOf[A] { // warn
+            ${ _ }: Mirror.ProductOf[A] {
               type MirroredLabel = l // warn
               type MirroredElemLabels = el // warn
               type MirroredElemTypes = et // warn


### PR DESCRIPTION
Backports #24486 to the 3.3.7.

PR submitted by the release tooling.