### PR TITLE
Backport "End of new expr never shrinks" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -2651,7 +2651,9 @@ object Parsers {
      */
     def newExpr(): Tree =
       val start = in.skipToken()
-      def reposition(t: Tree) = t.withSpan(Span(start, in.lastOffset))
+      def reposition(t: Tree) =
+        val end = if t.span.exists then in.lastOffset max t.span.end else in.lastOffset
+        t.withSpan(Span(start, end))
       possibleTemplateStart()
       val parents =
         if in.isNestedStart then Nil
@@ -2665,11 +2667,12 @@ object Parsers {
           else parent
       case parents =>
         // With brace syntax, the last token consumed by a parser is }, but with indent syntax,
-        // the last token consumed by a parser is OUTDENT, which causes mismatching spans, so don't reposition.
+        // the last token consumed by a parser is OUTDENT, which causes mismatching spans, so don't update end.
         val indented = in.token == INDENT
         val body =
-          val bo = templateBodyOpt(emptyConstructor, parents, derived = Nil)
-          if !indented then reposition(bo) else bo
+          val tbo = templateBodyOpt(emptyConstructor, parents, derived = Nil)
+          if indented then tbo.withSpan(tbo.span.withStart(start))
+          else reposition(tbo)
         New(body)
     end newExpr
 

--- a/tests/neg/i25248.scala
+++ b/tests/neg/i25248.scala
@@ -1,0 +1,2 @@
+val y = new c(for baz <- if baz // x then y else new A { // error
+  val z = w } do 27) 42 // error

--- a/tests/semanticdb/expect/StructuralTypes.expect.scala
+++ b/tests/semanticdb/expect/StructuralTypes.expect.scala
@@ -16,7 +16,7 @@ object StructuralTypes/*<-example::StructuralTypes.*/:
 
   val V/*<-example::StructuralTypes.V.*/: Object/*->java::lang::Object#*/ {
     def scalameta/*<-local4*/: String/*->scala::Predef.String#*/
-  } = new:
-    /*<-local6*/def scalameta/*<-local5*/ = "4.0"
+  } = /*<-local6*/new:
+    def scalameta/*<-local5*/ = "4.0"
   V/*->example::StructuralTypes.V.*/.scalameta/*->scala::reflect::Selectable#selectDynamic().*/
 end StructuralTypes/*->example::StructuralTypes.*/

--- a/tests/semanticdb/metac.expect
+++ b/tests/semanticdb/metac.expect
@@ -3772,7 +3772,7 @@ Occurrences:
 [16:9..16:15): Object -> java/lang/Object#
 [17:8..17:17): scalameta <- local4
 [17:19..17:25): String -> scala/Predef.String#
-[19:4..19:4): <- local6
+[18:6..18:6): <- local6
 [19:8..19:17): scalameta <- local5
 [20:2..20:3): V -> example/StructuralTypes.V.
 [20:4..20:13): scalameta -> scala/reflect/Selectable#selectDynamic().


### PR DESCRIPTION
Backports #25253 to the 3.3.8.

PR submitted by the release tooling.
[skip ci]