### PR TITLE
Backport "Coursier dependency imports should have lexicographic ordering" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
@@ -700,7 +700,7 @@ object TreeChecker {
       // Check that we only add the captured type `T` instead of a more complex type like `List[T]`.
       // If we have `F[T]` with captured `F` and `T`, we should list `F` and `T` separately in the args.
       def isAllowedTypeArg(tp: Type): Boolean = tp.dealias match
-        case _: TypeRef => true
+        case _: TypeRef | _: TermRef | _: ThisType => true
         case tp: AndType => isAllowedTypeArg(tp.tp1) && isAllowedTypeArg(tp.tp2)
         case _ => false
 

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/AmmoniteIvyCompletions.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/AmmoniteIvyCompletions.scala
@@ -32,11 +32,14 @@ object AmmoniteIvyCompletions:
               CoursierComplete.inferEditRange(pos.point, text)
             pos.withStart(rangeStart).withEnd(rangeEnd).toLsp
         val completions = coursierComplete.complete(dependency.nn)
+        val normalized = dependency.replace(":::", ":").replace("::", ":")
+        val isVersionCompletion = normalized.split(":").length >= 3
         completions
           .map(insertText =>
-            CompletionValue.IvyImport(
+            CompletionValue.Coursier(
               insertText.stripPrefix(":"),
               Some(insertText),
-              Some(ivyEditRange)
+              Some(ivyEditRange),
+              isVersionCompletion
             )
           )

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/AmmoniteIvyCompletions.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/AmmoniteIvyCompletions.scala
@@ -32,8 +32,8 @@ object AmmoniteIvyCompletions:
               CoursierComplete.inferEditRange(pos.point, text)
             pos.withStart(rangeStart).withEnd(rangeEnd).toLsp
         val completions = coursierComplete.complete(dependency.nn)
-        val normalized = dependency.replace(":::", ":").replace("::", ":")
-        val isVersionCompletion = normalized.split(":").length >= 3
+        val normalized = dependency.nn.replace(":::", ":").nn.replace("::", ":").nn
+        val isVersionCompletion = normalized.split(":").nn.length >= 3
         completions
           .map(insertText =>
             CompletionValue.Coursier(

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/CompletionValue.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/CompletionValue.scala
@@ -30,7 +30,7 @@ enum CompletionSource:
   case NamedArgKind
   case AutoFillKind
   case FileSystemMemberKind
-  case IvyImportKind
+  case CoursierKind
   case InterpolatorKind
   case MatchCompletionKind
   case CaseKeywordKind
@@ -282,13 +282,14 @@ object CompletionValue:
     override def completionItemKind(using Context): CompletionItemKind =
       CompletionItemKind.File
 
-  case class IvyImport(
+  case class Coursier(
       label: String,
       override val insertText: Option[String],
-      override val range: Option[Range]
+      override val range: Option[Range],
+      isVersionCompletion: Boolean = false
   ) extends CompletionValue:
     override val filterText: Option[String] = insertText
-    override def completionItemDataKind: Integer = CompletionSource.IvyImportKind.ordinal
+    override def completionItemDataKind: Integer = CompletionSource.CoursierKind.ordinal
     override def completionItemKind(using Context): CompletionItemKind =
       CompletionItemKind.Folder
 

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/Completions.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/Completions.scala
@@ -729,7 +729,7 @@ class Completions(
               (autofill.label, true)
             case fileSysMember: CompletionValue.FileSystemMember =>
               (fileSysMember.label, true)
-            case ii: CompletionValue.IvyImport => (ii.label, true)
+            case ii: CompletionValue.Coursier => (ii.label, true)
             case sv: CompletionValue.SingletonValue => (sv.label, true)
 
         if !alreadySeen(id) && include then
@@ -1032,10 +1032,7 @@ class Completions(
               o1.label,
               o2.label
             )
-          case (
-                sym1: CompletionValue.Symbolic,
-                sym2: CompletionValue.Symbolic,
-              ) =>
+          case (sym1: CompletionValue.Symbolic, sym2: CompletionValue.Symbolic) =>
             if compareCompletionValue(sym1, sym2) then 0
             else if compareCompletionValue(sym2, sym1) then 1
             else
@@ -1080,6 +1077,10 @@ class Completions(
                             if byParamCount != 0 then byParamCount
                             else s1.detailString.compareTo(s2.detailString)
             end if
+          case (sym1: CompletionValue.Coursier, sym2: CompletionValue.Coursier) =>
+            val comparison = IdentifierComparator.compare(sym1.label, sym2.label)
+            if sym1.isVersionCompletion && sym2.isVersionCompletion then -comparison
+            else comparison
           case _ =>
             val byClass = prioritizeByClass(o1, o2)
             if byClass != 0 then byClass

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/ScalaCliCompletions.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/ScalaCliCompletions.scala
@@ -34,12 +34,15 @@ class ScalaCliCompletions(
     val completions = coursierComplete.complete(dependency)
     val (editStart, editEnd) = CoursierComplete.inferEditRange(pos.point, text)
     val editRange = pos.withStart(editStart).withEnd(editEnd).toLsp
+    val normalized = dependency.replace(":::", ":").replace("::", ":")
+    val isVersionCompletion = normalized.split(":").length >= 3
     completions
       .map(insertText =>
-        CompletionValue.IvyImport(
+        CompletionValue.Coursier(
           insertText.stripPrefix(":"),
           Some(insertText),
-          Some(editRange)
+          Some(editRange),
+          isVersionCompletion
         )
       )
 

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/ScalaCliCompletions.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/ScalaCliCompletions.scala
@@ -34,8 +34,8 @@ class ScalaCliCompletions(
     val completions = coursierComplete.complete(dependency)
     val (editStart, editEnd) = CoursierComplete.inferEditRange(pos.point, text)
     val editRange = pos.withStart(editStart).withEnd(editEnd).toLsp
-    val normalized = dependency.replace(":::", ":").replace("::", ":")
-    val isVersionCompletion = normalized.split(":").length >= 3
+    val normalized = dependency.nn.replace(":::", ":").nn.replace("::", ":").nn
+    val isVersionCompletion = normalized.split(":").nn.length >= 3
     completions
       .map(insertText =>
         CompletionValue.Coursier(

--- a/presentation-compiler/test/dotty/tools/pc/base/BaseCompletionSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/base/BaseCompletionSuite.scala
@@ -227,7 +227,10 @@ abstract class BaseCompletionSuite extends BasePCSuite:
       case Some(top) => baseItems.take(top)
       case None => baseItems
     val filteredItems = items.filter(item => filter(item.getLabel))
-    filteredItems.foreach { item =>
+    val nonEmptyExpected = filteredItems.isEmpty && expected.linesIterator.exists(_.trim.nonEmpty)
+    val result = if nonEmptyExpected then items else filteredItems
+
+    result.foreach { item =>
       val label = TestCompletions.getFullyQualifiedLabel(item)
       val commitCharacter =
         if includeCommitCharacter then
@@ -254,6 +257,7 @@ abstract class BaseCompletionSuite extends BasePCSuite:
         })
         .append(commitCharacter)
         .append(completionKind)
+        .append(if nonEmptyExpected then " [FILTERED OUT]" else "")
         .append("\n")
     }
     val completionSources = filteredItems

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionScalaCliSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionScalaCliSuite.scala
@@ -16,6 +16,27 @@ class CompletionScalaCliSuite extends BaseCompletionSuite:
          |io.circul""".stripMargin
     )
 
+  @Test def `simple-lib-name` =
+    checkSubset(
+      """|//> using dep "org.scala-lang::scala@@
+         |package A
+         |""".stripMargin,
+      """|scala3-library
+         |""".stripMargin,
+    )
+
+  @Test def `ordering` =
+    check(
+      """|//> using dep "org.scala@@
+         |package A
+         |""".stripMargin,
+      """|org.scala-debugger
+         |org.scala-lang
+         |org.scala-lang-osgi
+         |""".stripMargin,
+      filter = a => a.contains("scala-lang") || a.contains("scala-debugger")
+    )
+
   @Test def `multiple-deps` =
     checkEdit(
       """|// Multiple using lib
@@ -140,6 +161,16 @@ class CompletionScalaCliSuite extends BaseCompletionSuite:
          |""".stripMargin,
       """|io.circe
          |io.circul""".stripMargin
+    )
+
+  @Test def `lexicographic-order` =
+    checkSubset(
+      """|//> using dep "org.scala-lang@@"
+         |package A
+         |""".stripMargin,
+      """|org.scala-lang
+         |org.scala-lang-osgi
+         |""".stripMargin
     )
 
   @Ignore

--- a/scaladoc/test-source-links/dotty/tools/scaladoc/source-links/RemoteLinksTest.scala
+++ b/scaladoc/test-source-links/dotty/tools/scaladoc/source-links/RemoteLinksTest.scala
@@ -94,4 +94,4 @@ class RemoteLinksTest:
             }
         }
     IO.foreachFileIn(output, processFile)
-    mtsl.result
+    mtsl.result()

--- a/tests/neg-deep-subtype/i25216.scala
+++ b/tests/neg-deep-subtype/i25216.scala
@@ -1,6 +1,6 @@
 trait X[A]
 
-given [A <: X[B], B <: A] => A => B = ???
+given [A <: X[B], B <: A]: (A => B) = ???
 
 type Z = {
   val v: Int

--- a/tests/neg-macros/i23008.check
+++ b/tests/neg-macros/i23008.check
@@ -4,8 +4,8 @@
   |                 Exception occurred while executing macro expansion.
   |                 java.lang.IllegalArgumentException: requirement failed: value of StringConstant cannot be `null`
   |                 	at scala.Predef$.require(Predef.scala:337)
+  |                 	at scala.quoted.runtime.impl.QuotesImpl$reflect$StringConstant$.apply(QuotesImpl.scala:2425)
   |                 	at scala.quoted.runtime.impl.QuotesImpl$reflect$StringConstant$.apply(QuotesImpl.scala:2424)
-  |                 	at scala.quoted.runtime.impl.QuotesImpl$reflect$StringConstant$.apply(QuotesImpl.scala:2423)
   |                 	at scala.quoted.ToExpr$StringToExpr.apply(ToExpr.scala:80)
   |                 	at scala.quoted.ToExpr$StringToExpr.apply(ToExpr.scala:78)
   |                 	at scala.quoted.Expr$.apply(Expr.scala:70)

--- a/tests/printing/transformed/lazy-vals-new-offset.check
+++ b/tests/printing/transformed/lazy-vals-new-offset.check
@@ -1,4 +1,4 @@
-[[syntax trees at end of MegaPhase{dropOuterAccessors, checkNoSuperThis, flatten, transformWildcards, moveStatic, expandPrivate, restoreScopes, selectStatic, Collect entry points, collectSuperCalls, repeatableAnnotations}]] // tests/printing/transformed/lazy-vals-new-offset.scala
+[[syntax trees at end of MegaPhase{dropOuterAccessors, checkNoSuperThis, flatten, transformWildcards, moveStatic, expandPrivate, restoreScopes, selectStatic, Collect entry points, repeatableAnnotations}]] // tests/printing/transformed/lazy-vals-new-offset.scala
 package <empty> {
   @SourceFile("tests/printing/transformed/lazy-vals-new-offset.scala") final
     module class A extends Object {

--- a/tests/printing/transformed/lazy-vals-new-varhandle.check
+++ b/tests/printing/transformed/lazy-vals-new-varhandle.check
@@ -1,4 +1,4 @@
-[[syntax trees at end of MegaPhase{dropOuterAccessors, checkNoSuperThis, flatten, transformWildcards, moveStatic, expandPrivate, restoreScopes, selectStatic, Collect entry points, collectSuperCalls, repeatableAnnotations}]] // tests/printing/transformed/lazy-vals-new-varhandle.scala
+[[syntax trees at end of MegaPhase{dropOuterAccessors, checkNoSuperThis, flatten, transformWildcards, moveStatic, expandPrivate, restoreScopes, selectStatic, Collect entry points, repeatableAnnotations}]] // tests/printing/transformed/lazy-vals-new-varhandle.scala
 package <empty> {
   @SourceFile("tests/printing/transformed/lazy-vals-new-varhandle.scala") final
     module class A extends Object {


### PR DESCRIPTION
Backports #21592 to the 3.3.8.

PR submitted by the release tooling.