### PR TITLE
Backport "Fix false unused import warning for given CanEqual in pattern matching" to 3.3 LTS

### DIFF
--- a/tests/warn/i25227.scala
+++ b/tests/warn/i25227.scala
@@ -1,0 +1,21 @@
+//> using options -Wunused:all
+
+import scala.language.strictEquality
+
+object Givens:
+  given CanEqual[Any, Null] = CanEqual.derived
+  given CanEqual[Null, Any] = CanEqual.derived
+
+object Test:
+  import Givens.given  // no warn: used by `case null =>`
+
+  def m(value: Any): Boolean = value match
+    case null => true
+    case _ => false
+
+object TestUnused:
+  import Givens.given  // warn: not used here
+
+  def m(value: Any): Boolean = value match
+    case _: String => true
+    case _ => false


### PR DESCRIPTION
Backports #25231 to the 3.3.8.

PR submitted by the release tooling.
[skip ci]