### PR TITLE
Backport "Fix pkg obj prefix of opaque tp ext meth" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeUtils.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeUtils.scala
@@ -4,6 +4,9 @@ package core
 
 import TypeErasure.ErasedValueType
 import Types.*, Contexts.*, Symbols.*, Flags.*, Decorators.*, SymDenotations.*
+import Names.{Name, TermName}
+import Constants.Constant
+
 import Names.Name
 import StdNames.nme
 


### PR DESCRIPTION
Backports #21527 to the 3.3.8.

PR submitted by the release tooling.