### PR TITLE
Backport "add the `transparent` flag to `java.lang.Object`" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -314,7 +314,7 @@ class Definitions {
     val cls = requiredClass("java.lang.Object")
     assert(!cls.isCompleted, "race for completing java.lang.Object")
     cls.info = ClassInfo(cls.owner.thisType, cls, List(AnyType, MatchableType), newScope)
-    cls.setFlag(NoInits | JavaDefined)
+    cls.setFlag(NoInits | JavaDefined | TransparentType)
 
     ensureConstructor(cls, cls.denot.asClass, EmptyScope)
     val companion = JavaLangPackageVal.info.decl(nme.Object).symbol.asTerm
@@ -1986,7 +1986,6 @@ class Definitions {
       "AnyVal" -> Set("scala"),
       "Matchable" -> Set("scala"),
       "Product" -> Set("scala"),
-      "Object" -> Set("java.lang"),
       "Comparable" -> Set("java.lang"),
       "Serializable" -> Set("java.io"),
       "BitSetOps" -> Set("scala.collection"),

--- a/scaladoc/src/dotty/tools/scaladoc/tasty/TastyParser.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/TastyParser.scala
@@ -142,7 +142,8 @@ case class ScaladocTastyInspector()(using ctx: DocContext) extends Inspector:
     )
     "scala" -> aM.copy(
       kind = Kind.Class(Nil, Nil),
-      members = objectMembers
+      members = objectMembers,
+      modifiers = defn.ObjectClass.getExtraModifiers()
     )
 
 object ScaladocTastyInspector:


### PR DESCRIPTION
Backports #25394 to the 3.3.8.

PR submitted by the release tooling.
[skip ci]