### PR TITLE
Backport "Fix protected constructor access" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -437,6 +437,14 @@ object Contexts {
         .setScope(this.scope)
     }
 
+    /** Is this a super call context?
+     *  This is the case if we are in a primary constructor and
+     *  the outer context has as owner the owner of the enclosing class.
+     *  The enclosing class is `owner.owner`, hence `outer.owner == owner.owner.owner`.
+     */
+    def isSuperCallContext: Boolean =
+      owner.isPrimaryConstructor && outer.owner == owner.owner.owner
+
     /** The super- or this-call context with given owner and locals. */
     private def superOrThisCallContext(owner: Symbol, locals: Scope): FreshContext = {
       val classCtx = outersIterator.dropWhile(!_.isClassDefContext).next()

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -902,17 +902,16 @@ object SymDenotations {
       }
 
       /** Is protected access to target symbol permitted? */
-      def isProtectedAccessOK: Boolean =
+      def isProtectedAccessOK: Boolean = {
         val cls = owner.enclosingSubClass
         if !cls.exists then
           pre.termSymbol.isPackageObject && accessWithin(pre.termSymbol.owner)
-        else {
-          val isConstructorAccessOK = isConstructor && ctx.owner.isConstructor
+        else
+          def isConstructorAccessOK = isConstructor && ctx.isSuperCallContext
           // allow accesses to types from arbitrary subclasses fixes #4737
           // don't perform this check for static members
           isType || pre.derivesFrom(cls) || isConstructorAccessOK || owner.is(ModuleClass)
-        }
-      end isProtectedAccessOK
+      }
 
       if pre eq NoPrefix then true
       else if isAbsent() then false

--- a/tests/neg/i25442.check
+++ b/tests/neg/i25442.check
@@ -1,0 +1,34 @@
+-- [E173] Reference Error: tests/neg/i25442/protected-constructors.scala:7:22 ------------------------------------------
+7 |class C extends B(new A(1)) // error
+  |                      ^
+  |   constructor A cannot be accessed as a member of protectedCtors.A from class C.
+  |     protected constructor A can only be accessed from class C in package protectedCtors or one of its subclasses.
+-- [E173] Reference Error: tests/neg/i25442/protected-constructors.scala:10:22 -----------------------------------------
+10 |class E extends D(new D(1)) // error
+   |                      ^
+   | constructor D cannot be accessed as a member of protectedCtors.D from class E.
+   |   protected constructor D can only be accessed from class E in package protectedCtors or one of its subclasses.
+-- Error: tests/neg/i25442/protected-constructors.scala:18:24 ----------------------------------------------------------
+18 |class J extends G(new F(1)) // error: protected primary in super args
+   |                        ^
+   |                        too many arguments for constructor F in class F: (): protectedCtors.F
+-- [E173] Reference Error: tests/neg/i25442/protected-constructors.scala:22:14 -----------------------------------------
+22 |  val k = new A(1) // error
+   |              ^
+   | constructor A cannot be accessed as a member of protectedCtors.A from class K.
+   |   protected constructor A can only be accessed from class K in package protectedCtors or one of its subclasses.
+-- [E173] Reference Error: tests/neg/i25442/protected-constructors.scala:27:28 -----------------------------------------
+27 |class N extends M(() => new A(2)) // error
+   |                            ^
+   | constructor A cannot be accessed as a member of protectedCtors.A from class N.
+   |   protected constructor A can only be accessed from class N in package protectedCtors or one of its subclasses.
+-- [E173] Reference Error: tests/neg/i25442/test.scala:7:15 ------------------------------------------------------------
+7 |  def t2 = new I(42) // error
+  |               ^
+  |               constructor I cannot be accessed as a member of I from class M.
+  |                 protected constructor I can only be accessed from class M or one of its subclasses.
+-- [E173] Reference Error: tests/neg/i25442/test.scala:8:35 ------------------------------------------------------------
+8 |  def this(x: Int) = { this(); new I(x) } // error
+  |                                   ^
+  |                             constructor I cannot be accessed as a member of I from class M.
+  |                               protected constructor I can only be accessed from class M or one of its subclasses.

--- a/tests/neg/i25442/protected-constructors.scala
+++ b/tests/neg/i25442/protected-constructors.scala
@@ -1,0 +1,27 @@
+package protectedCtors
+
+class A protected (x: Int)
+
+// Protected constructor in super call arguments (transitive parent)
+class B(a: A) extends A(a.hashCode)
+class C extends B(new A(1)) // error
+
+class D protected (x: Any)
+class E extends D(new D(1)) // error
+
+// Mixed visibility constructors
+class F protected (x: Int) {
+  def this() = this(0) // public secondary
+}
+class G(f: F) extends F(f.hashCode)
+class H extends G(new F()) // ok: public secondary in super args
+class J extends G(new F(1)) // error: protected primary in super args
+
+// new in primary constructor body
+class K extends A(42) {
+  val k = new A(1) // error
+}
+
+// Lambda in super call arguments
+class M(f: () => A) extends A(1)
+class N extends M(() => new A(2)) // error

--- a/tests/neg/i25442/test.scala
+++ b/tests/neg/i25442/test.scala
@@ -5,4 +5,5 @@ class I protected (x: Int) {
 class M protected () extends I(42) {
   def t1 = new M()   // ok
   def t2 = new I(42) // error
+  def this(x: Int) = { this(); new I(x) } // error
 }

--- a/tests/pos/i25442.scala
+++ b/tests/pos/i25442.scala
@@ -1,0 +1,18 @@
+package protectedCtorsPos
+
+class A protected (x: Int)
+
+// Super calls are allowed
+class B extends A(42)
+
+// Inner class extending protected parent
+class C extends A(42) {
+  class Inner extends A(1)
+}
+
+// Mixed visibility: public secondary constructor is accessible
+class D protected (x: Int) {
+  def this() = this(0)
+}
+class E(d: D) extends D(d.hashCode)
+class F extends E(new D())


### PR DESCRIPTION
Backports #25523 to the 3.3.8.

PR submitted by the release tooling.
[skip ci]