### PR TITLE
Backport "Enhance WInferUnion to not warn propagated explicit union types" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/WInferUnion.scala
+++ b/compiler/src/dotty/tools/dotc/transform/WInferUnion.scala
@@ -20,7 +20,10 @@ class WInferUnion extends MiniPhase {
 
   override def transformTypeApply(tree: tpd.TypeApply)(using Context): tpd.Tree =
     val inferredOrTypes = tree.args.find: tpt =>
-      tpt.isInstanceOf[InferredTypeTree] && tpt.tpe.stripTypeVar.isInstanceOf[OrType]
+      tpt.isInstanceOf[InferredTypeTree]
+      && tpt.tpe.stripTypeVar.match
+          case tp: OrType if tp.isSoft => true
+          case _ => false
     inferredOrTypes.foreach: tpt =>
       report.warning(
         InferUnionWarning(tpt.tpe.stripTypeVar),

--- a/tests/warn/i25094.check
+++ b/tests/warn/i25094.check
@@ -1,0 +1,5 @@
+-- [E225] Type Warning: tests/warn/i25094.scala:6:19 -------------------------------------------------------------------
+6 |  def f2(x: Int) = g(if x > 0 then x else null) // warn
+  |                   ^
+  |                   A type argument was inferred to be union type Int | Null
+  |                   This may indicate a programming error.

--- a/tests/warn/i25094.scala
+++ b/tests/warn/i25094.scala
@@ -1,0 +1,6 @@
+//> using options -Winfer-union
+
+object TestInferredUnion:
+  def g[T](x: T) = x
+  def f1(x: Int | Null) = g(x)
+  def f2(x: Int) = g(if x > 0 then x else null) // warn


### PR DESCRIPTION
Backports #25280 to the 3.3.8.

PR submitted by the release tooling.
[skip ci]