### PR TITLE
Backport "bugfix: Fix wrong type in InferredType code action" to 3.3 LTS

### DIFF
--- a/presentation-compiler/src/main/dotty/tools/pc/InferredTypeProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/InferredTypeProvider.scala
@@ -12,6 +12,7 @@ import scala.meta as m
 import dotty.tools.dotc.ast.Trees.*
 import dotty.tools.dotc.ast.untpd
 import dotty.tools.dotc.core.Contexts.*
+import dotty.tools.dotc.core.Flags.*
 import dotty.tools.dotc.core.NameOps.*
 import dotty.tools.dotc.core.Names.*
 import dotty.tools.dotc.core.Symbols.*
@@ -88,6 +89,11 @@ final class InferredTypeProvider(
       sourceText.substring(0, nameEnd).nn +
         sourceText.substring(tptEnd + 1, sourceText.length())
 
+    def widenJavaEnumSingleton(tpe: Type)(using Context): Type = tpe match
+      case tp: TermRef if tp.termSymbol.isAllOf(Enum | JavaDefined) =>
+        tp.widen
+      case _ => tpe
+
     def optDealias(tpe: Type): Type =
       def isInScope(tpe: Type): Boolean =
         tpe match
@@ -99,9 +105,9 @@ final class InferredTypeProvider(
           case AppliedType(tycon, args) =>
             isInScope(tycon) && args.forall(isInScope)
           case _ => true
-      if isInScope(tpe)
-      then tpe
-      else tpe.deepDealiasAndSimplify
+      val widened = widenJavaEnumSingleton(tpe)
+      if isInScope(widened) then widened
+      else widened.deepDealiasAndSimplify
 
     val printer = ShortenedTypePrinter(
       symbolSearch,

--- a/presentation-compiler/test/dotty/tools/pc/tests/edit/InsertInferredTypeSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/edit/InsertInferredTypeSuite.scala
@@ -44,6 +44,17 @@ class InsertInferredTypeSuite extends BaseCodeActionSuite:
          |}""".stripMargin
     )
 
+  @Test def `java-enum` =
+    checkEdit(
+      """|object A{
+         |  final val <<javaEnum>> = java.util.Locale.Category.DISPLAY
+         |}""".stripMargin,
+      """|import java.util.Locale.Category
+         |object A{
+         |  final val javaEnum: Category = java.util.Locale.Category.DISPLAY
+         |}""".stripMargin
+    )
+
   @Test def `wrong-val2` =
     checkEdit(
       """|object A{


### PR DESCRIPTION
Backports #25469 to the 3.3.8.

PR submitted by the release tooling.
[skip ci]