### PR TITLE
Backport "Report info logs in checked test output if enabled with -Ylog" to 3.3 LTS

### DIFF
--- a/compiler/test/dotty/tools/dotc/reporting/TestReporter.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/TestReporter.scala
@@ -36,7 +36,7 @@ extends Reporter with UniqueMessagePositions with HideNonSensicalMessages with M
   final def messages: Iterator[String] = _messageBuf.iterator
 
   protected final val _consoleBuf = new StringWriter
-  protected final val _consoleReporter = new ConsoleReporter(scala.Console.in, new PrintWriter(_consoleBuf)):
+  protected final val _consoleReporter = new TestConsoleReporter(new PrintWriter(_consoleBuf)):
     override protected def renderPath(file: AbstractFile): String = TestReporter.renderPath(file)
 
   final def consoleOutput: String = _consoleBuf.toString
@@ -80,11 +80,22 @@ extends Reporter with UniqueMessagePositions with HideNonSensicalMessages with M
       case _ => ""
     }
 
-    if dia.level >= WARNING then
+    if _consoleReporter.isDiagnosticRelevant(dia) then
       _consoleReporter.doReport(dia)
       _diagnosticBuf.append(dia)
     printMessageAndPos(dia, extra)
   }
+}
+
+class TestConsoleReporter(writer: PrintWriter) extends ConsoleReporter(null, writer) {
+  // Report even info-level diagnostics if they've been explicitly enabled by -Ylog
+  def isDiagnosticRelevant(dia: Diagnostic)(using Context): Boolean =
+    dia.level >= WARNING || ctx.settings.Ylog.value.containsPhase(ctx.phase)
+
+  /** Print the message with the given position indication. */
+  override def doReport(dia: Diagnostic)(using Context): Unit =
+    if isDiagnosticRelevant(dia) then printMessage(messageAndPos(dia))
+    else echoMessage(messageAndPos(dia))
 }
 
 object TestReporter {

--- a/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
+++ b/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
@@ -26,7 +26,7 @@ import dotc.{Compiler, Driver}
 import dotc.core.Contexts.*
 import dotc.decompiler
 import dotc.report
-import dotc.interfaces.Diagnostic.ERROR
+import dotc.interfaces.Diagnostic.{ERROR, WARNING}
 import dotc.reporting.{Reporter, TestReporter}
 import dotc.reporting.Diagnostic
 import dotc.config.Config
@@ -739,8 +739,8 @@ trait ParallelTesting extends RunnerOrchestration:
     override def maybeFailureMessage(testSource: TestSource, reporters: Seq[TestReporter]): Option[String] =
       lazy val (expected, expCount) = getWarnMapAndExpectedCount(testSource.sourceFiles.toIndexedSeq)
       lazy val obtCount = reporters.foldLeft(0)(_ + _.warningCount)
-      lazy val (unfulfilled, unexpected) = getMissingExpectedWarnings(expected, diagnostics.iterator)
       lazy val diagnostics = reporters.flatMap(_.diagnostics.toSeq.sortBy(_.pos.line))
+      lazy val (unfulfilled, unexpected) = getMissingExpectedWarnings(expected, diagnostics.iterator.filter(_.level >= WARNING))
       lazy val messages = diagnostics.map(d => s" at ${d.pos.line + 1}: ${d.message}")
       def showLines(title: String, lines: Seq[String]) = if lines.isEmpty then "" else lines.mkString(s"$title\n", "\n", "")
       def hasMissingAnnotations = unfulfilled.nonEmpty || unexpected.nonEmpty

--- a/tests/warn/multiple-entry-points.check
+++ b/tests/warn/multiple-entry-points.check
@@ -1,0 +1,5 @@
+[log genBCode] Adding static forwarder for 'method main' from First to 'module class First$'
+[log genBCode] No Main-Class due to multiple entry points:
+  Second
+  First
+[log genBCode] Adding static forwarder for 'method main' from Second to 'module class Second$'

--- a/tests/warn/multiple-entry-points/1_First.scala
+++ b/tests/warn/multiple-entry-points/1_First.scala
@@ -1,0 +1,6 @@
+//> using option -Ylog:genBCode
+
+object First {
+  def main(args: Array[String]): Unit =
+    println("first")
+}

--- a/tests/warn/multiple-entry-points/2_Second.scala
+++ b/tests/warn/multiple-entry-points/2_Second.scala
@@ -1,0 +1,4 @@
+object Second {
+  def main(args: Array[String]): Unit =
+    println("second")
+}


### PR DESCRIPTION
Backports #25391 to the 3.3.8.

PR submitted by the release tooling.
[skip ci]