### PR TITLE
Backport "Do not update Symbol defTrees when retyping after Inlining " to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -365,6 +365,7 @@ object Contexts {
 
     /** Is current phase after TyperPhase? */
     final def isAfterTyper = base.isAfterTyper(phase)
+    final def isAfterInlining = base.isAfterInlining(phase)
     final def isTyper = base.isTyper(phase)
 
     /** Is this a context for the members of a class definition? */

--- a/compiler/src/dotty/tools/dotc/core/Phases.scala
+++ b/compiler/src/dotty/tools/dotc/core/Phases.scala
@@ -291,6 +291,8 @@ object Phases {
     }
 
     final def isAfterTyper(phase: Phase): Boolean = phase.id > typerPhase.id
+    final def isAfterInlining(phase: Phase): Boolean =
+      inliningPhase != NoPhase && phase.id > inliningPhase.id
     final def isTyper(phase: Phase): Boolean = phase.id == typerPhase.id
   }
 

--- a/compiler/src/dotty/tools/dotc/core/Phases.scala
+++ b/compiler/src/dotty/tools/dotc/core/Phases.scala
@@ -336,12 +336,14 @@ object Phases {
 
       for unit <- units do ctx.profiler.onUnit(this, unit):
         given unitCtx: Context = runCtx.fresh.setPhase(this.start).setCompilationUnit(unit).withRootImports
+        val previousTyperState = unitCtx.typerState.snapshot()
         if ctx.run.enterUnit(unit) then
           try
             run
             buf += unitCtx.compilationUnit
           catch
             case _: CompilationUnit.SuspendException => // this unit will be run again in `Run#compileSuspendedUnits`
+              unitCtx.typerState.resetTo(previousTyperState)
             case ex: Throwable if !ctx.run.enrichedErrorMessage =>
               println(ctx.run.enrichErrorMessage(s"unhandled exception while running $phaseName on $unit"))
               throw ex

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2538,7 +2538,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
     }
     val vdef1 = assignType(cpy.ValDef(vdef)(name, tpt1, rhs1), sym)
     postProcessInfo(vdef1, sym)
-    vdef1.setDefTree
+    if (!ctx.isAfterInlining) vdef1.setDefTree
     val nnInfo = rhs1.notNullInfo
     vdef1.withNotNullInfo(if sym.is(Lazy) then nnInfo.retractedInfo else nnInfo)
   }
@@ -2668,7 +2668,8 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
     if !sym.is(Module) && !sym.isConstructor && sym.info.finalResultType.isErasedClass then
       sym.setFlag(Erased)
     mdef.ensureHasSym(sym)
-    mdef.setDefTree
+    if (!ctx.isAfterInlining) mdef.setDefTree
+    else mdef
 
   def typedTypeDef(tdef: untpd.TypeDef, sym: Symbol)(using Context): Tree = ctx.profiler.onTypedDef(sym) {
     val TypeDef(name, rhs) = tdef

--- a/tests/pos-macros/i22584/Macro.scala
+++ b/tests/pos-macros/i22584/Macro.scala
@@ -22,7 +22,7 @@ object Macros {
         }
       }
 
-    val expected = "List(DefDef(boolean,List(List()),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,module class scala)),class Boolean)],Select(This(Ident(MyClass1)),boolean)), DefDef(finalVal,List(List()),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,module class lang)),class String)],Select(This(Ident(MyClass1)),finalVal)), DefDef(int,List(List()),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,module class scala)),class Int)],Select(This(Ident(MyClass1)),int)), DefDef(string,List(List()),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,module class lang)),class String)],Select(This(Ident(MyClass1)),string)))"
+    val expected = "List(ValDef(boolean,TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,module class <root>)),object scala),class Boolean)],EmptyTree), ValDef(finalVal,Ident(String),Literal(Constant(result))), ValDef(int,TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,module class <root>)),object scala),class Int)],EmptyTree), ValDef(string,TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,module class scala)),object Predef),type String)],EmptyTree))"
     assert(caseFieldValOrDefDefs.toString == expected)
 
     '{ () }

--- a/tests/pos/i21176-a/Macro.scala
+++ b/tests/pos/i21176-a/Macro.scala
@@ -1,0 +1,12 @@
+//> using options -Wsafe-init
+import scala.quoted.*
+
+class Macro:
+  def tuple[T](name: String): (String, List[T]) = (name, List[T]())
+  inline def nameTuple[T]: (String, List[T]) = tuple(Macro.named)
+
+object Macro:
+  def namedMacro(using q: Quotes): Expr[String] =
+    Expr("test")
+
+  inline def named: String = ${Macro.namedMacro}

--- a/tests/pos/i21176-a/Main.scala
+++ b/tests/pos/i21176-a/Main.scala
@@ -1,0 +1,7 @@
+//> using options -Wsafe-init
+class Test extends Macro:
+  val abc = nameTuple[Int]
+
+@main
+def run(): Unit =
+  println(new Test().abc)

--- a/tests/pos/i21176-b/Macro.scala
+++ b/tests/pos/i21176-b/Macro.scala
@@ -1,0 +1,9 @@
+import scala.quoted.*
+
+class Macro:
+  inline def nameTuple[NameTuple_T]: (String, List[NameTuple_T]) = Macro.tuple[NameTuple_T](Macro.named)
+
+object Macro:
+  def namedMacro(using q: Quotes): Expr[String] = Expr("test")
+  inline def named: String = ${Macro.namedMacro}
+  def tuple[Tuple_T](name: String): (String, List[Tuple_T]) = (name, List.empty[Tuple_T])

--- a/tests/pos/i21176-b/Main.scala
+++ b/tests/pos/i21176-b/Main.scala
@@ -1,0 +1,2 @@
+class Test extends Macro:
+  val abc = nameTuple[Int]


### PR DESCRIPTION
Backports #23870 to the 3.3.8.

PR submitted by the release tooling.
[skip ci]