### PR TITLE
Backport "Better refinement symbols in semanticDB" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/semanticdb/ExtractSemanticDB.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/ExtractSemanticDB.scala
@@ -12,7 +12,8 @@ import Contexts.*
 import Symbols.*
 import Flags.*
 import Names.Name
-import StdNames.nme
+import Types._
+import StdNames.{nme, tpnme}
 import NameOps.*
 import Denotations.StaleSymbol
 import util.Spans.Span
@@ -379,6 +380,11 @@ object ExtractSemanticDB:
             traverseAnnotsOfDefinition(ctorSym)
             ctorParams(tree.constr.termParamss, tree.constr.leadingTypeParams, tree.body)
             registerDefinition(ctorSym, tree.constr.nameSpan.startPos, Set.empty, tree.source)
+        case ReflectiveSelectableApply(qual, memberName, sel) =>
+          traverse(sel.qualifier)
+          val qualTpe = qual.symbol.info
+          val member = extractRefinement(qualTpe, memberName)
+          member.foreach(sym => registerUse(sym.symbolName, sel.nameSpan, tree.source))
         case tree: Apply if tree.fun.symbol.exists =>
           @tu lazy val genParamSymbol: Name => String = tree.fun.symbol.funParamSymbol
           traverse(tree.fun)
@@ -466,6 +472,33 @@ object ExtractSemanticDB:
         case _ =>
 
     end traverse
+
+    private def extractRefinement(site: Type, memberName: String)(using Context): Option[Symbol] =
+      def loop(site: Type, owner: Symbol): Option[Symbol] =
+        site match
+          case RefinedType(_, name, info) if name.toString() == memberName =>
+            val flags = info match
+              case _: (ExprType | MethodOrPoly) => Method
+              case _ => EmptyFlags
+            Some(newSymbol(owner, name, flags, info))
+          case RefinedType(parent, _, _) => loop(parent, owner)
+          case tp: ExprType => loop(tp.superType, owner)
+          case tp: TypeProxy =>
+            loop(tp.superType, tp.typeSymbol)
+          case _ =>
+            None
+      loop(site, NoSymbol)
+
+    private object ReflectiveSelectableApply:
+      def unapply(tree: Tree)(using Context): Option[(Tree, String, Select)] = tree match
+        case Apply(
+            sel @ Select(Apply(Ident(reflSelectable), List(qual)), fun),
+            Literal(Constants.Constant(memberName: String)) :: args
+          ) if reflSelectable == nme.reflectiveSelectable &&
+              (fun == nme.selectDynamic || fun == nme.applyDynamic) =>
+            Some(qual, memberName, sel)
+        case _ => None
+    end ReflectiveSelectableApply
 
     private object PatternValDef:
 

--- a/compiler/src/dotty/tools/dotc/semanticdb/Scala3.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/Scala3.scala
@@ -257,8 +257,14 @@ object Scala3:
       /** Is symbol global? Non-global symbols get localN names */
       def isGlobal(using Context): Boolean =
         sym.exists && (
-          sym.is(Package)
-          || !sym.isSelfSym && (sym.is(Param) || sym.owner.isClass) && sym.owner.isGlobal
+          //packages are always global
+          sym.is(Package) ||
+          // Non-self parameters for global symbols
+            !sym.isSelfSym && (sym.is(Param) && sym.owner.isGlobal ||
+            // Topelevel class symbols are global
+            sym.owner.isClass ||
+            // Needed for refinement symbols, which are accessible in global scope
+            sym.owner.isType && !sym.owner.info.hiBound.isMatch) && sym.owner.isGlobal
         )
 
       def isLocalWithinSameName(using Context): Boolean =

--- a/compiler/src/dotty/tools/dotc/semanticdb/SemanticSymbolBuilder.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/SemanticSymbolBuilder.scala
@@ -7,6 +7,7 @@ import Contexts.*
 import Symbols.*
 import Flags.*
 import Names.Name
+import StdNames.tpnme
 
 import scala.annotation.tailrec
 import scala.collection.mutable
@@ -71,7 +72,11 @@ class SemanticSymbolBuilder:
   private def addSymName(b: StringBuilder, sym: Symbol)(using Context): Unit =
 
     def addOwner(owner: Symbol): Unit =
-      if !owner.isRoot then addSymName(b, owner)
+      if !owner.isRoot then
+        // Skip synthetic refinement class so refinement members get the type alias as owner
+        // e.g. User#name(). instead of User#`<refinement>`#name().
+        if owner.name == tpnme.REFINE_CLASS then addOwner(owner.owner)
+        else addSymName(b, owner)
 
     def addOverloadIdx(initSym: Symbol): Unit =
       // revert from the compiler-generated overload of the signature polymorphic method

--- a/tests/semanticdb/expect/Advanced.expect.scala
+++ b/tests/semanticdb/expect/Advanced.expect.scala
@@ -25,11 +25,11 @@ class Wildcards/*<-advanced::Wildcards#*/ {
 object Test/*<-advanced::Test.*/ {
   val s/*<-advanced::Test.s.*/ = new Structural/*->advanced::Structural#*/
   val s1/*<-advanced::Test.s1.*/ = s/*->advanced::Test.s.*/.s1/*->advanced::Structural#s1().*/
-  val s1x/*<-advanced::Test.s1x.*/ = s/*->advanced::Test.s.*/.s1/*->advanced::Structural#s1().*/.x/*->scala::reflect::Selectable#selectDynamic().*/
+  val s1x/*<-advanced::Test.s1x.*/ = s/*->advanced::Test.s.*/.s1/*->advanced::Structural#s1().*/.x/*->local13*/
   val s2/*<-advanced::Test.s2.*/ = s/*->advanced::Test.s.*/.s2/*->advanced::Structural#s2().*/
-  val s2x/*<-advanced::Test.s2x.*/ = s/*->advanced::Test.s.*/.s2/*->advanced::Structural#s2().*/.x/*->scala::reflect::Selectable#selectDynamic().*/
+  val s2x/*<-advanced::Test.s2x.*/ = s/*->advanced::Test.s.*/.s2/*->advanced::Structural#s2().*/.x/*->local14*/
   val s3/*<-advanced::Test.s3.*/ = s/*->advanced::Test.s.*/.s3/*->advanced::Structural#s3().*/
-  val s3x/*<-advanced::Test.s3x.*/ = s/*->advanced::Test.s.*/.s3/*->advanced::Structural#s3().*/.m/*->scala::reflect::Selectable#applyDynamic().*/(???/*->scala::Predef.`???`().*/)
+  val s3x/*<-advanced::Test.s3x.*/ = s/*->advanced::Test.s.*/.s3/*->advanced::Structural#s3().*/.m/*->local15*/(???/*->scala::Predef.`???`().*/)
 
   val e/*<-advanced::Test.e.*/ = new Wildcards/*->advanced::Wildcards#*/
   val e1/*<-advanced::Test.e1.*/ = e/*->advanced::Test.e.*/.e1/*->advanced::Wildcards#e1().*/
@@ -37,15 +37,15 @@ object Test/*<-advanced::Test.*/ {
 
   {
     (???/*->scala::Predef.`???`().*/ : Any/*->scala::Any#*/) match {
-      case e3/*<-local13*/: List/*->scala::package.List#*/[_] =>
-        val e3x/*<-local15*/ = e3/*->local13*/.head/*->scala::collection::IterableOps#head().*/
+      case e3/*<-local16*/: List/*->scala::package.List#*/[_] =>
+        val e3x/*<-local18*/ = e3/*->local16*/.head/*->scala::collection::IterableOps#head().*/
         ()
     }
   }
 
   // see: https://github.com/lampepfl/dotty/pull/14608#discussion_r835642563
-  lazy val foo/*<-advanced::Test.foo.*/: (reflect.Selectable/*->scala::reflect::Selectable#*/ { type A/*<-local16*/ = Int/*->scala::Int#*/ }) &/*->scala::`&`#*/ (reflect.Selectable/*->scala::reflect::Selectable#*/ { type A/*<-local17*/ = Int/*->scala::Int#*/; val a/*<-local18*/: A/*->local17*/ }) = ???/*->scala::Predef.`???`().*/
-  def bar/*<-advanced::Test.bar().*/: foo/*->advanced::Test.foo.*/.A/*->local17*/ = foo/*->advanced::Test.foo.*/.a/*->scala::reflect::Selectable#selectDynamic().*/
+  lazy val foo/*<-advanced::Test.foo.*/: (reflect.Selectable/*->scala::reflect::Selectable#*/ { type A/*<-local19*/ = Int/*->scala::Int#*/ }) &/*->scala::`&`#*/ (reflect.Selectable/*->scala::reflect::Selectable#*/ { type A/*<-local20*/ = Int/*->scala::Int#*/; val a/*<-local21*/: A/*->local20*/ }) = ???/*->scala::Predef.`???`().*/
+  def bar/*<-advanced::Test.bar().*/: foo/*->advanced::Test.foo.*/.A/*->local20*/ = foo/*->advanced::Test.foo.*/.a/*->scala::reflect::Selectable#selectDynamic().*/
 }
 
 

--- a/tests/semanticdb/expect/RecOrRefined.expect.scala
+++ b/tests/semanticdb/expect/RecOrRefined.expect.scala
@@ -1,34 +1,34 @@
 package example
 
-def m1/*<-example::RecOrRefined$package.m1().*/(a/*<-example::RecOrRefined$package.m1().(a)*/: Int/*->scala::Int#*/ { val x/*<-local4*/: Int/*->scala::Int#*/ }) = ???/*->scala::Predef.`???`().*/
-def m2/*<-example::RecOrRefined$package.m2().*/(x/*<-example::RecOrRefined$package.m2().(x)*/: { val x/*<-local5*/: Int/*->scala::Int#*/; def y/*<-local6*/: Int/*->scala::Int#*/ }) = ???/*->scala::Predef.`???`().*/
-def m3/*<-example::RecOrRefined$package.m3().*/(x/*<-example::RecOrRefined$package.m3().(x)*/: { val x/*<-local7*/: Int/*->scala::Int#*/; def y/*<-local8*/: Int/*->scala::Int#*/; type z/*<-local9*/ }) = ???/*->scala::Predef.`???`().*/
+def m1/*<-example::RecOrRefined$package.m1().*/(a/*<-example::RecOrRefined$package.m1().(a)*/: Int/*->scala::Int#*/ { val x/*<-local1*/: Int/*->scala::Int#*/ }) = ???/*->scala::Predef.`???`().*/
+def m2/*<-example::RecOrRefined$package.m2().*/(x/*<-example::RecOrRefined$package.m2().(x)*/: { val x/*<-local2*/: Int/*->scala::Int#*/; def y/*<-local3*/: Int/*->scala::Int#*/ }) = ???/*->scala::Predef.`???`().*/
+def m3/*<-example::RecOrRefined$package.m3().*/(x/*<-example::RecOrRefined$package.m3().(x)*/: { val x/*<-local4*/: Int/*->scala::Int#*/; def y/*<-local5*/: Int/*->scala::Int#*/; type z/*<-local6*/ }) = ???/*->scala::Predef.`???`().*/
 trait PolyHolder/*<-example::PolyHolder#*/ {
   def foo/*<-example::PolyHolder#foo().*/[T/*<-example::PolyHolder#foo().[T]*/](t/*<-example::PolyHolder#foo().(t)*/: T/*->example::PolyHolder#foo().[T]*/): Any/*->scala::Any#*/
 }
 
-def m4/*<-example::RecOrRefined$package.m4().*/(x/*<-example::RecOrRefined$package.m4().(x)*/: PolyHolder/*->example::PolyHolder#*/ { def foo/*<-local12*/[T/*<-local10*/](t/*<-local11*/: T/*->local10*/): T/*->local10*/ }) = ???/*->scala::Predef.`???`().*/
-def m5/*<-example::RecOrRefined$package.m5().*/[Z/*<-example::RecOrRefined$package.m5().[Z]*/](x/*<-example::RecOrRefined$package.m5().(x)*/: Int/*->scala::Int#*/): PolyHolder/*->example::PolyHolder#*/ { def foo/*<-local15*/[T/*<-local13*/](t/*<-local14*/: T/*->local13*/): T/*->local13*/ } = ???/*->scala::Predef.`???`().*/
+def m4/*<-example::RecOrRefined$package.m4().*/(x/*<-example::RecOrRefined$package.m4().(x)*/: PolyHolder/*->example::PolyHolder#*/ { def foo/*<-local9*/[T/*<-local7*/](t/*<-local8*/: T/*->local7*/): T/*->local7*/ }) = ???/*->scala::Predef.`???`().*/
+def m5/*<-example::RecOrRefined$package.m5().*/[Z/*<-example::RecOrRefined$package.m5().[Z]*/](x/*<-example::RecOrRefined$package.m5().(x)*/: Int/*->scala::Int#*/): PolyHolder/*->example::PolyHolder#*/ { def foo/*<-local12*/[T/*<-local10*/](t/*<-local11*/: T/*->local10*/): T/*->local10*/ } = ???/*->scala::Predef.`???`().*/
 
-type m6/*<-example::RecOrRefined$package.m6#*/ = [X/*<-example::RecOrRefined$package.m6#[X]*/] =>> PolyHolder/*->example::PolyHolder#*/ { def foo/*<-local18*/[T/*<-local16*/](t/*<-local17*/: T/*->local16*/): T/*->local16*/ }
+type m6/*<-example::RecOrRefined$package.m6#*/ = [X/*<-example::RecOrRefined$package.m6#[X]*/] =>> PolyHolder/*->example::PolyHolder#*/ { def foo/*<-example::RecOrRefined$package.m6#foo().*/[T/*<-example::RecOrRefined$package.m6#foo().[T]*/](t/*<-example::RecOrRefined$package.m6#foo().(t)*/: T/*->example::RecOrRefined$package.m6#foo().[T]*/): T/*->example::RecOrRefined$package.m6#foo().[T]*/ }
 
 class Record/*<-example::Record#*/(elems/*<-example::Record#elems.*/: (String/*->scala::Predef.String#*/, Any/*->scala::Any#*/)*) extends Selectable/*->scala::Selectable#*/:
   private val fields/*<-example::Record#fields.*/ = elems/*->example::Record#elems.*/.toMap/*->scala::collection::IterableOnceOps#toMap().*/
   def selectDynamic/*<-example::Record#selectDynamic().*/(name/*<-example::Record#selectDynamic().(name)*/: String/*->scala::Predef.String#*/): Any/*->scala::Any#*/ = fields/*->example::Record#fields.*/(name/*->example::Record#selectDynamic().(name)*/)
 
 type Person/*<-example::RecOrRefined$package.Person#*/ = Record/*->example::Record#*/ {
-  val name/*<-local19*/: String/*->scala::Predef.String#*/
-  val age/*<-local20*/: Int/*->scala::Int#*/
+  val name/*<-example::RecOrRefined$package.Person#name.*/: String/*->scala::Predef.String#*/
+  val age/*<-example::RecOrRefined$package.Person#age.*/: Int/*->scala::Int#*/
 }
 
 // RecType
 class C/*<-example::C#*/ { type T1/*<-example::C#T1#*/; type T2/*<-example::C#T2#*/ }
-type C2/*<-example::RecOrRefined$package.C2#*/ = C/*->example::C#*/ { type T1/*<-local21*/; type T2/*<-local22*/ = T1/*->local21*/ }
+type C2/*<-example::RecOrRefined$package.C2#*/ = C/*->example::C#*/ { type T1/*<-example::RecOrRefined$package.C2#T1#*/; type T2/*<-example::RecOrRefined$package.C2#T2#*/ = T1/*->example::RecOrRefined$package.C2#T1#*/ }
 
 trait SpecialRefinement/*<-example::SpecialRefinement#*/ {
   def pickOne/*<-example::SpecialRefinement#pickOne().*/[T/*<-example::SpecialRefinement#pickOne().[T]*/](as/*<-example::SpecialRefinement#pickOne().(as)*/: T/*->example::SpecialRefinement#pickOne().[T]*/*): Option/*->scala::Option#*/[Any/*->scala::Any#*/]
 }
 
-class PickOneRefinement_1/*<-example::PickOneRefinement_1#*/[S/*<-example::PickOneRefinement_1#[S]*/ <: SpecialRefinement/*->example::SpecialRefinement#*/ { def pickOne/*<-local3*/[T/*<-local1*/](as/*<-local2*/: T/*->local1*/*): Option/*->scala::Option#*/[String/*->scala::Predef.String#*/] }] {
+class PickOneRefinement_1/*<-example::PickOneRefinement_1#*/[S/*<-example::PickOneRefinement_1#[S]*/ <: SpecialRefinement/*->example::SpecialRefinement#*/ { def pickOne/*<-example::PickOneRefinement_1#`<init>`().[S]pickOne().*/[T/*<-example::PickOneRefinement_1#`<init>`().[S]pickOne().[T]*/](as/*<-example::PickOneRefinement_1#`<init>`().[S]pickOne().(as)*/: T/*->example::PickOneRefinement_1#`<init>`().[S]pickOne().[T]*/*): Option/*->scala::Option#*/[String/*->scala::Predef.String#*/] }] {
   def run/*<-example::PickOneRefinement_1#run().*/(s/*<-example::PickOneRefinement_1#run().(s)*/: S/*->example::PickOneRefinement_1#[S]*/, as/*<-example::PickOneRefinement_1#run().(as)*/: String/*->scala::Predef.String#*/*): Option/*->scala::Option#*/[String/*->scala::Predef.String#*/] = s/*->example::PickOneRefinement_1#run().(s)*/.pickOne/*->example::SpecialRefinement#pickOne().*/(as/*->example::PickOneRefinement_1#run().(as)*/:_*)
 }

--- a/tests/semanticdb/expect/StructuralTypes.expect.scala
+++ b/tests/semanticdb/expect/StructuralTypes.expect.scala
@@ -4,19 +4,21 @@ import reflect.Selectable/*->scala::reflect::Selectable.*/.reflectiveSelectable/
 
 object StructuralTypes/*<-example::StructuralTypes.*/:
   type User/*<-example::StructuralTypes.User#*/ = {
-    def name/*<-local0*/: String/*->scala::Predef.String#*/
-    def age/*<-local1*/: Int/*->scala::Int#*/
-    def foo/*<-local3*/(x/*<-local2*/: Int/*->scala::Int#*/): Int/*->scala::Int#*/
+    def name/*<-example::StructuralTypes.User#name().*/: String/*->scala::Predef.String#*/
+    def age/*<-example::StructuralTypes.User#age().*/: Int/*->scala::Int#*/
   }
 
-  val user/*<-example::StructuralTypes.user.*/ = null.asInstanceOf/*->scala::Any#asInstanceOf().*/[User/*->example::StructuralTypes.User#*/]
-  user/*->example::StructuralTypes.user.*/.name/*->scala::reflect::Selectable#selectDynamic().*/
-  user/*->example::StructuralTypes.user.*/.age/*->scala::reflect::Selectable#selectDynamic().*/
-  val fooBar/*<-example::StructuralTypes.fooBar.*/ = user/*->example::StructuralTypes.user.*/ foo/*->scala::reflect::Selectable#applyDynamic().*/ 123
+  type FooUser/*<-example::StructuralTypes.FooUser#*/ = User/*->example::StructuralTypes.User#*/ {
+    def foo/*<-example::StructuralTypes.FooUser#foo().*/(x/*<-example::StructuralTypes.FooUser#foo().(x)*/: Int/*->scala::Int#*/): Int/*->scala::Int#*/
+  }
 
+  val user/*<-example::StructuralTypes.user.*/ = null.asInstanceOf/*->scala::Any#asInstanceOf().*/[FooUser/*->example::StructuralTypes.FooUser#*/]
+  user/*->example::StructuralTypes.user.*/.name/*->example::StructuralTypes.User#name().*/
+  user/*->example::StructuralTypes.user.*/.age/*->example::StructuralTypes.User#age().*/
+  val fooBar/*<-example::StructuralTypes.fooBar.*/ = user/*->example::StructuralTypes.user.*/ foo/*->example::StructuralTypes.FooUser#foo().*/ 123
   val V/*<-example::StructuralTypes.V.*/: Object/*->java::lang::Object#*/ {
-    def scalameta/*<-local4*/: String/*->scala::Predef.String#*/
-  } = /*<-local6*/new:
-    def scalameta/*<-local5*/ = "4.0"
-  V/*->example::StructuralTypes.V.*/.scalameta/*->scala::reflect::Selectable#selectDynamic().*/
+    def scalameta/*<-local0*/: String/*->scala::Predef.String#*/
+  } = /*<-local2*/new:
+    def scalameta/*<-local1*/ = "4.0"
+  V/*->example::StructuralTypes.V.*/.scalameta/*->local4*/
 end StructuralTypes/*->example::StructuralTypes.*/

--- a/tests/semanticdb/expect/StructuralTypes.scala
+++ b/tests/semanticdb/expect/StructuralTypes.scala
@@ -6,14 +6,16 @@ object StructuralTypes:
   type User = {
     def name: String
     def age: Int
+  }
+
+  type FooUser = User {
     def foo(x: Int): Int
   }
 
-  val user = null.asInstanceOf[User]
+  val user = null.asInstanceOf[FooUser]
   user.name
   user.age
   val fooBar = user foo 123
-
   val V: Object {
     def scalameta: String
   } = new:

--- a/tests/semanticdb/expect/StructuralTypesParams.expect.scala
+++ b/tests/semanticdb/expect/StructuralTypesParams.expect.scala
@@ -1,0 +1,18 @@
+package example
+
+import reflect.Selectable/*->scala::reflect::Selectable.*/.reflectiveSelectable/*->scala::reflect::Selectable.reflectiveSelectable().*/
+
+object StructuralTypesParams/*<-example::StructuralTypesParams.*/:
+  type User/*<-example::StructuralTypesParams.User#*/ = {
+    def foo/*<-example::StructuralTypesParams.User#foo().*/(arg1/*<-example::StructuralTypesParams.User#foo().(arg1)*/: Int/*->scala::Int#*/, arg2/*<-example::StructuralTypesParams.User#foo().(arg2)*/: String/*->scala::Predef.String#*/): String/*->scala::Predef.String#*/
+    def age/*<-example::StructuralTypesParams.User#age().*/: Int/*->scala::Int#*/
+
+  }
+  val user/*<-example::StructuralTypesParams.user.*/ = null.asInstanceOf/*->scala::Any#asInstanceOf().*/[User/*->example::StructuralTypesParams.User#*/]
+  val num/*<-example::StructuralTypesParams.num.*/ = 123
+  val str/*<-example::StructuralTypesParams.str.*/ = "abc"
+  val fooBar/*<-example::StructuralTypesParams.fooBar.*/ = user/*->example::StructuralTypesParams.user.*/.foo/*->example::StructuralTypesParams.User#foo().*/(num/*->example::StructuralTypesParams.num.*/, str/*->example::StructuralTypesParams.str.*/)
+  val fooBaz/*<-example::StructuralTypesParams.fooBaz.*/ = user/*->example::StructuralTypesParams.user.*/.foo/*->example::StructuralTypesParams.User#foo().*/(arg1 = num/*->example::StructuralTypesParams.num.*/, arg2 = str/*->example::StructuralTypesParams.str.*/)
+  val age/*<-example::StructuralTypesParams.age.*/ = user/*->example::StructuralTypesParams.user.*/.age/*->example::StructuralTypesParams.User#age().*/
+
+end StructuralTypesParams/*->example::StructuralTypesParams.*/

--- a/tests/semanticdb/expect/StructuralTypesParams.scala
+++ b/tests/semanticdb/expect/StructuralTypesParams.scala
@@ -1,0 +1,18 @@
+package example
+
+import reflect.Selectable.reflectiveSelectable
+
+object StructuralTypesParams:
+  type User = {
+    def foo(arg1: Int, arg2: String): String
+    def age: Int
+
+  }
+  val user = null.asInstanceOf[User]
+  val num = 123
+  val str = "abc"
+  val fooBar = user.foo(num, str)
+  val fooBaz = user.foo(arg1 = num, arg2 = str)
+  val age = user.age
+
+end StructuralTypesParams

--- a/tests/semanticdb/expect/dep-match.expect.scala
+++ b/tests/semanticdb/expect/dep-match.expect.scala
@@ -1,9 +1,9 @@
 object Test_depmatch/*<-_empty_::Test_depmatch.*/ {
-  type Foo/*<-_empty_::Test_depmatch.Foo#*/ = Int/*->scala::Int#*/ { type U/*<-local0*/ }
+  type Foo/*<-_empty_::Test_depmatch.Foo#*/ = Int/*->scala::Int#*/ { type U/*<-_empty_::Test_depmatch.Foo#U#*/ }
   type Bar/*<-_empty_::Test_depmatch.Bar#*/[T/*<-_empty_::Test_depmatch.Bar#[T]*/] = T/*->_empty_::Test_depmatch.Bar#[T]*/ match {
     case Unit/*->scala::Unit#*/ => Unit/*->scala::Unit#*/
   }
   inline def baz/*<-_empty_::Test_depmatch.baz().*/(foo/*<-_empty_::Test_depmatch.baz().(foo)*/: Foo/*->_empty_::Test_depmatch.Foo#*/): Unit/*->scala::Unit#*/ = {
-    val v/*<-local1*/: Bar/*->_empty_::Test_depmatch.Bar#*/[foo/*->_empty_::Test_depmatch.baz().(foo)*/.U/*->local0*/] = ???/*->scala::Predef.`???`().*/
+    val v/*<-local0*/: Bar/*->_empty_::Test_depmatch.Bar#*/[foo/*->_empty_::Test_depmatch.baz().(foo)*/.U/*->_empty_::Test_depmatch.Foo#U#*/] = ???/*->scala::Predef.`???`().*/
   }
 }

--- a/tests/semanticdb/metac.expect
+++ b/tests/semanticdb/metac.expect
@@ -111,11 +111,11 @@ local8 => method m (param x: Int): Int
 local9 => final class $anon extends Object { self: $anon => +2 decls }
 local11 => abstract val method x Int
 local12 => type B  = A
-local13 => val local e3: List[local14]
-local15 => val local e3x: local14
-local16 => type A  = Int
-local17 => type A  = Int
-local18 => abstract val method a A
+local16 => val local e3: List[local17]
+local18 => val local e3x: local17
+local19 => type A  = Int
+local20 => type A  = Int
+local21 => abstract val method a A
 
 Occurrences:
 [0:8..0:16): advanced <- advanced/
@@ -194,21 +194,21 @@ Occurrences:
 [27:6..27:9): s1x <- advanced/Test.s1x.
 [27:12..27:13): s -> advanced/Test.s.
 [27:14..27:16): s1 -> advanced/Structural#s1().
-[27:17..27:18): x -> scala/reflect/Selectable#selectDynamic().
+[27:17..27:18): x -> local13
 [28:6..28:8): s2 <- advanced/Test.s2.
 [28:11..28:12): s -> advanced/Test.s.
 [28:13..28:15): s2 -> advanced/Structural#s2().
 [29:6..29:9): s2x <- advanced/Test.s2x.
 [29:12..29:13): s -> advanced/Test.s.
 [29:14..29:16): s2 -> advanced/Structural#s2().
-[29:17..29:18): x -> scala/reflect/Selectable#selectDynamic().
+[29:17..29:18): x -> local14
 [30:6..30:8): s3 <- advanced/Test.s3.
 [30:11..30:12): s -> advanced/Test.s.
 [30:13..30:15): s3 -> advanced/Structural#s3().
 [31:6..31:9): s3x <- advanced/Test.s3x.
 [31:12..31:13): s -> advanced/Test.s.
 [31:14..31:16): s3 -> advanced/Structural#s3().
-[31:17..31:18): m -> scala/reflect/Selectable#applyDynamic().
+[31:17..31:18): m -> local15
 [31:19..31:22): ??? -> scala/Predef.`???`().
 [33:6..33:7): e <- advanced/Test.e.
 [33:14..33:23): Wildcards -> advanced/Wildcards#
@@ -221,27 +221,27 @@ Occurrences:
 [35:17..35:21): head -> scala/collection/IterableOps#head().
 [38:5..38:8): ??? -> scala/Predef.`???`().
 [38:11..38:14): Any -> scala/Any#
-[39:11..39:13): e3 <- local13
+[39:11..39:13): e3 <- local16
 [39:15..39:19): List -> scala/package.List#
-[40:12..40:15): e3x <- local15
-[40:18..40:20): e3 -> local13
+[40:12..40:15): e3x <- local18
+[40:18..40:20): e3 -> local16
 [40:21..40:25): head -> scala/collection/IterableOps#head().
 [46:11..46:14): foo <- advanced/Test.foo.
 [46:17..46:24): reflect -> scala/reflect/
 [46:25..46:35): Selectable -> scala/reflect/Selectable#
-[46:43..46:44): A <- local16
+[46:43..46:44): A <- local19
 [46:47..46:50): Int -> scala/Int#
 [46:54..46:55): & -> scala/`&`#
 [46:57..46:64): reflect -> scala/reflect/
 [46:65..46:75): Selectable -> scala/reflect/Selectable#
-[46:83..46:84): A <- local17
+[46:83..46:84): A <- local20
 [46:87..46:90): Int -> scala/Int#
-[46:96..46:97): a <- local18
-[46:99..46:100): A -> local17
+[46:96..46:97): a <- local21
+[46:99..46:100): A -> local20
 [46:106..46:109): ??? -> scala/Predef.`???`().
 [47:6..47:9): bar <- advanced/Test.bar().
 [47:11..47:14): foo -> advanced/Test.foo.
-[47:15..47:16): A -> local17
+[47:15..47:16): A -> local20
 [47:19..47:22): foo -> advanced/Test.foo.
 [47:23..47:24): a -> scala/reflect/Selectable#selectDynamic().
 [52:6..52:13): HKClass <- advanced/HKClass#
@@ -3360,6 +3360,9 @@ example/PickOneRefinement_1#[S] => typeparam S  <: SpecialRefinement { abstract 
 example/PickOneRefinement_1#[S](as) => param as: T*
 example/PickOneRefinement_1#[S][T] => typeparam T 
 example/PickOneRefinement_1#`<init>`(). => primary ctor <init> [typeparam S  <: SpecialRefinement { abstract method pickOne [typeparam T ](param as: T*): Option[String] }](): PickOneRefinement_1[S]
+example/PickOneRefinement_1#`<init>`().[S]pickOne(). => abstract method pickOne [typeparam T ](param as: T*): Option[String] <: example/SpecialRefinement#pickOne().
+example/PickOneRefinement_1#`<init>`().[S]pickOne().(as) => param as: T*
+example/PickOneRefinement_1#`<init>`().[S]pickOne().[T] => typeparam T 
 example/PickOneRefinement_1#run(). => method run (param s: S, param as: String*): Option[String]
 example/PickOneRefinement_1#run().(as) => param as: String*
 example/PickOneRefinement_1#run().(s) => param s: S
@@ -3370,7 +3373,11 @@ example/PolyHolder#foo().(t) => param t: T
 example/PolyHolder#foo().[T] => typeparam T 
 example/RecOrRefined$package. => final package object example extends Object { self: example.type => +9 decls }
 example/RecOrRefined$package.C2# => type C2  = C { type T2  = T1 <: example/C#T2#; type T1  <: example/C#T1# }
+example/RecOrRefined$package.C2#T1# => type T1  <: example/C#T1#
+example/RecOrRefined$package.C2#T2# => type T2  = T1 <: example/C#T2#
 example/RecOrRefined$package.Person# => type Person  = Record { abstract val method age Int; abstract val method name String }
+example/RecOrRefined$package.Person#age. => abstract val method age Int
+example/RecOrRefined$package.Person#name. => abstract val method name String
 example/RecOrRefined$package.m1(). => method m1 (param a: Int { abstract val method x Int }): Nothing
 example/RecOrRefined$package.m1().(a) => param a: Int { abstract val method x Int }
 example/RecOrRefined$package.m2(). => method m2 (param x: Object { abstract method y => Int; abstract val method x Int }): Nothing
@@ -3384,6 +3391,9 @@ example/RecOrRefined$package.m5().(x) => param x: Int
 example/RecOrRefined$package.m5().[Z] => typeparam Z 
 example/RecOrRefined$package.m6# => type m6 [typeparam X ] = PolyHolder { abstract method foo [typeparam T ](param t: T): T <: example/PolyHolder#foo(). }
 example/RecOrRefined$package.m6#[X] => typeparam X 
+example/RecOrRefined$package.m6#foo(). => abstract method foo [typeparam T ](param t: T): T <: example/PolyHolder#foo().
+example/RecOrRefined$package.m6#foo().(t) => param t: T
+example/RecOrRefined$package.m6#foo().[T] => typeparam T 
 example/Record# => class Record extends Object with Selectable { self: Record => +4 decls }
 example/Record#`<init>`(). => primary ctor <init> (param elems: Tuple2[String, Any]*): Record
 example/Record#`<init>`().(elems) => param elems: Tuple2[String, Any]*
@@ -3397,51 +3407,41 @@ example/SpecialRefinement#pickOne(). => abstract method pickOne [typeparam T ](p
 example/SpecialRefinement#pickOne().(as) => param as: T*
 example/SpecialRefinement#pickOne().[T] => typeparam T 
 local0 => abstract method pickOne [typeparam T ](param as: T*): Option[String]
-local1 => typeparam T 
-local2 => param as: T*
-local3 => abstract method pickOne [typeparam T ](param as: T*): Option[String] <: example/SpecialRefinement#pickOne().
+local1 => abstract val method x Int
+local2 => abstract val method x Int
+local3 => abstract method y => Int
 local4 => abstract val method x Int
-local5 => abstract val method x Int
-local6 => abstract method y => Int
-local7 => abstract val method x Int
-local8 => abstract method y => Int
-local9 => type z 
+local5 => abstract method y => Int
+local6 => type z 
+local7 => typeparam T 
+local8 => param t: T
+local9 => abstract method foo [typeparam T ](param t: T): T <: example/PolyHolder#foo().
 local10 => typeparam T 
 local11 => param t: T
 local12 => abstract method foo [typeparam T ](param t: T): T <: example/PolyHolder#foo().
-local13 => typeparam T 
-local14 => param t: T
-local15 => abstract method foo [typeparam T ](param t: T): T <: example/PolyHolder#foo().
-local16 => typeparam T 
-local17 => param t: T
-local18 => abstract method foo [typeparam T ](param t: T): T <: example/PolyHolder#foo().
-local19 => abstract val method name String
-local20 => abstract val method age Int
-local21 => type T1  <: example/C#T1#
-local22 => type T2  = T1 <: example/C#T2#
 
 Occurrences:
 [0:8..0:15): example <- example/
 [2:4..2:6): m1 <- example/RecOrRefined$package.m1().
 [2:7..2:8): a <- example/RecOrRefined$package.m1().(a)
 [2:10..2:13): Int -> scala/Int#
-[2:20..2:21): x <- local4
+[2:20..2:21): x <- local1
 [2:23..2:26): Int -> scala/Int#
 [2:32..2:35): ??? -> scala/Predef.`???`().
 [3:4..3:6): m2 <- example/RecOrRefined$package.m2().
 [3:7..3:8): x <- example/RecOrRefined$package.m2().(x)
-[3:16..3:17): x <- local5
+[3:16..3:17): x <- local2
 [3:19..3:22): Int -> scala/Int#
-[3:28..3:29): y <- local6
+[3:28..3:29): y <- local3
 [3:31..3:34): Int -> scala/Int#
 [3:40..3:43): ??? -> scala/Predef.`???`().
 [4:4..4:6): m3 <- example/RecOrRefined$package.m3().
 [4:7..4:8): x <- example/RecOrRefined$package.m3().(x)
-[4:16..4:17): x <- local7
+[4:16..4:17): x <- local4
 [4:19..4:22): Int -> scala/Int#
-[4:28..4:29): y <- local8
+[4:28..4:29): y <- local5
 [4:31..4:34): Int -> scala/Int#
-[4:41..4:42): z <- local9
+[4:41..4:42): z <- local6
 [4:48..4:51): ??? -> scala/Predef.`???`().
 [5:6..5:16): PolyHolder <- example/PolyHolder#
 [6:2..6:2): <- example/PolyHolder#`<init>`().
@@ -3453,31 +3453,31 @@ Occurrences:
 [9:4..9:6): m4 <- example/RecOrRefined$package.m4().
 [9:7..9:8): x <- example/RecOrRefined$package.m4().(x)
 [9:10..9:20): PolyHolder -> example/PolyHolder#
-[9:27..9:30): foo <- local12
-[9:31..9:32): T <- local10
-[9:34..9:35): t <- local11
-[9:37..9:38): T -> local10
-[9:41..9:42): T -> local10
+[9:27..9:30): foo <- local9
+[9:31..9:32): T <- local7
+[9:34..9:35): t <- local8
+[9:37..9:38): T -> local7
+[9:41..9:42): T -> local7
 [9:48..9:51): ??? -> scala/Predef.`???`().
 [10:4..10:6): m5 <- example/RecOrRefined$package.m5().
 [10:7..10:8): Z <- example/RecOrRefined$package.m5().[Z]
 [10:10..10:11): x <- example/RecOrRefined$package.m5().(x)
 [10:13..10:16): Int -> scala/Int#
 [10:19..10:29): PolyHolder -> example/PolyHolder#
-[10:36..10:39): foo <- local15
-[10:40..10:41): T <- local13
-[10:43..10:44): t <- local14
-[10:46..10:47): T -> local13
-[10:50..10:51): T -> local13
+[10:36..10:39): foo <- local12
+[10:40..10:41): T <- local10
+[10:43..10:44): t <- local11
+[10:46..10:47): T -> local10
+[10:50..10:51): T -> local10
 [10:56..10:59): ??? -> scala/Predef.`???`().
 [12:5..12:7): m6 <- example/RecOrRefined$package.m6#
 [12:11..12:12): X <- example/RecOrRefined$package.m6#[X]
 [12:18..12:28): PolyHolder -> example/PolyHolder#
-[12:35..12:38): foo <- local18
-[12:39..12:40): T <- local16
-[12:42..12:43): t <- local17
-[12:45..12:46): T -> local16
-[12:49..12:50): T -> local16
+[12:35..12:38): foo <- example/RecOrRefined$package.m6#foo().
+[12:39..12:40): T <- example/RecOrRefined$package.m6#foo().[T]
+[12:42..12:43): t <- example/RecOrRefined$package.m6#foo().(t)
+[12:45..12:46): T -> example/RecOrRefined$package.m6#foo().[T]
+[12:49..12:50): T -> example/RecOrRefined$package.m6#foo().[T]
 [14:6..14:12): Record <- example/Record#
 [14:12..14:12): <- example/Record#`<init>`().
 [14:13..14:18): elems <- example/Record#elems.
@@ -3495,9 +3495,9 @@ Occurrences:
 [16:48..16:52): name -> example/Record#selectDynamic().(name)
 [18:5..18:11): Person <- example/RecOrRefined$package.Person#
 [18:14..18:20): Record -> example/Record#
-[19:6..19:10): name <- local19
+[19:6..19:10): name <- example/RecOrRefined$package.Person#name.
 [19:12..19:18): String -> scala/Predef.String#
-[20:6..20:9): age <- local20
+[20:6..20:9): age <- example/RecOrRefined$package.Person#age.
 [20:11..20:14): Int -> scala/Int#
 [24:6..24:7): C <- example/C#
 [24:10..24:10): <- example/C#`<init>`().
@@ -3505,9 +3505,9 @@ Occurrences:
 [24:24..24:26): T2 <- example/C#T2#
 [25:5..25:7): C2 <- example/RecOrRefined$package.C2#
 [25:10..25:11): C -> example/C#
-[25:19..25:21): T1 <- local21
-[25:28..25:30): T2 <- local22
-[25:33..25:35): T1 -> local21
+[25:19..25:21): T1 <- example/RecOrRefined$package.C2#T1#
+[25:28..25:30): T2 <- example/RecOrRefined$package.C2#T2#
+[25:33..25:35): T1 -> example/RecOrRefined$package.C2#T1#
 [27:6..27:23): SpecialRefinement <- example/SpecialRefinement#
 [28:2..28:2): <- example/SpecialRefinement#`<init>`().
 [28:6..28:13): pickOne <- example/SpecialRefinement#pickOne().
@@ -3520,10 +3520,10 @@ Occurrences:
 [31:25..31:25): <- example/PickOneRefinement_1#`<init>`().
 [31:26..31:27): S <- example/PickOneRefinement_1#[S]
 [31:31..31:48): SpecialRefinement -> example/SpecialRefinement#
-[31:55..31:62): pickOne <- local3
-[31:63..31:64): T <- local1
-[31:66..31:68): as <- local2
-[31:70..31:71): T -> local1
+[31:55..31:62): pickOne <- example/PickOneRefinement_1#`<init>`().[S]pickOne().
+[31:63..31:64): T <- example/PickOneRefinement_1#`<init>`().[S]pickOne().[T]
+[31:66..31:68): as <- example/PickOneRefinement_1#`<init>`().[S]pickOne().(as)
+[31:70..31:71): T -> example/PickOneRefinement_1#`<init>`().[S]pickOne().[T]
 [31:75..31:81): Option -> scala/Option#
 [31:82..31:88): String -> scala/Predef.String#
 [32:6..32:9): run <- example/PickOneRefinement_1#run().
@@ -3725,23 +3725,24 @@ Schema => SemanticDB v4
 Uri => StructuralTypes.scala
 Text => empty
 Language => Scala
-Symbols => 12 entries
-Occurrences => 33 entries
+Symbols => 13 entries
+Occurrences => 35 entries
 Synthetics => 4 entries
 
 Symbols:
-example/StructuralTypes. => final object StructuralTypes extends Object { self: StructuralTypes.type => +5 decls }
-example/StructuralTypes.User# => type User  = Object { abstract method foo (param x: Int): Int; abstract method age => Int; abstract method name => String }
+example/StructuralTypes. => final object StructuralTypes extends Object { self: StructuralTypes.type => +6 decls }
+example/StructuralTypes.FooUser# => type FooUser  = User { abstract method foo (param x: Int): Int }
+example/StructuralTypes.FooUser#foo(). => abstract method foo (param x: Int): Int
+example/StructuralTypes.FooUser#foo().(x) => param x: Int
+example/StructuralTypes.User# => type User  = Object { abstract method age => Int; abstract method name => String }
+example/StructuralTypes.User#age(). => abstract method age => Int
+example/StructuralTypes.User#name(). => abstract method name => String
 example/StructuralTypes.V. => val method V Object { abstract method scalameta => String }
 example/StructuralTypes.fooBar. => val method fooBar Int
-example/StructuralTypes.user. => val method user User
-local0 => abstract method name => String
-local1 => abstract method age => Int
-local2 => param x: Int
-local3 => abstract method foo (param x: Int): Int
-local4 => abstract method scalameta => String
-local5 => method scalameta => String
-local6 => final class $anon extends Object { self: $anon => +2 decls }
+example/StructuralTypes.user. => val method user FooUser
+local0 => abstract method scalameta => String
+local1 => method scalameta => String
+local2 => final class $anon extends Object { self: $anon => +2 decls }
 
 Occurrences:
 [0:8..0:15): example <- example/
@@ -3750,39 +3751,107 @@ Occurrences:
 [2:26..2:46): reflectiveSelectable -> scala/reflect/Selectable.reflectiveSelectable().
 [4:7..4:22): StructuralTypes <- example/StructuralTypes.
 [5:7..5:11): User <- example/StructuralTypes.User#
-[6:8..6:12): name <- local0
+[6:8..6:12): name <- example/StructuralTypes.User#name().
 [6:14..6:20): String -> scala/Predef.String#
-[7:8..7:11): age <- local1
+[7:8..7:11): age <- example/StructuralTypes.User#age().
 [7:13..7:16): Int -> scala/Int#
-[8:8..8:11): foo <- local3
-[8:12..8:13): x <- local2
-[8:15..8:18): Int -> scala/Int#
-[8:21..8:24): Int -> scala/Int#
-[11:6..11:10): user <- example/StructuralTypes.user.
-[11:18..11:30): asInstanceOf -> scala/Any#asInstanceOf().
-[11:31..11:35): User -> example/StructuralTypes.User#
-[12:2..12:6): user -> example/StructuralTypes.user.
-[12:7..12:11): name -> scala/reflect/Selectable#selectDynamic().
-[13:2..13:6): user -> example/StructuralTypes.user.
-[13:7..13:10): age -> scala/reflect/Selectable#selectDynamic().
-[14:6..14:12): fooBar <- example/StructuralTypes.fooBar.
-[14:15..14:19): user -> example/StructuralTypes.user.
-[14:20..14:23): foo -> scala/reflect/Selectable#applyDynamic().
-[16:6..16:7): V <- example/StructuralTypes.V.
-[16:9..16:15): Object -> java/lang/Object#
-[17:8..17:17): scalameta <- local4
-[17:19..17:25): String -> scala/Predef.String#
-[18:6..18:6): <- local6
-[19:8..19:17): scalameta <- local5
-[20:2..20:3): V -> example/StructuralTypes.V.
-[20:4..20:13): scalameta -> scala/reflect/Selectable#selectDynamic().
-[21:4..21:19): StructuralTypes -> example/StructuralTypes.
+[10:7..10:14): FooUser <- example/StructuralTypes.FooUser#
+[10:17..10:21): User -> example/StructuralTypes.User#
+[11:8..11:11): foo <- example/StructuralTypes.FooUser#foo().
+[11:12..11:13): x <- example/StructuralTypes.FooUser#foo().(x)
+[11:15..11:18): Int -> scala/Int#
+[11:21..11:24): Int -> scala/Int#
+[14:6..14:10): user <- example/StructuralTypes.user.
+[14:18..14:30): asInstanceOf -> scala/Any#asInstanceOf().
+[14:31..14:38): FooUser -> example/StructuralTypes.FooUser#
+[15:2..15:6): user -> example/StructuralTypes.user.
+[15:7..15:11): name -> example/StructuralTypes.User#name().
+[16:2..16:6): user -> example/StructuralTypes.user.
+[16:7..16:10): age -> example/StructuralTypes.User#age().
+[17:6..17:12): fooBar <- example/StructuralTypes.fooBar.
+[17:15..17:19): user -> example/StructuralTypes.user.
+[17:20..17:23): foo -> example/StructuralTypes.FooUser#foo().
+[18:6..18:7): V <- example/StructuralTypes.V.
+[18:9..18:15): Object -> java/lang/Object#
+[19:8..19:17): scalameta <- local0
+[19:19..19:25): String -> scala/Predef.String#
+[20:6..20:6): <- local2
+[21:8..21:17): scalameta <- local1
+[22:2..22:3): V -> example/StructuralTypes.V.
+[22:4..22:13): scalameta -> local4
+[23:4..23:19): StructuralTypes -> example/StructuralTypes.
 
 Synthetics:
-[12:2..12:6):user => reflectiveSelectable(*)
-[13:2..13:6):user => reflectiveSelectable(*)
+[15:2..15:6):user => reflectiveSelectable(*)
+[16:2..16:6):user => reflectiveSelectable(*)
+[17:15..17:19):user => reflectiveSelectable(*)
+[22:2..22:3):V => reflectiveSelectable(*)
+
+expect/StructuralTypesParams.scala
+----------------------------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => StructuralTypesParams.scala
+Text => empty
+Language => Scala
+Symbols => 12 entries
+Occurrences => 33 entries
+Synthetics => 3 entries
+
+Symbols:
+example/StructuralTypesParams. => final object StructuralTypesParams extends Object { self: StructuralTypesParams.type => +8 decls }
+example/StructuralTypesParams.User# => type User  = Object { abstract method age => Int; abstract method foo (param arg1: Int, param arg2: String): String }
+example/StructuralTypesParams.User#age(). => abstract method age => Int
+example/StructuralTypesParams.User#foo(). => abstract method foo (param arg1: Int, param arg2: String): String
+example/StructuralTypesParams.User#foo().(arg1) => param arg1: Int
+example/StructuralTypesParams.User#foo().(arg2) => param arg2: String
+example/StructuralTypesParams.age. => val method age Int
+example/StructuralTypesParams.fooBar. => val method fooBar String
+example/StructuralTypesParams.fooBaz. => val method fooBaz String
+example/StructuralTypesParams.num. => val method num Int
+example/StructuralTypesParams.str. => val method str String
+example/StructuralTypesParams.user. => val method user User
+
+Occurrences:
+[0:8..0:15): example <- example/
+[2:7..2:14): reflect -> scala/reflect/
+[2:15..2:25): Selectable -> scala/reflect/Selectable.
+[2:26..2:46): reflectiveSelectable -> scala/reflect/Selectable.reflectiveSelectable().
+[4:7..4:28): StructuralTypesParams <- example/StructuralTypesParams.
+[5:7..5:11): User <- example/StructuralTypesParams.User#
+[6:8..6:11): foo <- example/StructuralTypesParams.User#foo().
+[6:12..6:16): arg1 <- example/StructuralTypesParams.User#foo().(arg1)
+[6:18..6:21): Int -> scala/Int#
+[6:23..6:27): arg2 <- example/StructuralTypesParams.User#foo().(arg2)
+[6:29..6:35): String -> scala/Predef.String#
+[6:38..6:44): String -> scala/Predef.String#
+[7:8..7:11): age <- example/StructuralTypesParams.User#age().
+[7:13..7:16): Int -> scala/Int#
+[10:6..10:10): user <- example/StructuralTypesParams.user.
+[10:18..10:30): asInstanceOf -> scala/Any#asInstanceOf().
+[10:31..10:35): User -> example/StructuralTypesParams.User#
+[11:6..11:9): num <- example/StructuralTypesParams.num.
+[12:6..12:9): str <- example/StructuralTypesParams.str.
+[13:6..13:12): fooBar <- example/StructuralTypesParams.fooBar.
+[13:15..13:19): user -> example/StructuralTypesParams.user.
+[13:20..13:23): foo -> example/StructuralTypesParams.User#foo().
+[13:24..13:27): num -> example/StructuralTypesParams.num.
+[13:29..13:32): str -> example/StructuralTypesParams.str.
+[14:6..14:12): fooBaz <- example/StructuralTypesParams.fooBaz.
+[14:15..14:19): user -> example/StructuralTypesParams.user.
+[14:20..14:23): foo -> example/StructuralTypesParams.User#foo().
+[14:31..14:34): num -> example/StructuralTypesParams.num.
+[14:43..14:46): str -> example/StructuralTypesParams.str.
+[15:6..15:9): age <- example/StructuralTypesParams.age.
+[15:12..15:16): user -> example/StructuralTypesParams.user.
+[15:17..15:20): age -> example/StructuralTypesParams.User#age().
+[17:4..17:25): StructuralTypesParams -> example/StructuralTypesParams.
+
+Synthetics:
+[13:15..13:19):user => reflectiveSelectable(*)
 [14:15..14:19):user => reflectiveSelectable(*)
-[20:2..20:3):V => reflectiveSelectable(*)
+[15:12..15:16):user => reflectiveSelectable(*)
 
 expect/Synthetic.scala
 ----------------------
@@ -4557,16 +4626,16 @@ _empty_/Test_depmatch. => final object Test_depmatch extends Object { self: Test
 _empty_/Test_depmatch.Bar# => type Bar [typeparam T ] = T match { Unit => Unit }
 _empty_/Test_depmatch.Bar#[T] => typeparam T 
 _empty_/Test_depmatch.Foo# => type Foo  = Int { type U  }
+_empty_/Test_depmatch.Foo#U# => type U 
 _empty_/Test_depmatch.baz(). => inline macro baz (param foo: Foo): Unit
 _empty_/Test_depmatch.baz().(foo) => param foo: Foo
-local0 => type U 
-local1 => val local v: Bar[foo.U]
+local0 => val local v: Bar[foo.U]
 
 Occurrences:
 [0:7..0:20): Test_depmatch <- _empty_/Test_depmatch.
 [1:7..1:10): Foo <- _empty_/Test_depmatch.Foo#
 [1:13..1:16): Int -> scala/Int#
-[1:24..1:25): U <- local0
+[1:24..1:25): U <- _empty_/Test_depmatch.Foo#U#
 [2:7..2:10): Bar <- _empty_/Test_depmatch.Bar#
 [2:11..2:12): T <- _empty_/Test_depmatch.Bar#[T]
 [2:16..2:17): T -> _empty_/Test_depmatch.Bar#[T]
@@ -4576,10 +4645,10 @@ Occurrences:
 [5:17..5:20): foo <- _empty_/Test_depmatch.baz().(foo)
 [5:22..5:25): Foo -> _empty_/Test_depmatch.Foo#
 [5:28..5:32): Unit -> scala/Unit#
-[6:8..6:9): v <- local1
+[6:8..6:9): v <- local0
 [6:11..6:14): Bar -> _empty_/Test_depmatch.Bar#
 [6:15..6:18): foo -> _empty_/Test_depmatch.baz().(foo)
-[6:19..6:20): U -> local0
+[6:19..6:20): U -> _empty_/Test_depmatch.Foo#U#
 [6:24..6:27): ??? -> scala/Predef.`???`().
 
 expect/example-dir/FileInDir.scala


### PR DESCRIPTION
Backports #18604 to the 3.3.8.

PR submitted by the release tooling.
[skip ci]