### PR TITLE
Backport "Ensure the inline match scrutinee type conforms to the recalculated type" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/inlines/InlineReducer.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/InlineReducer.scala
@@ -339,7 +339,7 @@ class InlineReducer(inliner: Inliner)(using Context):
 
     /** The initial scrutinee binding: `val $scrutineeN = <scrutinee>` */
     val scrutineeSym = newSym(InlineScrutineeName.fresh(), Synthetic, scrutType).asTerm
-    val scrutineeBinding = normalizeBinding(ValDef(scrutineeSym, scrutinee.ensureConforms(scrutType)))
+    val scrutineeBinding = normalizeBinding(ValDef(scrutineeSym, scrutinee))
 
     def reduceCase(cdef: CaseDef): MatchReduxWithGuard = {
       val caseBindingMap = new mutable.ListBuffer[(Symbol, MemberDef)]()

--- a/compiler/src/dotty/tools/dotc/inlines/InlineReducer.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/InlineReducer.scala
@@ -339,7 +339,7 @@ class InlineReducer(inliner: Inliner)(using Context):
 
     /** The initial scrutinee binding: `val $scrutineeN = <scrutinee>` */
     val scrutineeSym = newSym(InlineScrutineeName.fresh(), Synthetic, scrutType).asTerm
-    val scrutineeBinding = normalizeBinding(ValDef(scrutineeSym, scrutinee))
+    val scrutineeBinding = normalizeBinding(ValDef(scrutineeSym, scrutinee.ensureConforms(scrutType)))
 
     def reduceCase(cdef: CaseDef): MatchReduxWithGuard = {
       val caseBindingMap = new mutable.ListBuffer[(Symbol, MemberDef)]()

--- a/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
@@ -967,13 +967,17 @@ class Inliner(val call: tpd.Tree)(using Context):
       if (!tree.isInline || ctx.owner.isInlineMethod) // don't reduce match of nested inline method yet
         super.typedMatchFinish(tree, sel, wideSelType, cases, pt)
       else {
-        def selTyped(sel: Tree): Type = sel match {
+        def selTyped(sel: Tree): Tree = sel match {
           case Typed(sel2, _) => selTyped(sel2)
-          case Block(Nil, sel2) => selTyped(sel2)
-          case Inlined(_, Nil, sel2) => selTyped(sel2)
-          case _ => sel.tpe
+          case block @ Block(Nil, sel2) => tpd.cpy.Block(block)(Nil, selTyped(sel2))
+          case inlined @ Inlined(_, Nil, sel2) => tpd.cpy.Inlined(inlined)(inlined.call, inlined.bindings, selTyped(sel2))
+          case _ => sel
         }
-        val selType = if (sel.isEmpty) wideSelType else selTyped(sel)
+        val (retypedSel, selType) =
+          if (sel.isEmpty) (sel, wideSelType)
+          else
+            val retypedSel = selTyped(sel)
+            (retypedSel, retypedSel.tpe)
 
         /** Make an Inlined that has no bindings. */
         def flattenInlineBlock(tree: Tree): Tree = {
@@ -1038,7 +1042,7 @@ class Inliner(val call: tpd.Tree)(using Context):
                         | patterns :  ${tree.cases.map(patStr).mkString("\n             ")}"""
                 errorTree(tree, msg)
             }
-        reduceInlineMatchExpr(sel)
+        reduceInlineMatchExpr(retypedSel)
       }
 
     override def newLikeThis(nestingLevel: Int): Typer = new InlineTyper(initialErrorCount, nestingLevel)

--- a/tests/pos/i24479.scala
+++ b/tests/pos/i24479.scala
@@ -1,0 +1,11 @@
+object test {
+  class A
+  class B extends A
+
+  inline def f[T](inline v: Any): T = inline v match {
+    case x: T => x
+  }
+
+  inline def b: B = new B()
+  f[A](b: A)
+}


### PR DESCRIPTION
Backports #24988 to the 3.3.8.

PR submitted by the release tooling.
[skip ci]