### PR TITLE
Backport "Add "did you mean to use parentheses/a block" when finding a complex expression on the RHS of an infix operator" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/inlines/InlineReducer.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/InlineReducer.scala
@@ -95,7 +95,10 @@ class InlineReducer(inliner: Inliner)(using Context):
                 false
             }
           }
-        val idx = cls.asClass.paramAccessors.filter(_.is(Flags.Method)).indexWhere(matches(_, tree.symbol))
+        val accessors =
+          if (cls.asClass.is(Scala2x)) cls.asClass.paramAccessors.filter(_.is(Method))
+          else cls.asClass.paramAccessors
+        val idx = accessors.indexWhere(matches(_, tree.symbol))
         if (idx >= 0 && idx < args.length) {
           def finish(arg: Tree) =
             new TreeTypeMap().transform(arg) // make sure local bindings in argument have fresh symbols

--- a/compiler/src/dotty/tools/dotc/inlines/InlineReducer.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/InlineReducer.scala
@@ -95,7 +95,7 @@ class InlineReducer(inliner: Inliner)(using Context):
                 false
             }
           }
-        val idx = cls.asClass.paramAccessors.indexWhere(matches(_, tree.symbol))
+        val idx = cls.asClass.paramAccessors.filter(_.is(Flags.Method)).indexWhere(matches(_, tree.symbol))
         if (idx >= 0 && idx < args.length) {
           def finish(arg: Tree) =
             new TreeTypeMap().transform(arg) // make sure local bindings in argument have fresh symbols

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -367,9 +367,13 @@ object Parsers {
         else
           val found = in.token
           val statFollows = mustStartStatTokens.contains(found)
+          val extra =
+          if in.isOperator && Tokens.canStartExprTokens3.contains(in.lookahead.token) then
+            " - did you intend to apply an infix operator? If so, wrap the right operand in parentheses or in a block."
+          else ""
           syntaxError(
             if noPrevStat then IllegalStartOfStatement(what, isModifier, statFollows)
-            else em"end of $what expected but ${showToken(found)} found")
+            else em"end of $what expected but ${showToken(found)} found$extra")
           if statFollows then
             stopping // it's a statement that might be legal in an outer context
           else

--- a/tests/neg-macros/i15159.check
+++ b/tests/neg-macros/i15159.check
@@ -4,7 +4,7 @@
   |  Exception occurred while executing macro expansion.
   |  java.lang.AssertionError: class X is not a member of A
   |  	at TestMacro$.testImpl$$anonfun$1(Macro_1.scala:8)
-  |  	at scala.collection.immutable.List.map(List.scala:240)
+  |  	at scala.collection.immutable.List.map(List.scala:236)
   |  	at TestMacro$.testImpl(Macro_1.scala:7)
   |
   |---------------------------------------------------------------------------------------------------------------------

--- a/tests/neg-macros/i23008.check
+++ b/tests/neg-macros/i23008.check
@@ -3,13 +3,6 @@
   |                 ^^^^^^^^^^^^^^^^^^
   |                 Exception occurred while executing macro expansion.
   |                 java.lang.IllegalArgumentException: requirement failed: value of StringConstant cannot be `null`
-  |                 	at scala.Predef$.require(Predef.scala:337)
-  |                 	at scala.quoted.runtime.impl.QuotesImpl$reflect$StringConstant$.apply(QuotesImpl.scala:2425)
-  |                 	at scala.quoted.runtime.impl.QuotesImpl$reflect$StringConstant$.apply(QuotesImpl.scala:2424)
-  |                 	at scala.quoted.ToExpr$StringToExpr.apply(ToExpr.scala:80)
-  |                 	at scala.quoted.ToExpr$StringToExpr.apply(ToExpr.scala:78)
-  |                 	at scala.quoted.Expr$.apply(Expr.scala:70)
-  |                 	at Macros$.buildStringCode(Macro_1.scala:9)
   |
   |---------------------------------------------------------------------------------------------------------------------
   |Inline stack trace

--- a/tests/neg-macros/i23008/Macro_1.scala
+++ b/tests/neg-macros/i23008/Macro_1.scala
@@ -6,6 +6,11 @@ object Macros {
   def buildStringCode(using Quotes): Expr[String] = {
     import quotes.reflect.*
     val str: String = null
-    Expr(str)
+    try
+      Expr(str)
+    catch
+      case error: java.lang.IllegalArgumentException =>
+        error.setStackTrace(Array[StackTraceElement]())
+        throw error
   }
 }

--- a/tests/neg/i22575.check
+++ b/tests/neg/i22575.check
@@ -1,4 +1,9 @@
 -- Error: tests/neg/i22575.scala:11:21 ---------------------------------------------------------------------------------
 11 |  requireConst(transp(nonTranspDouble)) // error
    |               ^^^^^^^^^^^^^^^^^^^^^^^
-   |               expected a constant value but found: (x: Int) => (x * 2):(Int => Int).apply(2)
+   |               expected a constant value but found: (
+   |                 {
+   |                   def $anonfun(x: Int): Int = x.*(2)
+   |                   closure($anonfun)
+   |                 }
+   |               :(Int => Int)).apply(2)

--- a/tests/neg/infix-then-complex-expr.check
+++ b/tests/neg/infix-then-complex-expr.check
@@ -1,7 +1,7 @@
 -- Error: tests/neg/infix-then-complex-expr.scala:3:2 ------------------------------------------------------------------
 3 |  && // error
   |  ^^
-  |  end of statement expected but identifier found
+  |end of statement expected but identifier found - did you intend to apply an infix operator? If so, wrap the right operand in parentheses or in a block.
 -- [E002] Syntax Warning: tests/neg/infix-then-complex-expr.scala:4:2 --------------------------------------------------
 4 |  try java.lang.Boolean.valueOf("true")
   |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/neg/infix-then-complex-expr.check
+++ b/tests/neg/infix-then-complex-expr.check
@@ -1,0 +1,17 @@
+-- Error: tests/neg/infix-then-complex-expr.scala:3:2 ------------------------------------------------------------------
+3 |  && // error
+  |  ^^
+  |  end of statement expected but identifier found
+-- [E002] Syntax Warning: tests/neg/infix-then-complex-expr.scala:4:2 --------------------------------------------------
+4 |  try java.lang.Boolean.valueOf("true")
+  |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |  A try without catch or finally is equivalent to putting
+  |  its body in a block; no exceptions are handled.
+  |
+  | longer explanation available when compiling with `-explain`
+-- [E129] Potential Issue Warning: tests/neg/infix-then-complex-expr.scala:2:2 -----------------------------------------
+2 |  true
+  |  ^^^^
+  |  A pure expression does nothing in statement position
+  |
+  | longer explanation available when compiling with `-explain`

--- a/tests/neg/infix-then-complex-expr.scala
+++ b/tests/neg/infix-then-complex-expr.scala
@@ -1,0 +1,4 @@
+@main def test = println:
+  true
+  && // error
+  try java.lang.Boolean.valueOf("true")

--- a/tests/pos/i25292.scala
+++ b/tests/pos/i25292.scala
@@ -1,10 +1,5 @@
 //> using options -Ycheck:all
 
-val namedTuple: (x: 42, y: true) = (x = 42, y = true)
-val a = namedTuple match
-  case (1, y) => ()
-  case (x, y) => ()
-
 val tuple: (42, true) = (42, true)
 val b = tuple match
   case (1, y) => ()


### PR DESCRIPTION
Backports #25099 to the 3.3.8.

PR submitted by the release tooling.