### PR TITLE
Backport "Observe outdent also for type cases and type blocks in quotes" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -2958,6 +2958,7 @@ object Parsers {
       }
       CaseDef(pat, EmptyTree, atSpan(accept(ARROW)) {
         val t = rejectWildcardType(typ())
+        in.observeOutdented()
         if in.token == SEMI then in.nextToken()
         newLinesOptWhenFollowedBy(CASE)
         t

--- a/tests/pos/i25513.scala
+++ b/tests/pos/i25513.scala
@@ -1,0 +1,5 @@
+type Foo[A, B] = (
+  (A, B) match
+    case (Int, Int) => (A, B),
+  A
+)


### PR DESCRIPTION
Backports #25519 to the 3.3.8.

PR submitted by the release tooling.
[skip ci]