### PR TITLE
Backport "Ability to hide snippets from the documentation" to 3.3 LTS

### DIFF
--- a/scaladoc-testcases/src/tests/snippetTestcaseHidden.scala
+++ b/scaladoc-testcases/src/tests/snippetTestcaseHidden.scala
@@ -1,0 +1,14 @@
+package tests.snippetTestcaseHidden
+
+class SnippetTestcaseHidden:
+  /**
+    * ```scala sc-hidden sc-name:preamble
+    * val xs: List[Int] = List(1, 2, 3)
+    * ```
+    *
+    * SNIPPET(OUTERLINEOFFSET:11,OUTERCOLUMNOFFSET:6,INNERLINEOFFSET:4,INNERCOLUMNOFFSET:2)
+    * ```scala sc:compile sc-compile-with:preamble
+    * val ys = xs.map(x => x * 2)
+    * ```
+    */
+  def a = 3

--- a/scaladoc/src/dotty/tools/scaladoc/snippets/FlexmarkSnippetProcessor.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/snippets/FlexmarkSnippetProcessor.scala
@@ -40,6 +40,8 @@ object FlexmarkSnippetProcessor:
           .filter(_.startsWith("sc-opts:"))
           .flatMap(_.stripPrefix("sc-opts:").split(",").map(_.trim).toSeq)
 
+        val isHidden = info.contains("sc-hidden")
+
         val argOverride: Option[SnippetCompilerArg] =
           (flagOverride, scalacOptions) match {
             case (None, Seq()) => None
@@ -88,8 +90,13 @@ object FlexmarkSnippetProcessor:
             result
         }
 
-        node.insertBefore(ExtendedFencedCodeBlock(id, node, snippetCompilationResult))
+        if isHidden && id.isEmpty then
+          report.warning("Snippet with sc-hidden should also have sc-name: to be useful as a preamble for other snippets")
+
+        val extendedNode = ExtendedFencedCodeBlock(id, node, snippetCompilationResult)
+        if !isHidden then node.insertBefore(extendedNode)
         node.unlink()
+
         id.fold(snippetMap)(id =>
           val snippetAsImport = s"""|//{i:$id
                                     |$snippet

--- a/scaladoc/test/dotty/tools/scaladoc/snippets/SnippetsE2eTest.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/snippets/SnippetsE2eTest.scala
@@ -23,7 +23,7 @@ abstract class SnippetsE2eTest(testName: String, flag: SCFlags) extends Scaladoc
 
   val source = Source.fromFile(s"${BuildInfo.test_testcasesSourceRoot}/tests/$testName.scala")
 
-  val snippetsCount = source.getLines().filter(_.indexOf("```scala") != -1).size
+  val snippetsCount = source.getLines().filter(l => l.indexOf("```scala") != -1 && !l.contains("sc-hidden")).size
 
   def report(str: String) = s"""|In test $testName:
                                 |$str""".stripMargin

--- a/scaladoc/test/dotty/tools/scaladoc/snippets/SnippetsE2eTestcases.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/snippets/SnippetsE2eTestcases.scala
@@ -10,3 +10,5 @@ class SnippetE2eTestcase2 extends SnippetsE2eTest("snippetTestcase2", SCFlags.Co
 class SnippetE2eTestcase3 extends SnippetsE2eTest("snippetTestcase3", SCFlags.Compile)
 
 class SnippetE2eTestcaseMacro extends SnippetsE2eTest("snippetTestcaseMacro", SCFlags.Compile)
+
+class SnippetE2eTestcaseHidden extends SnippetsE2eTest("snippetTestcaseHidden", SCFlags.Compile)


### PR DESCRIPTION
Backports #25411 to the 3.3.8.

PR submitted by the release tooling.
[skip ci]