### PR TITLE
Backport "preserve span of `this` during statification of trait constructors" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/BCodeSkelBuilder.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeSkelBuilder.scala
@@ -788,7 +788,10 @@ trait BCodeSkelBuilder extends BCodeHelpers {
           typeMap = _.substThis(enclosingClass, selfParamRef.symbol.termRef)
             .subst(dd.termParamss.head.map(_.symbol), regularParamRefs.map(_.symbol.termRef)),
           treeMap = {
-            case tree: This if tree.symbol == enclosingClass => selfParamRef
+            case tree: This if tree.symbol == enclosingClass =>
+              // Since we want the positions to be accurate in the bytecode, we preserve
+              // the original span of the `this` node when we `statify` it.
+              selfParamRef.withSpan(tree.span)
             case tree => tree
           },
           oldOwners = origSym :: Nil,

--- a/compiler/test/dotty/tools/backend/jvm/SourcePositionsTest.scala
+++ b/compiler/test/dotty/tools/backend/jvm/SourcePositionsTest.scala
@@ -114,3 +114,26 @@ class SourcePositionsTest extends DottyBytecodeTest:
       assertEquals(expected, lineNumbers)
     }
   }
+
+  @Test def i23413: Unit =
+    val code =
+      """
+      |trait Test:
+      |  def mult(x: Int): Int
+      |
+      |  mult(3)
+      |  mult(4)
+      |  mult(5)
+      |
+      """.stripMargin
+    checkBCode(code): dir =>
+      val testClass = loadClassNode(dir.lookupName("Test.class", directory = false).input, skipDebugInfo = false)
+      val testMethod = getMethod(testClass, "$init$")
+      val lineNumbers = instructionsFromMethod(testMethod).collect {case ln: LineNumber => ln}
+      val expected = List(
+        LineNumber(5, Label(0)),  // mult(3)
+        LineNumber(6, Label(6)),  // mult(4)
+        LineNumber(7, Label(12)), // mult(5)
+      )
+      assertEquals(expected, lineNumbers)
+  end i23413


### PR DESCRIPTION
Backports #25354 to the 3.3.8.

PR submitted by the release tooling.
[skip ci]