### PR TITLE
Backport "do not hide when a `class` or a `trait` extends `Any`" to 3.3 LTS

### DIFF
--- a/scaladoc-testcases/src/tests/traitSignatures.scala
+++ b/scaladoc-testcases/src/tests/traitSignatures.scala
@@ -8,3 +8,5 @@ trait B extends A
 trait C(a: Int)
 
 trait D(b: Double) extends C, A
+
+trait E extends Any

--- a/scaladoc/src/dotty/tools/scaladoc/tasty/ClassLikeSupport.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/ClassLikeSupport.scala
@@ -284,7 +284,7 @@ trait ClassLikeSupport:
           case t: TypeTree => t.tpe.typeSymbol
           case tree if tree.symbol.isClassConstructor => tree.symbol.owner
           case tree => tree.symbol
-        if parentSymbol != defn.ObjectClass && parentSymbol != defn.AnyClass && !parentSymbol.isHiddenByVisibility
+        if parentSymbol != defn.ObjectClass && !parentSymbol.isHiddenByVisibility
       yield (parentTree, parentSymbol)
 
     def getConstructors: List[Symbol] = c.membersToDocument.collect {


### PR DESCRIPTION
Backports #25403 to the 3.3.8.

PR submitted by the release tooling.
[skip ci]