### PR TITLE
Backport "Fix crashing for context bound type variables in quoted patterns" to 3.3 LTS

### DIFF
--- a/tests/neg/i25260.check
+++ b/tests/neg/i25260.check
@@ -1,0 +1,6 @@
+-- [E095] Syntax Error: tests/neg/i25260.scala:3:30 --------------------------------------------------------------------
+3 |  expr match { case '{ type t : List; $x: t } => ??? } // error
+  |                              ^
+  |                              =, >:, or <: expected, but ':' found
+  |
+  | longer explanation available when compiling with `-explain`

--- a/tests/neg/i25260.scala
+++ b/tests/neg/i25260.scala
@@ -1,0 +1,3 @@
+import scala.quoted._
+def expr(expr: Expr[Any])(using Quotes) =
+  expr match { case '{ type t : List; $x: t } => ??? } // error


### PR DESCRIPTION
Backports #25286 to the 3.3.8.

PR submitted by the release tooling.
[skip ci]