### PR TITLE
Backport "Fix named arguments evaluation order with by-name parameters" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1082,8 +1082,8 @@ trait Applications extends Compatibility {
             // with all non-explicit default parameters at the end in declaration order.
             val orderedArgDefs = {
               // Indices of original typed arguments that are lifted by liftArgs
-              val impureArgIndices = typedArgBuf.zipWithIndex.collect {
-                case (arg, idx) if !lifter.noLift(arg) => idx
+              val impureArgIndices = typedArgBuf.lazyZip(methodType.paramInfos).zipWithIndex.collect {
+                case ((arg, tp), idx) if lifter.wouldLift(arg, tp) => idx
               }
               def position(arg: Trees.Tree[T]) = {
                 val i = args.indexOf(arg)

--- a/compiler/src/dotty/tools/dotc/typer/EtaExpansion.scala
+++ b/compiler/src/dotty/tools/dotc/typer/EtaExpansion.scala
@@ -33,6 +33,13 @@ abstract class Lifter {
   /** The corresponding lifter for pass-by-name arguments */
   protected def exprLifter: Lifter = NoLift
 
+  private def lifterFor(paramType: Type): Lifter =
+    if paramType.isInstanceOf[ExprType] then exprLifter else this
+
+  /** Returns true if the argument would be lifted for the given parameter type. */
+  def wouldLift(arg: tpd.Tree, paramType: Type)(using Context): Boolean =
+    !paramType.hasAnnotation(defn.InlineParamAnnot) && !lifterFor(paramType).noLift(arg)
+
   /** The flags of a lifted definition */
   protected def liftedFlags: FlagSet = EmptyFlags
 
@@ -90,8 +97,7 @@ abstract class Lifter {
         args.lazyZip(mt.paramNames).lazyZip(mt.paramInfos).map { (arg, name, tp) =>
           if tp.hasAnnotation(defn.InlineParamAnnot) then arg
           else
-            val lifter = if (tp.isInstanceOf[ExprType]) exprLifter else this
-            lifter.liftArg(defs, arg, if (name.firstPart contains '$') EmptyTermName else name)
+            lifterFor(tp).liftArg(defs, arg, if name.firstPart.contains('$') then EmptyTermName else name)
         }
       case _ =>
         args.mapConserve(liftArg(defs, _))

--- a/tests/run/evaluation-order.check
+++ b/tests/run/evaluation-order.check
@@ -1,0 +1,2 @@
+b evaluated
+c evaluated

--- a/tests/run/evaluation-order.scala
+++ b/tests/run/evaluation-order.scala
@@ -1,0 +1,11 @@
+abstract class Foo(a: => Int, b: Int, c: Int)
+
+object Bar extends Foo(
+  b = { println("b evaluated"); 2 },
+  c = { println("c evaluated"); 3 },
+  a = { println("a evaluated"); 1 }
+)
+
+object Test:
+  def main(args: Array[String]): Unit =
+    Bar  // trigger initialization


### PR DESCRIPTION
Backports #25161 to the 3.3.8.

PR submitted by the release tooling.
[skip ci]