### PR TITLE
Fix inline match reduction issue

### DIFF
--- a/compiler/src/dotty/tools/dotc/inlines/InlineReducer.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/InlineReducer.scala
@@ -95,7 +95,10 @@ class InlineReducer(inliner: Inliner)(using Context):
                 false
             }
           }
-        val idx = cls.asClass.paramAccessors.filter(_.is(Flags.Method)).indexWhere(matches(_, tree.symbol))
+        val accessors =
+          if (cls.asClass.is(Scala2x)) cls.asClass.paramAccessors.filter(_.is(Method))
+          else cls.asClass.paramAccessors
+        val idx = accessors.indexWhere(matches(_, tree.symbol))
         if (idx >= 0 && idx < args.length) {
           def finish(arg: Tree) =
             new TreeTypeMap().transform(arg) // make sure local bindings in argument have fresh symbols

--- a/compiler/src/dotty/tools/dotc/inlines/InlineReducer.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/InlineReducer.scala
@@ -95,7 +95,7 @@ class InlineReducer(inliner: Inliner)(using Context):
                 false
             }
           }
-        val idx = cls.asClass.paramAccessors.indexWhere(matches(_, tree.symbol))
+        val idx = cls.asClass.paramAccessors.filter(_.is(Flags.Method)).indexWhere(matches(_, tree.symbol))
         if (idx >= 0 && idx < args.length) {
           def finish(arg: Tree) =
             new TreeTypeMap().transform(arg) // make sure local bindings in argument have fresh symbols


### PR DESCRIPTION
```scala
val $scrutinee1: (Int, Int) = Tuple2.apply[Int, Int](1, 2)
val $proxy2: Int = $scrutinee1._2
```
was not able to be reduced.
Alternative fixes:
* backport d04b3c704022ea3ccf93fb082c17e657374cec4d (I tried back porting only the directly related part, but that caused other errors, so probably the whole thing would have to be back ported)
* I think it's also ok to adjust the Inliner test, this bug is basically unrelated, and the improvement to inline match reduction still work even without this 