### PR TITLE
Backport "Scaladoc: Take title from sidebar.yml into account" to 3.3 LTS

### DIFF
--- a/scaladoc/src/dotty/tools/scaladoc/site/StaticSiteLoader.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/site/StaticSiteLoader.scala
@@ -55,11 +55,8 @@ class StaticSiteLoader(val root: File, val args: Scaladoc.Args)(using StaticSite
           .map(relativizeIfNeeded)
           .map(_.toFile)
           .filter(_.exists)
-          .map(loadTemplateFile(_))
-        val title = (
-          optionTitle.map(TemplateName.SidebarDefined(_)) ++
-          indexPageOpt.map(_.title)
-        ).headOption.getOrElse {
+          .map(loadTemplateFile(_, optionTitle.map(TemplateName.SidebarDefined(_))))
+        val title = indexPageOpt.map(_.title).getOrElse {
           report.error(s"Title for subsection needs to be set in YAML config or in index file")
           TemplateName.FilenameDefined("unnamed_section")
         }

--- a/scaladoc/test-documentations/sidebar/_docs/directory/index.md
+++ b/scaladoc/test-documentations/sidebar/_docs/directory/index.md
@@ -1,0 +1,3 @@
+# Directory index
+
+This is the index file of the directory.

--- a/scaladoc/test-documentations/sidebar/_docs/index.md
+++ b/scaladoc/test-documentations/sidebar/_docs/index.md
@@ -1,0 +1,3 @@
+# Docs Home
+
+This is the index page.

--- a/scaladoc/test-documentations/sidebar/sidebar.yml
+++ b/scaladoc/test-documentations/sidebar/sidebar.yml
@@ -1,0 +1,5 @@
+index: index.md
+subsection:
+  - title: A Directory Subsection
+    index: directory/index.md
+    directory: directory

--- a/scaladoc/test/dotty/tools/scaladoc/site/SiteGeneratationTest.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/site/SiteGeneratationTest.scala
@@ -124,3 +124,10 @@ class SiteGeneratationTest extends BaseHtmlTest:
         )
     }
   }
+
+  @Test
+  def sidebarFile() = withGeneratedSite(testDocPath.resolve("sidebar")) {
+    withHtmlFile("docs/index.html")(
+      _.assertTextsIn("#leftColumn #docs-nav > div:nth-child(1) > span > a > span", "A Directory Subsection"))
+    withHtmlFile("docs/directory/index.html")(_.assertTextsIn("title", "A Directory Subsection"))
+  }


### PR DESCRIPTION
Backports #18997 to the 3.3.8.

PR submitted by the release tooling.
[skip ci]