### PR TITLE
Backport "Inlines: decide sealing against original target, while using widened type as cast destination" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/inlines/Inlines.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inlines.scala
@@ -566,17 +566,29 @@ object Inlines:
             val withAdjustedThisTypes = if call.symbol.is(Macro) then fixThisTypeModuleClassReferences(unpacked) else unpacked
             (call.tpe & withAdjustedThisTypes, withAdjustedThisTypes != unpacked)
           else (call.tpe, false)
+        // `target` might contain a method reference, which is an invalid cast target. Use its return type instead.
+        // see https://github.com/scala/scala3/issues/25091
         val resultType = target.widenIfUnstable
         if forceCast then
           // we need to force the cast for issues with ThisTypes, as ensureConforms will just
           // check subtyping and then choose not to cast, leaving the previous, incorrect type
           inlined.cast(resultType)
-        else
-          inlined.ensureConforms(resultType)
+        else if !(inlined.tpe <:< target) then
           // Make sure that the sealing with the declared type
           // is type correct. Without it we might get problems since the
           // expression's type is the opaque alias but the call's type is
           // the opaque type itself. An example is in pos/opaque-inline1.scala.
+          //
+          // Here we can't just use `inlined.ensureConforms(resultType)`:
+          // `target.widenIfUnstable` is an upper approximation of `target`,
+          // so a tree may conform to it while still not conforming to `target`.
+          // This can happen when widening drops path-/prefix-sensitive information
+          // (e.g. projected opaque-proxy types).
+          // We check conformance against the original `target`, but cast to the
+          // widened type to avoid NoType issues at erasure (see #25091, #25417).
+          inlined.cast(resultType)
+        else
+          inlined
     end expand
   end InlineCall
 end Inlines

--- a/tests/pos/i25417.scala
+++ b/tests/pos/i25417.scala
@@ -1,0 +1,24 @@
+import scala.compiletime.summonFrom
+
+trait Decoder[A]
+
+given Decoder[String] with {}
+
+trait Mirror[T]:
+  type IronType
+
+given [T](using mirror: Mirror[T], ev: Decoder[mirror.IronType]): Decoder[T] =
+  ev.asInstanceOf[Decoder[T]]
+
+object Foo:
+  opaque type T = String
+
+  inline given Mirror[T] with
+    type IronType = String
+
+inline def summonFooDecoder: Decoder[Foo.T] =
+  summonFrom {
+    case decodeA: Decoder[Foo.T] => decodeA
+  }
+
+val fooDecoder: Decoder[Foo.T] = summonFooDecoder

--- a/tests/pos/i25427.scala
+++ b/tests/pos/i25427.scala
@@ -1,0 +1,15 @@
+import scala.compiletime.summonInline
+
+trait MyEvidence[T]
+
+object Scope:
+  opaque type T = String
+
+  inline given MyEvidence[T] with {}
+
+inline def summonInlineNoOpProxy: MyEvidence[Scope.T] = summonInline[MyEvidence[Scope.T]]
+
+val smoke = (
+  summonInline[MyEvidence[Scope.T]],
+  summonInlineNoOpProxy,
+)


### PR DESCRIPTION
Backports #25448 to the 3.3.8.

PR submitted by the release tooling.
[skip ci]