### PR TITLE
Backport "Patch to allow interop with XMLBuilder and -Yexplicit-nulls" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/xml/SymbolicXMLBuilder.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/xml/SymbolicXMLBuilder.scala
@@ -68,7 +68,13 @@ class SymbolicXMLBuilder(parser: Parser, preserveWS: Boolean)(using Context) {
 
   // convenience methods
   private def LL[A](x: A*): List[List[A]] = List(List(x:_*))
-  private def const(x: Any) = Literal(Constant(x))
+  // Changing type to String causes a compiler crash in pickler phase,
+  // so we leave it as Any for now.
+  private def const(x: Any) = 
+    val lit = Literal(Constant(x))
+    if ctx.explicitNulls && x == null
+    then TypeApply(Select(lit, nme.asInstanceOf_), TypeTree(defn.StringType) :: Nil)
+    else lit
   private def wild                          = Ident(nme.WILDCARD)
   private def wildStar                      = Ident(tpnme.WILDCARD_STAR)
   private def _scala(name: Name)            = scalaDot(name)

--- a/compiler/src/dotty/tools/dotc/parsing/xml/SymbolicXMLBuilder.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/xml/SymbolicXMLBuilder.scala
@@ -13,6 +13,7 @@ import Names.*, StdNames.*, ast.Trees.*, ast.{tpd, untpd}
 import Symbols.*, Contexts.*
 import util.Spans.*
 import Parsers.Parser
+import dotty.tools.dotc.ast.tpd.TreeOps
 
 /** This class builds instance of `Tree` that represent XML.
  *

--- a/compiler/src/dotty/tools/dotc/parsing/xml/SymbolicXMLBuilder.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/xml/SymbolicXMLBuilder.scala
@@ -69,7 +69,7 @@ class SymbolicXMLBuilder(parser: Parser, preserveWS: Boolean)(using Context) {
 
   // convenience methods
   private def LL[A](x: A*): List[List[A]] = List(List(x:_*))
-// Changing type to String causes a compiler crash in pickler phase,
+  // Changing type to String causes a compiler crash in pickler phase,
   // so we leave it as Any for now.
   private def const(x: Any) = 
     val lit = Literal(Constant(x))

--- a/compiler/src/dotty/tools/dotc/parsing/xml/SymbolicXMLBuilder.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/xml/SymbolicXMLBuilder.scala
@@ -68,7 +68,7 @@ class SymbolicXMLBuilder(parser: Parser, preserveWS: Boolean)(using Context) {
 
   // convenience methods
   private def LL[A](x: A*): List[List[A]] = List(List(x:_*))
-  // Changing type to String causes a compiler crash in pickler phase,
+// Changing type to String causes a compiler crash in pickler phase,
   // so we leave it as Any for now.
   private def const(x: Any) = 
     val lit = Literal(Constant(x))

--- a/tests/explicit-nulls/run/xml.scala
+++ b/tests/explicit-nulls/run/xml.scala
@@ -1,0 +1,59 @@
+
+object Test {
+  import scala.xml._
+
+  def main(args: Array[String]): Unit = {
+    val xml =  <hello>world</hello>
+    assert(xml.toString == "helloworld")
+    val sq: NodeBuffer = <hello/><world/>
+    assert(sq.mkString == "helloworld")
+
+    val subSq: Node = <a><b/><c/></a>
+    assert(subSq.child.toString == "Vector(b, c)") // implementation detail
+
+    val attrSeq: Elem = <a foo="txt&entityref;txt"/>
+    assert(attrSeq.attributes.asInstanceOf[UnprefixedAttribute].value.toString == "Vector(txt, &entityref;, txt)")
+
+    val g: Group = <xml:group><a/><b/><c/></xml:group>
+    assert(g.nodes.toString == "Vector(a, b, c)")
+  }
+}
+package scala.xml {
+  type MetaData = AnyRef
+
+  trait NamespaceBinding
+  object TopScope extends NamespaceBinding
+  object Null
+  abstract class Node {
+    def label: String
+    def child: Seq[Node]
+    override def toString = label + child.mkString
+  }
+  class Elem(prefix: String, val label: String, val attributes: MetaData, scope: NamespaceBinding, minimizeEmpty: Boolean, val child: Node*) extends Node
+  class NodeBuffer extends Seq[Node] {
+    val nodes = scala.collection.mutable.ArrayBuffer.empty[Node]
+    def &+(o: Any): NodeBuffer =
+      o match {
+        case n: Node => nodes.addOne(n) ; this
+        case t: Text => nodes.addOne(Atom(t)) ; this
+      }
+    // Members declared in scala.collection.IterableOnce
+    def iterator: Iterator[scala.xml.Node] = nodes.iterator
+    // Members declared in scala.collection.SeqOps
+    def apply(i: Int): scala.xml.Node = nodes(i)
+    def length: Int = nodes.length
+  }
+  case class Text(text: String)
+  case class Atom(t: Text) extends Node {
+    def label = t.text
+    def child = Nil
+  }
+
+  case class UnprefixedAttribute(key: String, value: Seq[Node], next: MetaData)
+  case class EntityRef(entityName: String) extends Node {
+    def label = s"&$entityName;"
+    def child = Nil
+  }
+
+  case class Group(nodes: Seq[Node])
+}


### PR DESCRIPTION
Backports #25221 to the 3.3.8.

PR submitted by the release tooling.
[skip ci]