### PR TITLE
Backport "Use TypeComparer.constValue in TypeEval" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -2605,7 +2605,7 @@ object SymDenotations {
       for (sym <- scope.toList.iterator)
         // We need to be careful to not force the denotation of `sym` here,
         // otherwise it will be brought forward to the current run.
-        if (sym.defRunId != ctx.runId && sym.isClass && sym.asClass.assocFile.nn.path == file.path)
+        if (sym.defRunId != ctx.runId && sym.isClass && sym.asClass.assocFile != null && sym.asClass.assocFile.nn.path == file.path)
           scope.unlink(sym, sym.lastKnownDenotation.name)
     }
   }

--- a/compiler/src/dotty/tools/dotc/core/TypeEval.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeEval.scala
@@ -2,6 +2,8 @@ package dotty.tools
 package dotc
 package core
 
+import scala.reflect.Typeable
+
 import Types.*, Contexts.*, Symbols.*, Constants.*, Decorators.*
 import config.Printers.typr
 import reporting.trace
@@ -23,33 +25,22 @@ object TypeEval:
             if tp1.isStable then tp1.fixForEvaluation else tp
           case tp => tp
 
-      def constValue(tp: Type): Option[Any] = tp.fixForEvaluation match
-        case ConstantType(Constant(n)) => Some(n)
-        case _ => None
+      extension (tp: Type) def constant[T: Typeable]: Option[T] =
+        TypeComparer.constValue(tp.fixForEvaluation).collect { case Constant(c: T) => c }
 
-      def boolValue(tp: Type): Option[Boolean] = tp.fixForEvaluation match
-        case ConstantType(Constant(n: Boolean)) => Some(n)
-        case _ => None
+      def constValue(tp: Type): Option[Any] = tp.constant[Any]
 
-      def intValue(tp: Type): Option[Int] = tp.fixForEvaluation match
-        case ConstantType(Constant(n: Int)) => Some(n)
-        case _ => None
+      def boolValue(tp: Type): Option[Boolean] = tp.constant[Boolean]
 
-      def longValue(tp: Type): Option[Long] = tp.fixForEvaluation match
-        case ConstantType(Constant(n: Long)) => Some(n)
-        case _ => None
+      def intValue(tp: Type): Option[Int] = tp.constant[Int]
 
-      def floatValue(tp: Type): Option[Float] = tp.fixForEvaluation match
-        case ConstantType(Constant(n: Float)) => Some(n)
-        case _ => None
+      def longValue(tp: Type): Option[Long] = tp.constant[Long]
 
-      def doubleValue(tp: Type): Option[Double] = tp.fixForEvaluation match
-        case ConstantType(Constant(n: Double)) => Some(n)
-        case _ => None
+      def floatValue(tp: Type): Option[Float] = tp.constant[Float]
 
-      def stringValue(tp: Type): Option[String] = tp.fixForEvaluation match
-        case ConstantType(Constant(n: String)) => Some(n)
-        case _ => None
+      def doubleValue(tp: Type): Option[Double] = tp.constant[Double]
+
+      def stringValue(tp: Type): Option[String] = tp.constant[String]
 
       // Returns Some(true) if the type is a constant.
       // Returns Some(false) if the type is not a constant.

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionStaleSymbolSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionStaleSymbolSuite.scala
@@ -9,7 +9,7 @@ class CompletionStaleSymbolSuite extends BaseCompletionSuite:
   @Test def `multiple-requests` =
     checkRenamedToplevel(
       "Metals",
-      (contents, max) => contents.replace("object Metals", s"object Metals$max"),
+      (contents, max) => contents.replace("object Metals", s"object Metals$max").nn,
       s"""|B example
           |Metals123456789 example
           |""".stripMargin
@@ -18,7 +18,7 @@ class CompletionStaleSymbolSuite extends BaseCompletionSuite:
   @Test def `multiple-requests-backtick` =
     checkRenamedToplevel(
       "`M Metals M`",
-      (contents, max) => contents.replace("Metals M", "Metals M "),
+      (contents, max) => contents.replace("Metals M", "Metals M ").nn,
       s"""|B example
           |M Metals M example
           |""".stripMargin

--- a/tests/pos/i24717.scala
+++ b/tests/pos/i24717.scala
@@ -1,0 +1,13 @@
+import scala.compiletime.ops.int.+
+import scala.compiletime.ops.int.S
+
+object test {
+  object O {
+    opaque type O = Int
+    transparent inline def v: O = 123
+  }
+
+  val a: 123 & O.O = O.v
+  val b: S[a.type] = 124
+  val c: a.type + 1 = 124
+}


### PR DESCRIPTION
Backports #24718 to the 3.3.8.

PR submitted by the release tooling.