### PR TITLE
Backport "Init MacroClassLoader in scaladoc" to 3.3 LTS

### DIFF
--- a/scaladoc-testcases/src/tests/snippetTestcaseMacro.scala
+++ b/scaladoc-testcases/src/tests/snippetTestcaseMacro.scala
@@ -1,0 +1,21 @@
+package tests.snippetTestcaseMacro
+
+import scala.quoted.*
+
+/** Regression test for https://github.com/scala/scala3/issues/24946
+  * Scaladoc snippet compilation fails when the snippet calls a macro
+  * defined in the same compilation unit.
+  */
+object MacroLib:
+  inline def hello: String = ${ helloImpl }
+
+  def helloImpl(using Quotes): Expr[String] = Expr("Hello")
+
+class SnippetTestcaseMacro:
+  /**
+    * SNIPPET(OUTERLINEOFFSET:17,OUTERCOLUMNOFFSET:6,INNERLINEOFFSET:4,INNERCOLUMNOFFSET:2)
+    * ```scala sc:compile
+    * MacroLib.hello
+    * ```
+    */
+  def a = 3

--- a/scaladoc/src/dotty/tools/scaladoc/snippets/SnippetCompiler.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/snippets/SnippetCompiler.scala
@@ -5,6 +5,7 @@ import dotty.tools.io.{AbstractFile, VirtualDirectory}
 import dotty.tools.dotc.Driver
 import dotty.tools.dotc.core.Contexts.Context
 import dotty.tools.dotc.core.Mode
+import dotty.tools.dotc.core.MacroClassLoader
 import dotty.tools.dotc.config.Settings.Setting._
 import dotty.tools.dotc.interfaces.{ SourcePosition => ISourcePosition }
 import dotty.tools.dotc.ast.Trees.Tree
@@ -41,7 +42,7 @@ class SnippetCompiler(
         ctx.setSetting(setting.setting, setting.value)
       }
       res.initialize()(using res)
-      res
+      MacroClassLoader.init(res)
 
   private val scala3Compiler = new Compiler
 

--- a/scaladoc/test/dotty/tools/scaladoc/snippets/SnippetsE2eTestcases.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/snippets/SnippetsE2eTestcases.scala
@@ -8,3 +8,5 @@ class SnippetE2eTestcase2 extends SnippetsE2eTest("snippetTestcase2", SCFlags.Co
 
 
 class SnippetE2eTestcase3 extends SnippetsE2eTest("snippetTestcase3", SCFlags.Compile)
+
+class SnippetE2eTestcaseMacro extends SnippetsE2eTest("snippetTestcaseMacro", SCFlags.Compile)


### PR DESCRIPTION
Backports #25141 to the 3.3.8.

PR submitted by the release tooling.
[skip ci]