### PR TITLE
Backport "Use deprecatedOverriding message" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/CrossVersionChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/CrossVersionChecks.scala
@@ -79,7 +79,7 @@ class CrossVersionChecks extends MiniPhase:
     for parent <- parents
         psym = parent.tpe.classSymbol
         annot <- psym.getAnnotation(defn.DeprecatedInheritanceAnnot)
-        if !skipWarning(psym)
+        if !skipDeprecation(psym)
     do
       val msg = annot.argumentConstantString(0).map(msg => s": $msg").getOrElse("")
       val since = annot.argumentConstantString(1).map(version => s" (since: $version)").getOrElse("")
@@ -181,12 +181,12 @@ object CrossVersionChecks:
       val composed = em"${annotee.showLocated} is deprecated${since}${message}"
       report.deprecationWarning(composed, pos, origin = annotee.showFullName)
     sym.getAnnotation(defn.DeprecatedAnnot) match
-      case Some(annot) => if !skipWarning(sym) then warn(sym, annot)
+      case Some(annot) => if !skipDeprecation(sym) then warn(sym, annot)
       case _ =>
         if sym.isAllOf(SyntheticMethod) then
           val companion = sym.owner.companionClass
           if companion.is(CaseClass) then
-            for annot <- companion.getAnnotation(defn.DeprecatedAnnot) if !skipWarning(sym) do
+            for annot <- companion.getAnnotation(defn.DeprecatedAnnot) if !skipDeprecation(sym) do
               warn(companion, annot)
 
   /** Decide whether the deprecation of `sym` should be ignored in this context.
@@ -207,7 +207,7 @@ object CrossVersionChecks:
    *  class (or its companion) is either the deprecated case class
    *  or the case class of the deprecated element.
    */
-  private def skipWarning(sym: Symbol)(using Context): Boolean =
+  def skipDeprecation(sym: Symbol)(using Context): Boolean =
 
     // is the owner an enum or its companion and also the owner of sym
     def isEnumOwner(owner: Symbol)(using Context) =
@@ -235,4 +235,4 @@ object CrossVersionChecks:
       owner.is(Synthetic) && symIsCaseOrMember
 
     siteIsSyntheticCaseClassMember || siteIsEnclosedByDeprecatedElement
-  end skipWarning
+  end skipDeprecation

--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -19,6 +19,7 @@ import config.Feature.{warnOnMigration, migrateTo3, sourceVersion}
 import config.SourceVersion.{`3.0`, `future`}
 import config.Printers.refcheck
 import reporting.*
+import Annotations.Annotation
 import Constants.Constant
 
 object RefChecks {
@@ -410,12 +411,17 @@ object RefChecks {
         if trueMatch && noErrorType then
           emitOverrideError(overrideErrorMsg(msg, compareTypes))
 
-      def overrideDeprecation(what: String, member: Symbol, other: Symbol, fix: String): Unit =
-        report.deprecationWarning(
-          em"overriding $what${infoStringWithLocation(other)} is deprecated;\n  ${infoString(member)} should be $fix.",
-          if member.owner == clazz then member.srcPos else clazz.srcPos,
-          origin = other.showFullName
-        )
+      def overrideDeprecation(annot: Annotation, member: Symbol, other: Symbol): Unit =
+        if !CrossVersionChecks.skipDeprecation(member) then
+          val message =
+            annot.argumentConstantString(0).filter(!_.isEmpty)
+              .getOrElse(s"${infoString(member)} should be removed or renamed.")
+          val since = annot.argumentConstantString(1).filter(!_.isEmpty).map(" since " + _).getOrElse("")
+          val composed =
+            em"""overriding ${infoStringWithLocation(other)} is deprecated$since;
+                |  $message"""
+          val pos = if member.owner == clazz then member.srcPos else clazz.srcPos
+          report.deprecationWarning(msg = composed, pos, origin = other.showFullName)
 
       def autoOverride(sym: Symbol) =
         sym.is(Synthetic) && (
@@ -561,7 +567,7 @@ object RefChecks {
       else if !other.isExperimental && member.hasAnnotation(defn.ExperimentalAnnot) then // (1.12)
         overrideError("may not override non-experimental member")
       else if other.hasAnnotation(defn.DeprecatedOverridingAnnot) then
-        overrideDeprecation("", member, other, "removed or renamed")
+        other.getAnnotation(defn.DeprecatedOverridingAnnot).foreach(overrideDeprecation(_, member, other))
     end checkOverride
 
     val checker = if makeOverridingPairsChecker == null then OverridingPairsChecker(clazz, self) else makeOverridingPairsChecker(clazz, self)

--- a/tests/warn/deprecated-override.check
+++ b/tests/warn/deprecated-override.check
@@ -1,0 +1,20 @@
+-- Deprecation Warning: tests/warn/deprecated-override.scala:13:15 -----------------------------------------------------
+13 |  override def f = 2  // warn
+   |               ^
+   |               overriding method f in class B of type => Int is deprecated;
+   |                 method f of type => Int should be removed or renamed.
+-- Deprecation Warning: tests/warn/deprecated-override.scala:14:15 -----------------------------------------------------
+14 |  override def g() = println("goodbye, cruel world") // warn
+   |               ^
+   |               overriding method g in class B of type (): Unit is deprecated since now;
+   |                 Please don't.
+-- Deprecation Warning: tests/warn/deprecated-override.scala:20:7 ------------------------------------------------------
+20 |object E extends B, D  // warn
+   |       ^
+   |       overriding method f in class B of type => Int is deprecated;
+   |         method f in trait D of type => Int should be removed or renamed.
+-- Deprecation Warning: tests/warn/deprecated-override.scala:30:15 -----------------------------------------------------
+30 |  override def f = "hello, world" // warn
+   |               ^
+   |               overriding method f in trait X of type => String is deprecated;
+   |                 method f of type => String should be removed or renamed.

--- a/tests/warn/deprecated-override.scala
+++ b/tests/warn/deprecated-override.scala
@@ -1,15 +1,30 @@
-//> using options -source future -deprecation 
+//> using options -deprecation
 
 trait A:
   def f: Int
+  def g(): Unit
 
 class B extends A:
   @deprecatedOverriding def f = 1
+  @deprecatedOverriding("Please don't.", since = "now")
+  def g() = println("hello, world")
 
 class C extends B:
   override def f = 2  // warn
+  override def g() = println("goodbye, cruel world") // warn
 
 trait D extends A:
   override def f = 3
+  override def g() = ()
 
 object E extends B, D  // warn
+
+@deprecated
+class F extends B:
+  override def g() = println("goodbye, cruel world") // nowarn
+
+trait X[T]:
+  @deprecatedOverriding def f: T
+
+class Y extends X[String]:
+  override def f = "hello, world" // warn


### PR DESCRIPTION
Backports #25439 to the 3.3.8.

PR submitted by the release tooling.
[skip ci]