### PR TITLE
Backport "Better handling of illegal trees in `extension`" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -994,10 +994,10 @@ object desugar {
 
   /** Transform extension construct to list of extension methods */
   def extMethods(ext: ExtMethods)(using Context): Tree = flatTree {
-    ext.methods map {
+    ext.methods.map:
       case exp: Export => exp
       case mdef: DefDef => defDef(extMethod(mdef, ext.paramss))
-    }
+      case _ => EmptyTree // we ignore all the other trees. Error was reported during parsing.
   }
   /** Transforms
    *

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -3923,14 +3923,12 @@ object Parsers {
 
     /** ClassDef ::= id ClassConstr TemplateOpt
      */
-    def classDef(start: Offset, mods: Modifiers): TypeDef = atSpan(start, nameStart) {
-      classDefRest(start, mods, ident().toTypeName)
-    }
-
-    def classDefRest(start: Offset, mods: Modifiers, name: TypeName): TypeDef =
-      val constr = classConstr(if mods.is(Case) then ParamOwner.CaseClass else ParamOwner.Class)
-      val templ = templateOpt(constr)
-      finalizeDef(TypeDef(name, templ), mods, start)
+    def classDef(start: Offset, mods: Modifiers): TypeDef =
+      atSpan(start, nameStart):
+        val name = ident().toTypeName
+        val constr = classConstr(if mods.is(Case) then ParamOwner.CaseClass else ParamOwner.Class)
+        val templ = templateOpt(constr)
+        finalizeDef(TypeDef(name, templ), mods, start)
 
     /** ClassConstr ::= [ClsTypeParamClause] [ConstrMods] ClsTermParamClauses
      */
@@ -4135,13 +4133,31 @@ object Parsers {
       val meths = new ListBuffer[Tree]
       while
         val start = in.offset
-        if in.token == EXPORT then
-          meths ++= exportClause()
-        else
-          val mods = defAnnotsMods(modifierTokens)
-          if in.token != EOF then
+        val mods = defAnnotsMods(modifierTokens)
+        in.token match
+          case IMPORT =>
+            syntaxError(em"imports are not allowed inside extensions")
+            meths ++= importClause()
+          case EXPORT =>
+            meths ++= exportClause()
+          case VAL =>
+            accept(VAL)
+            val tree = patDefOrDcl(start, mods)
+            meths += tree
+            syntaxError(em"values are not allowed inside extensions", tree.span)
+          case VAR =>
+            accept(VAR)
+            val tree = patDefOrDcl(start, mods) // we don't set the Var modifier here (we don't care)
+            meths += tree
+            syntaxError(em"values are not allowed inside extensions", tree.span)
+          case DEF =>
             accept(DEF)
             meths += defDefOrDcl(start, mods, numLeadParams)
+          case TYPE =>
+            val tree = typeDefOrDcl(start, in.skipToken(mods))
+            meths += tree
+            syntaxError(em"types are not allowed inside extensions", tree.span)
+          case _ =>
         in.token != EOF && statSepOrEnd(meths, what = "extension method")
       do ()
       if meths.isEmpty then syntaxErrorOrIncomplete(em"`def` expected")

--- a/compiler/src/dotty/tools/dotc/reporting/ConsoleReporter.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/ConsoleReporter.scala
@@ -11,9 +11,11 @@ import Diagnostic.Error
   */
 class ConsoleReporter(
   reader: BufferedReader = Console.in,
-  writer: PrintWriter = new PrintWriter(Console.err, true)
+  writer: PrintWriter = new PrintWriter(Console.err, true),
+  echoer: PrintWriter = new PrintWriter(Console.out, true)
 ) extends ConsoleReporter.AbstractConsoleReporter {
   override def printMessage(msg: String): Unit = { writer.print(msg + "\n"); writer.flush() }
+  override def echoMessage(msg: String): Unit = { echoer.println(msg); echoer.flush() }
   override def flush()(using Context): Unit    = writer.flush()
 
   override def doReport(dia: Diagnostic)(using Context): Unit = {
@@ -28,6 +30,9 @@ object ConsoleReporter {
   abstract class AbstractConsoleReporter extends AbstractReporter {
     /** Prints the message. */
     def printMessage(msg: String): Unit
+
+    /** Print the informative message. */
+    def echoMessage(msg: String): Unit
 
     /** Prints the message with the given position indication. */
     def doReport(dia: Diagnostic)(using Context): Unit = {

--- a/compiler/src/dotty/tools/dotc/semanticdb/SemanticSymbolBuilder.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/SemanticSymbolBuilder.scala
@@ -264,11 +264,11 @@ private[semanticdb] object SemanticSymbolBuilder:
         addName(b, sym.name)
         if sym.is(Package) then b.append('/')
         else if sym.isType || sym.isAllOf(JavaModule) then b.append('#')
-        else if sym.is(Method) || (sym.is(Mutable) && !sym.is(JavaDefined))
+        else if (isScalaMethodOrVar || isJavaMethod)
           && (!sym.is(StableRealizable) || sym.isConstructor) then
-          b.append('(')
-          addOverloadIdx(sym)
-          b.append(").")
+            b.append('(')
+            addOverloadIdx(sym)
+            b.append(").")
         else b.append('.')
 
     sb match

--- a/compiler/src/dotty/tools/repl/ReplDriver.scala
+++ b/compiler/src/dotty/tools/repl/ReplDriver.scala
@@ -657,6 +657,7 @@ class ReplDriver(settings: Array[String],
   private object ReplConsoleReporter extends ConsoleReporter.AbstractConsoleReporter {
     override def posFileStr(pos: SourcePosition) = "" // omit file paths
     override def printMessage(msg: String): Unit = out.println(msg)
+    override def echoMessage(msg: String): Unit  = printMessage(msg)
     override def flush()(using Context): Unit    = out.flush()
   }
 

--- a/compiler/test/dotty/tools/dotc/reporting/TestReporter.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/TestReporter.scala
@@ -87,7 +87,7 @@ extends Reporter with UniqueMessagePositions with HideNonSensicalMessages with M
   }
 }
 
-class TestConsoleReporter(writer: PrintWriter) extends ConsoleReporter(null, writer) {
+class TestConsoleReporter(writer: PrintWriter) extends ConsoleReporter(scala.Console.in, writer) {
   // Report even info-level diagnostics if they've been explicitly enabled by -Ylog
   def isDiagnosticRelevant(dia: Diagnostic)(using Context): Boolean =
     dia.level >= WARNING || ctx.settings.Ylog.value.containsPhase(ctx.phase)

--- a/presentation-compiler/test/dotty/tools/pc/tests/PcSemanticdbSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/PcSemanticdbSuite.scala
@@ -52,5 +52,5 @@ class PcSemanticdbSuite extends BasePCSuite:
   ): Unit =
     val uri = new URI(s"file:///$filename")
     val doc = presentationCompiler.semanticdbTextDocument(uri, original)
-    val obtained = DocumentPrinter.textDocumentPrettyPrint(doc.get())
+    val obtained = DocumentPrinter.textDocumentPrettyPrint(doc.nn.get().nn)
     assertNoDiff(expected, obtained)

--- a/tests/neg/i23036.check
+++ b/tests/neg/i23036.check
@@ -1,0 +1,40 @@
+-- Error: tests/neg/i23036.scala:2:2 -----------------------------------------------------------------------------------
+2 |  import self.*             // error
+  |  ^^^^^^
+  |  imports are not allowed inside extensions
+-- Error: tests/neg/i23036.scala:3:14 ----------------------------------------------------------------------------------
+3 |  opaque type Maybe[+A] = A // error
+  |  ^^^^^^^^^^^^^^^^^^^^^^^^^
+  |  types are not allowed inside extensions
+-- Error: tests/neg/i23036.scala:4:7 -----------------------------------------------------------------------------------
+4 |  type B = self.type        // error
+  |  ^^^^^^^^^^^^^^^^^^
+  |  types are not allowed inside extensions
+-- Error: tests/neg/i23036.scala:5:6 -----------------------------------------------------------------------------------
+5 |  val x: Int = self         // error
+  |  ^^^^^^^^^^^^^^^^^
+  |  values are not allowed inside extensions
+-- Error: tests/neg/i23036.scala:6:6 -----------------------------------------------------------------------------------
+6 |  var z: Int = self         // error
+  |  ^^^^^^^^^^^^^^^^^
+  |  values are not allowed inside extensions
+-- Error: tests/neg/i23036.scala:10:2 ----------------------------------------------------------------------------------
+10 |  import self.*             // error
+   |  ^^^^^^
+   |  imports are not allowed inside extensions
+-- Error: tests/neg/i23036.scala:11:14 ---------------------------------------------------------------------------------
+11 |  opaque type X[+A] = A     // error
+   |  ^^^^^^^^^^^^^^^^^^^^^
+   |  types are not allowed inside extensions
+-- Error: tests/neg/i23036.scala:12:7 ----------------------------------------------------------------------------------
+12 |  type Y = self.type        // error
+   |  ^^^^^^^^^^^^^^^^^^
+   |  types are not allowed inside extensions
+-- Error: tests/neg/i23036.scala:13:6 ----------------------------------------------------------------------------------
+13 |  val x: Int = self         // error
+   |  ^^^^^^^^^^^^^^^^^
+   |  values are not allowed inside extensions
+-- Error: tests/neg/i23036.scala:14:6 ----------------------------------------------------------------------------------
+14 |  var z: Int = self         // error
+   |  ^^^^^^^^^^^^^^^^^
+   |  values are not allowed inside extensions

--- a/tests/neg/i23036.scala
+++ b/tests/neg/i23036.scala
@@ -1,0 +1,14 @@
+extension (self: Int) {
+  import self.*             // error
+  opaque type Maybe[+A] = A // error
+  type B = self.type        // error
+  val x: Int = self         // error
+  var z: Int = self         // error
+}
+
+extension (self: Any)
+  import self.*             // error
+  opaque type X[+A] = A     // error
+  type Y = self.type        // error
+  val x: Int = self         // error
+  var z: Int = self         // error

--- a/tests/neg/i23729.check
+++ b/tests/neg/i23729.check
@@ -4,11 +4,11 @@
    |                                 expression expected but [31mmatch[0m found
    |
    | longer explanation available when compiling with `-explain`
--- [E040] Syntax Error: tests/neg/i23729.scala:18:6 --------------------------------------------------------------------
+-- Error: tests/neg/i23729.scala:18:6 ----------------------------------------------------------------------------------
 18 |      case Empty => Nil // error poor recovery
    |      ^^^^
-   |      'def' expected, but 'case' found
--- [E040] Syntax Error: tests/neg/i23729.scala:19:6 --------------------------------------------------------------------
+   |      end of extension method expected but 'case' found
+-- Error: tests/neg/i23729.scala:19:6 ----------------------------------------------------------------------------------
 19 |      case Node(_, l, _) => l.start :+ Left // error poor recovery
    |      ^^^^
-   |      'def' expected, but 'case' found
+   |      end of extension method expected but 'case' found

--- a/tests/warn/multiple-entry-points.check
+++ b/tests/warn/multiple-entry-points.check
@@ -1,5 +1,5 @@
-[log genBCode] Adding static forwarder for 'method main' from First to 'module class First$'
 [log genBCode] No Main-Class due to multiple entry points:
   Second
   First
+[log genBCode] Adding static forwarder for 'method main' from First to 'module class First$'
 [log genBCode] Adding static forwarder for 'method main' from Second to 'module class Second$'


### PR DESCRIPTION
Backports #25368 to the 3.3.8.

PR submitted by the release tooling.