### PR TITLE
Backport "Use other tree for actual symbol of Assign" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/printing/Formatting.scala
+++ b/compiler/src/dotty/tools/dotc/printing/Formatting.scala
@@ -10,7 +10,7 @@ import core.*
 import Texts.*, Types.*, Flags.*, Symbols.*, Contexts.*
 import Decorators.*
 import reporting.Message
-import util.DiffUtil
+import util.{Chars, DiffUtil}
 import Highlighting.*
 
 object Formatting {
@@ -168,7 +168,8 @@ object Formatting {
     }
 
     def assemble(args: Seq[Shown])(using Context): String = {
-      def isLineBreak(c: Char) = c == '\n' || c == '\f' // compatible with StringLike#isLineBreak
+      // compatible with CharArrayReader (not StringOps)
+      inline def isLineBreak(c: Char) = c == Chars.LF || c == Chars.FF
       def stripTrailingPart(s: String) = {
         val (pre, post) = s.span(c => !isLineBreak(c))
         pre ++ post.stripMargin

--- a/compiler/src/dotty/tools/dotc/typer/Dynamic.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Dynamic.scala
@@ -136,8 +136,11 @@ trait Dynamic {
         typedDynamicAssign(qual, name, sel.span, Nil)
       case TypeApply(sel @ Select(qual, name), targs) if !isDynamicMethod(name) =>
         typedDynamicAssign(qual, name, sel.span, targs)
-      case _ =>
-        errorTree(tree, ReassignmentToVal(tree.lhs.symbol.name, pt))
+      case lhs =>
+        val name = lhs match
+          case nt: NameTree => nt.name
+          case _ => lhs.symbol.name
+        errorTree(tree, ReassignmentToVal(name, pt))
     }
   }
 

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1161,8 +1161,12 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
         def lhs1 = adapt(lhsCore, AssignProto, locked)
 
         def reassignmentToVal =
-          report.error(ReassignmentToVal(lhsCore.symbol.name, pt), tree.srcPos)
-          cpy.Assign(tree)(lhsCore, typed(tree.rhs, lhs1.tpe.widen)).withType(defn.UnitType)
+          val adapted = lhs1
+          val name = lhs match
+            case nt: NameTree => nt.name  // respects import rename
+            case _ => adapted.symbol.name // other LHS such as X.x += y
+          report.error(ReassignmentToVal(name, pt), tree.srcPos)
+          cpy.Assign(tree)(lhsCore, typed(tree.rhs, adapted.tpe.widen)).withType(defn.UnitType)
 
         def canAssign(sym: Symbol) =
           sym.is(Mutable, butNot = Accessor) ||
@@ -1239,7 +1243,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
               typedDynamicAssign(tree, pt)
             case tpe =>
               reassignmentToVal
-        }
+          }
     }
 
   def typedBlockStats(stats: List[untpd.Tree])(using Context): (List[tpd.Tree], Context) =

--- a/tests/neg/i22671.check
+++ b/tests/neg/i22671.check
@@ -1,0 +1,61 @@
+-- [E007] Type Mismatch Error: tests/neg/i22671.scala:41:22 ------------------------------------------------------------
+41 |    names_times(fields(0)) += fields(1).toLong // error
+   |                ^^^^^^^^^
+   |                Found:    Char
+   |                Required: String
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E008] Not Found Error: tests/neg/i22671.scala:45:6 -----------------------------------------------------------------
+45 |  x() += "42" // error
+   |  ^^^^^^
+   |  value += is not a member of Int - did you mean Int.!=? or perhaps Int.<=?
+-- [E052] Type Error: tests/neg/i22671.scala:49:6 ----------------------------------------------------------------------
+49 |    c = 42 // error
+   |    ^^^^^^
+   |    Reassignment to val c
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E052] Type Error: tests/neg/i22671.scala:9:6 -----------------------------------------------------------------------
+9 |  X.w = 27 // error
+  |  ^^^^^^^^
+  |  Reassignment to val w
+  |
+  | longer explanation available when compiling with `-explain`
+-- [E052] Type Error: tests/neg/i22671.scala:12:6 ----------------------------------------------------------------------
+12 |  X.x = 27 // error
+   |  ^^^^^^^^
+   |  Reassignment to val x
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E052] Type Error: tests/neg/i22671.scala:16:4 ----------------------------------------------------------------------
+16 |  x = 27 // error
+   |  ^^^^^^
+   |  Reassignment to val x
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E052] Type Error: tests/neg/i22671.scala:20:4 ----------------------------------------------------------------------
+20 |  y = 27 // error
+   |  ^^^^^^
+   |  Reassignment to val y
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E052] Type Error: tests/neg/i22671.scala:24:4 ----------------------------------------------------------------------
+24 |  y = 27 // error
+   |  ^^^^^^
+   |  Reassignment to val y
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E052] Type Error: tests/neg/i22671.scala:28:4 ----------------------------------------------------------------------
+28 |  x = 27 // error
+   |  ^^^^^^
+   |  Reassignment to val x
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E008] Not Found Error: tests/neg/i22671.scala:31:6 -----------------------------------------------------------------
+31 |  X.x += 27 // error
+   |  ^^^^^^
+   |  value += is not a member of Int - did you mean Int.!=? or perhaps Int.<=?
+-- [E008] Not Found Error: tests/neg/i22671.scala:32:4 -----------------------------------------------------------------
+32 |  1 += 1 // error
+   |  ^^^^
+   |  value += is not a member of Int - did you mean (1 : Int).!=? or perhaps (1 : Int).<=?

--- a/tests/neg/i22671.scala
+++ b/tests/neg/i22671.scala
@@ -1,0 +1,49 @@
+object X:
+  val w: Int = 42
+  def w(y: Int): Int = x + y
+  def x: Int = 42
+  def x(y: Int): Int = x + y
+  val z = 26
+
+def w =
+  X.w = 27 // error
+
+def f =
+  X.x = 27 // error
+
+def g =
+  import X.x
+  x = 27 // error
+
+def h =
+  import X.x as y
+  y = 27 // error
+
+def i =
+  import X.z as y
+  y = 27 // error
+
+def j =
+  val x = 42
+  x = 27 // error
+
+def k =
+  X.x += 27 // error
+  1 += 1 // error
+
+
+object t8763:
+  import collection.mutable
+  def bar(): Unit =
+    val names_times = mutable.Map.empty[String, mutable.Set[Long]]
+    val line = ""
+    val Array(fields) = line.split("\t")
+    names_times(fields(0)) += fields(1).toLong // error
+
+object t9834:
+  object x { def apply() = 42 ; def update(i: Int) = () }
+  x() += "42" // error
+
+class C(c: Int):
+  def test(): Unit =
+    c = 42 // error


### PR DESCRIPTION
Backports #22869 to the 3.3.8.

PR submitted by the release tooling.
[skip ci]