### PR TITLE
Backport "Fix #24997: Avoid unnecessary CHECKCAST in untupled function parameters" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -1519,12 +1519,23 @@ object desugar {
       flags =
         if params.nonEmpty && params.head.mods.is(Given) then SyntheticTermParam | Given
         else SyntheticTermParam)
+
+    def paramIsUsed(name: Name, body: Tree): Boolean =
+      val acc = new UntypedTreeAccumulator[Boolean]:
+        def apply(x: Boolean, t: Tree)(using Context) =
+          if x then true
+          else t match
+            case Ident(id) => id == name
+            case _ => foldOver(x, t)
+      acc(false, body)
+
     def selector(n: Int) =
       if (isGenericTuple) Apply(Select(refOfDef(param), nme.apply), Literal(Constant(n)))
       else Select(refOfDef(param), nme.selectorName(n))
     val vdefs =
-      params.zipWithIndex.map {
-        case (param, idx) =>
+      params.zipWithIndex.collect {
+        case (param, idx) if param.name != nme.WILDCARD &&
+          (!param.name.is(WildcardParamName) || paramIsUsed(param.name, body)) =>
           ValDef(param.name, param.tpt, selector(idx))
             .withSpan(param.span)
             .withAttachment(UntupledParam, ())

--- a/compiler/test/dotty/tools/backend/jvm/DottyBytecodeTests.scala
+++ b/compiler/test/dotty/tools/backend/jvm/DottyBytecodeTests.scala
@@ -1987,6 +1987,67 @@ class DottyBytecodeTests extends DottyBytecodeTest {
       assertEquals(expected, clsNode.interfaces.asScala)
     }
   }
+
+  // Test for https://github.com/scala/scala3/issues/24997
+  // Automatic untupling should not introduce extra CHECKCAST instructions for unused tuple elements
+  @Test def i24997 = {
+    val source =
+      """|class Wrapper[A](value: A):
+        |  def use[B](f: A => B): B = f(value)
+        |
+        |class Test:
+        |  def withCase: Int =
+        |    val w = Wrapper(("42", "Answer"))
+        |    w.use { case (s, _) => s.length }
+        |
+        |  def withoutCase: Int =
+        |    val w = Wrapper(("42", "Answer"))
+        |    w.use { (s, _) => s.length }
+        |""".stripMargin
+
+    checkBCode(source) { dir =>
+      val clsIn = dir.lookupName("Test.class", directory = false).input
+      val clsNode = loadClassNode(clsIn)
+
+      // Get instructions for both methods
+      def getCheckCastCount(methodPrefix: String): Int = {
+        clsNode.methods.asScala.filter(_.name.startsWith(methodPrefix)).map { method =>
+          instructionsFromMethod(method).count {
+            case TypeOp(Opcodes.CHECKCAST, _) => true
+            case _ => false
+          }
+        }.sum
+      }
+
+      val withCaseCasts = getCheckCastCount("withCase")
+      val withoutCaseCasts = getCheckCastCount("withoutCase")
+
+      // Both methods should have the same number of CHECKCAST instructions
+      // (specifically, they should NOT have extra ones for unused wildcard elements)
+      assertEquals(s"withCase should have 1 CHECKCAST", 1, withCaseCasts)
+      assertEquals(s"withoutCase should have 1 CHECKCAST", 1, withoutCaseCasts)
+    }
+  }
+
+  @Test def i24997_placeholder = {
+    // Regression test for https://github.com/scala/scala3/pull/25085
+    // Ensure that placeholder syntax `_ + _` works correctly when tupled.
+    // The previous fix accidentally removed the binding for the used synthetic parameters.
+    val source =
+      """|class Test:
+        |  def use(f: ((Int, Int)) => Int): Int = f((1, 2))
+        |
+        |  def test: Int =
+        |    use { _ + _ }
+        |""".stripMargin
+    checkBCode(source) { dir =>
+      // The main verification is that it compiles.
+      // We can also check that `test` method exists.
+      val clsIn = dir.lookupName("Test.class", directory = false).input
+      val clsNode = loadClassNode(clsIn)
+      assert(clsNode.methods.asScala.exists(_.name == "test"))
+    }
+  }
 }
 
 object invocationReceiversTestCode {


### PR DESCRIPTION
Backports #25085 to the 3.3.8.

PR submitted by the release tooling.
[skip ci]