### PR TITLE
Backport "Check protected parent constructor accesses only occurs in child constructors" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -906,10 +906,12 @@ object SymDenotations {
         val cls = owner.enclosingSubClass
         if !cls.exists then
           pre.termSymbol.isPackageObject && accessWithin(pre.termSymbol.owner)
-        else
+        else {
+          val isConstructorAccessOK = isConstructor && ctx.owner.isConstructor
           // allow accesses to types from arbitrary subclasses fixes #4737
           // don't perform this check for static members
-          isType || pre.derivesFrom(cls) || isConstructor || owner.is(ModuleClass)
+          isType || pre.derivesFrom(cls) || isConstructorAccessOK || owner.is(ModuleClass)
+        }
       end isProtectedAccessOK
 
       if pre eq NoPrefix then true

--- a/tests/neg/i25442/test.scala
+++ b/tests/neg/i25442/test.scala
@@ -1,0 +1,8 @@
+class I protected (x: Int) {
+  protected def f = x
+}
+
+class M protected () extends I(42) {
+  def t1 = new M()   // ok
+  def t2 = new I(42) // error
+}


### PR DESCRIPTION
Backports #25511 to the 3.3.8.

PR submitted by the release tooling.
[skip ci]