### PR TITLE
Backport "Always encode <init> in derived name" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/NameKinds.scala
+++ b/compiler/src/dotty/tools/dotc/core/NameKinds.scala
@@ -179,7 +179,7 @@ object NameKinds {
     def apply(qual: TermName, num: Int): TermName =
       qual.derived(new NumberedInfo(num))
     def unapply(name: DerivedName): Option[(TermName, Int)] = name match {
-      case DerivedName(underlying, info: this.NumberedInfo) => Some((underlying, info.num))
+      case DerivedName(underlying, info: this.NumberedInfo) if info.kind.tag == this.tag => Some((underlying, info.num))
       case _ => None
     }
     protected def skipSeparatorAndNum(name: SimpleName, separator: String): Int = {

--- a/compiler/src/dotty/tools/dotc/core/Names.scala
+++ b/compiler/src/dotty/tools/dotc/core/Names.scala
@@ -506,7 +506,7 @@ object Names {
     }
 
     override def isEmpty: Boolean = false
-    override def encode: ThisName = underlying.encode.derived(info.map(_.encode))
+    override def encode: ThisName = underlying.encode.derived(info.map(NameTransformer.encode)) // encodes <init>
     override def decode: ThisName = underlying.decode.derived(info.map(_.decode))
     override def firstPart: SimpleName = underlying.firstPart
     override def lastPart: SimpleName = info match {

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -466,7 +466,7 @@ object SymDenotations {
 
     /** The expanded name of this denotation. */
     final def expandedName(using Context): Name =
-      if (name.is(ExpandedName) || isConstructor) name
+      if name.is(ExpandedName) || isConstructor then name
       else name.expandedName(initial.owner)
         // need to use initial owner to disambiguate, as multiple private symbols with the same name
         // might have been moved from different origins into the same class

--- a/tests/run/i23477.scala
+++ b/tests/run/i23477.scala
@@ -1,0 +1,8 @@
+//> using options -Ycheck:expandPrivate
+
+class C private (x: Int, y: Int = 1):
+  def this() = this(1)
+
+@main def Test =
+  println:
+    C()


### PR DESCRIPTION
Backports #23478 to the 3.3.8.

PR submitted by the release tooling.
[skip ci]