### PR TITLE
Backport "Also trust TypeTest when there is a Bind" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
@@ -399,14 +399,15 @@ object PatternMatcher {
       // begin patternPlan
       swapBind(tree) match {
         case Typed(pat, tpt) =>
-          val isTrusted = pat match {
+          def isTrusted(pattern: Tree): Boolean = pattern match {
             case UnApply(extractor, _, _) =>
               extractor.symbol.is(Synthetic)
               && extractor.symbol.owner.linkedClass.is(Case)
               && !hasExplicitTypeArgs(extractor)
+            case Bind(_, body) => isTrusted(body)
             case _ => false
           }
-          TestPlan(TypeTest(tpt, isTrusted), scrutinee, tree.span,
+          TestPlan(TypeTest(tpt, isTrusted(pat)), scrutinee, tree.span,
             letAbstract(ref(scrutinee).cast(tpt.tpe)) { casted =>
               nonNull += casted
               patternPlan(casted, pat, onSuccess)

--- a/tests/pos/i24557.scala
+++ b/tests/pos/i24557.scala
@@ -1,0 +1,9 @@
+object test {
+  sealed trait X[T]
+  trait Iterable[T]
+  case class I[T, C <: Iterable[T]]() extends X[C]
+
+  def t[T](i: X[T]): Unit =
+    i match
+      case i @ I() => ()
+}


### PR DESCRIPTION
Backports #24568 to the 3.3.8.

PR submitted by the release tooling.
[skip ci]