### PR TITLE
Backport "Pretype args before skipping clause of overloaded application " to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -2335,10 +2335,12 @@ trait Applications extends Compatibility {
         deepPt match
           case pt @ FunProto(_, PolyProto(targs, resType)) =>
             // try to narrow further with snd argument list and following type params
+            pretypeArgs(candidates, pt)
             resolveMapped(candidates,
               skipParamClause(pt.typedArgs().tpes, targs.tpes), resType)
           case pt @ FunProto(_, resType: FunOrPolyProto) =>
             // try to narrow further with snd argument list
+            pretypeArgs(candidates, pt)
             resolveMapped(candidates,
               skipParamClause(pt.typedArgs().tpes, Nil), resType)
           case _ =>

--- a/tests/pos/i23011.scala
+++ b/tests/pos/i23011.scala
@@ -1,0 +1,16 @@
+
+type X = Double => Unit
+def g(x: Double): Unit = ???
+def g(x: String): Unit = ???
+
+def f1(x: X) = ???
+
+def f2(x: X, y: Int) = ???
+def f2(x: X, y: Boolean) = ???
+
+def f3(x: X)(y: Int) = ???
+def f3(x: X)(y: Boolean) = ???
+
+val r1 = f1(g) // ok
+val r2 = f2(g, 1) // ok
+val r3 = f3(g)(1) // was error: ambiguous overload for g


### PR DESCRIPTION
Backports #23012 to the 3.3.8.

PR submitted by the release tooling.
[skip ci]