### PR TITLE
Backport "Cleanup compiler test. remove unnecessary `isJavaAtLeast` conditions" to 3.3 LTS

### DIFF
--- a/compiler/test/dotty/tools/dotc/classpath/MultiReleaseJarTest.scala
+++ b/compiler/test/dotty/tools/dotc/classpath/MultiReleaseJarTest.scala
@@ -19,7 +19,6 @@ class MultiReleaseJarTest extends dotty.tools.backend.jvm.DottyBytecodeTest {
 
   @Test
   def mrJar(): Unit = {
-    if (!Properties.isJavaAtLeast("9")) { println("skipping mrJar() on old JDK"); return }
 
     // The test fails if the same jar file gets reused. This might be a caching problem in our classpath implementation
 
@@ -61,8 +60,7 @@ class MultiReleaseJarTest extends dotty.tools.backend.jvm.DottyBytecodeTest {
       assertEquals(Set("foo1", "bar1"), apiMethods(jar1, "8"))
       assertEquals(Set("foo1", "foo2", "bar1"), apiMethods(jar2, "9"))
 
-      if Properties.isJavaAtLeast("10") then
-        assertEquals(Set("foo1", "foo2", "bar1", "bar2"), apiMethods(jar3, "10"))
+      assertEquals(Set("foo1", "foo2", "bar1", "bar2"), apiMethods(jar3, "10"))
     } finally
       List(jar1, jar2, jar3).forall(path =>
         try Files.deleteIfExists(path)
@@ -72,7 +70,6 @@ class MultiReleaseJarTest extends dotty.tools.backend.jvm.DottyBytecodeTest {
 
   @Test
   def ctSymTest(): Unit = {
-    if (!Properties.isJavaAtLeast("9")) { println("skipping mrJar() on old JDK"); return }
 
     def classExists(className: String, release: String): Boolean = {
       given ctx: Context = initCtx.fresh

--- a/compiler/test/dotty/tools/io/ZipArchiveTest.scala
+++ b/compiler/test/dotty/tools/io/ZipArchiveTest.scala
@@ -6,7 +6,6 @@ import java.io.IOException
 import java.net.{URI, URL, URLClassLoader}
 import java.nio.file.{Files, Path, Paths}
 import java.util.jar.{Attributes, Manifest, JarEntry, JarOutputStream}
-import java.lang.invoke.{MethodHandles, MethodType}
 
 import org.junit.Assert._
 import org.junit.Test
@@ -46,23 +45,7 @@ class ZipArchiveTest {
   }
 
   private val bootClassLoader: ClassLoader = {
-    if (!util.Properties.isJavaAtLeast("9")) null
-    else {
-      try {
-        MethodHandles
-          .lookup()
-          .findStatic(
-            classOf[ClassLoader],
-            "getPlatformClassLoader",
-            MethodType.methodType(classOf[ClassLoader])
-          )
-          .invoke()
-          .asInstanceOf[ClassLoader]
-      } catch {
-        case _: Throwable =>
-          null
-      }
-    }
+    ClassLoader.getPlatformClassLoader
   }
 
   private def classLoader(location: URI): ClassLoader =


### PR DESCRIPTION
Backports #24589 to the 3.3.8.

PR submitted by the release tooling.
[skip ci]