### PR TITLE
Backport "bugfix: remove stale top-level symbols between runs" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -2605,7 +2605,7 @@ object SymDenotations {
       for (sym <- scope.toList.iterator)
         // We need to be careful to not force the denotation of `sym` here,
         // otherwise it will be brought forward to the current run.
-        if (sym.defRunId != ctx.runId && sym.isClass && sym.asClass.assocFile == file)
+        if (sym.defRunId != ctx.runId && sym.isClass && sym.asClass.assocFile.nn.path == file.path)
           scope.unlink(sym, sym.lastKnownDenotation.name)
     }
   }

--- a/presentation-compiler/test/dotty/tools/pc/base/BaseCompletionSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/base/BaseCompletionSuite.scala
@@ -32,7 +32,7 @@ abstract class BaseCompletionSuite extends BasePCSuite:
     result.setItems(newItems.asJava)
     result
 
-  private def getItems(
+  protected def getItems(
       original: String,
       filename: String = "A.scala"
   ): Seq[CompletionItem] =

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionStaleSymbolSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionStaleSymbolSuite.scala
@@ -1,0 +1,58 @@
+package dotty.tools.pc.tests.completion
+
+import dotty.tools.pc.base.BaseCompletionSuite
+
+import org.junit.Test
+
+class CompletionStaleSymbolSuite extends BaseCompletionSuite:
+
+  @Test def `multiple-requests` =
+    checkRenamedToplevel(
+      "Metals",
+      (contents, max) => contents.replace("object Metals", s"object Metals$max"),
+      s"""|B example
+          |Metals123456789 example
+          |""".stripMargin
+    )
+
+  @Test def `multiple-requests-backtick` =
+    checkRenamedToplevel(
+      "`M Metals M`",
+      (contents, max) => contents.replace("Metals M", "Metals M "),
+      s"""|B example
+          |M Metals M example
+          |""".stripMargin
+    )
+
+  private def checkRenamedToplevel(
+      toRename: String,
+      renameFunc: (String, Int) => String,
+      expected: String
+  ): Unit =
+    val file1 = "A.scala"
+    val file2 = "B.scala"
+    val baseFile = s"""|package example
+                       |object $toRename {
+                       |  val x = 1
+                       |  x@@
+                       |}""".stripMargin
+
+    def loop(fileContents: String, max: Int = 9): Unit =
+      getItems(fileContents, file1)
+      if max > 0 then
+        loop(renameFunc(fileContents, max), max - 1)
+
+    loop(baseFile)
+
+    val items = getItems(
+      s"""|package example
+          |object B {
+          |  val x = 1
+          |  example.@@
+          |}""".stripMargin,
+      file2
+    )
+    assertNoDiff(
+      items.map(_.getLabel).mkString("\n"),
+      expected
+    )

--- a/presentation-compiler/test/dotty/tools/pc/tests/inlayHints/InlayHintsSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/inlayHints/InlayHintsSuite.scala
@@ -1184,7 +1184,7 @@ class InlayHintsSuite extends BaseInlayHintsSuite {
          |
          |object Main:
          |  val a/*: A<<(1:11)>>[Int<<scala/Int#>>, String<<scala/Predef.String#>>]*/ = A[Int, String](/*dummy = */0, /*name = */"foo")
-         |  val res/*: Int<<scala/Int#>>*/ = a ++/*[Int<<scala/Int#>>, String<<java/lang/String#>>]*/ a
+         |  val res/*: Int<<scala/Int#>>*/ = a ++ a
          |""".stripMargin
     )
 


### PR DESCRIPTION
Backports #25317 to the 3.3.8.

PR submitted by the release tooling.
[skip ci]