### PR TITLE
Backport "Use `readAllBytes` instead of `ByteArrayOutputStream`" to 3.3 LTS

### DIFF
--- a/sjs-compiler-tests/test/scala/dotty/tools/dotc/JSRun.scala
+++ b/sjs-compiler-tests/test/scala/dotty/tools/dotc/JSRun.scala
@@ -54,16 +54,7 @@ object JSRun:
         ""
       case Some(stream) =>
         try
-          val result = new java.io.ByteArrayOutputStream()
-          val buffer = new Array[Byte](1024)
-          while ({
-            val len = stream.read(buffer)
-            len >= 0 && {
-              result.write(buffer, 0, len)
-              true
-            }
-          }) ()
-          new String(result.toByteArray(), StandardCharsets.UTF_8)
+          new String(stream.readAllBytes(), StandardCharsets.UTF_8)
         finally
           stream.close()
   end readStreamFully


### PR DESCRIPTION
Backports #25495 to the 3.3.8.

PR submitted by the release tooling.
[skip ci]