### PR TITLE
Backport "Use MatchCaseUnreachable" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -952,11 +952,11 @@ class UncheckedTypePattern(argType: Type, whyNot: String)(using Context)
         |"""
 }
 
-class MatchCaseUnreachable()(using Context)
+class MatchCaseUnreachable(why: String = "")(using Context)
 extends Message(MatchCaseUnreachableID) {
   def kind = MessageKind.MatchCaseUnreachable
-  def msg(using Context) = "Unreachable case"
-  def explain(using Context) = ""
+  override protected def msg(using Context) = "Unreachable case"
+  override protected def explain(using Context) = why
 }
 
 class MatchCaseOnlyNullWarning()(using Context)

--- a/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
@@ -200,12 +200,11 @@ object TypeTestsCasts {
           def testCls = effectiveClass(testType.widen)
           def unboxedTestCls = effectiveClass(unboxedTestType.widen)
 
-          def unreachable(why: => String)(using Context): Boolean = {
-            if (flagUnrelated)
-              if (inMatch) report.error(em"this case is unreachable since $why", expr.srcPos)
+          def unreachable(why: => String)(using Context): false =
+            if flagUnrelated then
+              if inMatch then report.error(MatchCaseUnreachable(why), expr.srcPos)
               else report.warning(em"this will always yield false since $why", expr.srcPos)
             false
-          }
 
           /** Are `foundCls` and `testCls` classes that allow checks
            *  whether a test would be always false?

--- a/tests/neg/i11118.check
+++ b/tests/neg/i11118.check
@@ -6,7 +6,9 @@
   |          If the narrowing is intentional, this can be communicated by adding `: @unchecked` after the expression,
   |          which may result in a MatchError at runtime.
   |          This patch can be rewritten automatically under -rewrite -source 3.2-migration.
--- Error: tests/neg/i11118.scala:2:4 -----------------------------------------------------------------------------------
+-- [E030] Match case Unreachable Error: tests/neg/i11118.scala:2:4 -----------------------------------------------------
 2 |val (a,b) = (1,2,3) // error // warning
   |    ^
-  |    this case is unreachable since type (Int, Int, Int) is not a subclass of class Tuple2
+  |    Unreachable case
+  |
+  | longer explanation available when compiling with `-explain`

--- a/tests/neg/i24789.scala
+++ b/tests/neg/i24789.scala
@@ -1,0 +1,10 @@
+//> using options -Werror -explain
+
+case class A(a: Int)
+case class B(b: Int)
+case class C(c: Int)
+
+val a = (A(1): A | B) match
+  case A(_) => "OK"
+  case B(_) => "OK"
+  case C(_) => "Not OK" // error


### PR DESCRIPTION
Backports #24829 to the 3.3.8.

PR submitted by the release tooling.
[skip ci]