### PR TITLE
Backport "Don't absolutize sources outside of the sourceroot in TASTy" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/util/SourceFile.scala
+++ b/compiler/src/dotty/tools/dotc/util/SourceFile.scala
@@ -232,7 +232,7 @@ object SourceFile {
 
   /** Returns the relative path of `source` within the `reference` path
    *
-   *  It returns the absolute path of `source` if it is not contained in `reference`.
+   *  It returns the current path under `source.file.jpath` if it is not contained in `reference`.
    */
   def relativePath(source: SourceFile, reference: String): String = {
     val file = source.file
@@ -263,7 +263,7 @@ object SourceFile {
         val path = refPath.relativize(sourcePath)
         path.iterator.asScala.mkString("/")
       else
-        sourcePath.toString
+        jpath.toString
   }
 
   /** Return true if file is a script:


### PR DESCRIPTION
Backports #25429 to the 3.3.8.

PR submitted by the release tooling.
[skip ci]