### PR TITLE
Backport "Don't generate bridge methods for inaccessible Java package-private methods" to 3.3 LTS

### DIFF
--- a/tests/run/java-package-private-bridge/JavaBase.java
+++ b/tests/run/java-package-private-bridge/JavaBase.java
@@ -1,0 +1,7 @@
+package jpkg;
+
+public class JavaBase {
+    Object packagePrivate() {
+        return "base";
+    }
+}

--- a/tests/run/java-package-private-bridge/JavaChild.java
+++ b/tests/run/java-package-private-bridge/JavaChild.java
@@ -1,0 +1,8 @@
+package jpkg;
+
+public class JavaChild extends JavaBase {
+    @Override
+    String packagePrivate() {
+        return "child";
+    }
+}

--- a/tests/run/java-package-private-bridge/MyJTable.scala
+++ b/tests/run/java-package-private-bridge/MyJTable.scala
@@ -1,0 +1,3 @@
+package other
+
+class MyJTable extends javax.swing.JTable

--- a/tests/run/java-package-private-bridge/ScalaChild.scala
+++ b/tests/run/java-package-private-bridge/ScalaChild.scala
@@ -1,0 +1,3 @@
+package other
+
+class ScalaChild extends jpkg.JavaChild

--- a/tests/run/java-package-private-bridge/Test.scala
+++ b/tests/run/java-package-private-bridge/Test.scala
@@ -1,0 +1,20 @@
+// scalajs: --skip
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    val hasBridge1 = classOf[other.ScalaChild].getDeclaredMethods.exists { m =>
+      m.getName == "packagePrivate" &&
+      m.getReturnType == classOf[Object]
+    }
+    assert(!hasBridge1,
+      s"ScalaChild should not have bridge for packagePrivate")
+
+    // JTable case
+    val hasBridge2 = classOf[other.MyJTable].getDeclaredMethods.exists { m =>
+      m.getName == "dropLocationForPoint" &&
+      m.getReturnType == classOf[javax.swing.TransferHandler.DropLocation]
+    }
+    assert(!hasBridge2,
+      s"MyJTable should not have bridge for dropLocationForPoint")
+  }
+}


### PR DESCRIPTION
Backports #25166 to the 3.3.8.

PR submitted by the release tooling.
[skip ci]