### PR TITLE
Backport "Update README: This is Scala 3" to 3.3 LTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
-Dotty
+Scala 3
 =====
-[![Dotty CI](https://github.com/lampepfl/dotty/workflows/Dotty/badge.svg?branch=master)](https://github.com/lampepfl/dotty/actions?query=branch%3Amain)
+[![Scala 3 CI](https://github.com/scala/scala3/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/scala/scala3/actions/workflows/ci.yaml?query=branch%3Amain)
 [![Join the chat at https://discord.com/invite/scala](https://img.shields.io/discord/632150470000902164)](https://discord.com/invite/scala)
+
+This is the home of the [Scala 3](https://www.scala-lang.org) standard library, compiler, and language spec.
 
 * [Documentation](https://docs.scala-lang.org/scala3/)
 
@@ -27,4 +29,4 @@ How to Contribute
 
 License
 =======
-Dotty is licensed under the [Apache License Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+Scala 3 is licensed under the [Apache License Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)


### PR DESCRIPTION
Backports #25424 to the 3.3.8.

PR submitted by the release tooling.
[skip ci]