### PR TITLE
Backport "Fix Ycheck crash from singleton tuple selects after specialization" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/SpecializeTuples.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SpecializeTuples.scala
@@ -41,7 +41,8 @@ class SpecializeTuples extends MiniPhase:
       qual.tpe.widenDealias match
         case AppliedType(tycon, args) if defn.isSpecializableTuple(tycon.classSymbol, args) =>
           val argIdx = if name == nme._1 then 0 else 1
-          Select(qual, name.specializedName(args(argIdx) :: Nil))
+          // Keep the specialized accessor for performance, then adapt back to the original expected type.
+          Select(qual, name.specializedName(args(argIdx) :: Nil)).ensureConforms(tree.tpe)
         case _ =>
           tree
     case _ => tree

--- a/tests/pos/i25292.scala
+++ b/tests/pos/i25292.scala
@@ -1,0 +1,11 @@
+//> using options -Ycheck:all
+
+val namedTuple: (x: 42, y: true) = (x = 42, y = true)
+val a = namedTuple match
+  case (1, y) => ()
+  case (x, y) => ()
+
+val tuple: (42, true) = (42, true)
+val b = tuple match
+  case (1, y) => ()
+  case (x, y) => ()


### PR DESCRIPTION
Backports #25331 to the 3.3.8.

PR submitted by the release tooling.
[skip ci]