### PR TITLE
Backport "Fix crash when processing path dependent context functions using HKTs" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -858,6 +858,13 @@ object ProtoTypes {
     }
   }
 
+  def containsTypeParamRef(tp: Type)(using Context): Boolean =
+    tp.stripped match {
+      case tr: TypeParamRef => true
+      case AppliedType(_, args) => args.exists(containsTypeParamRef)
+      case _ => false
+    }
+
   /** Approximate occurrences of parameter types and uninstantiated typevars
    *  by wildcard types.
    */
@@ -865,7 +872,9 @@ object ProtoTypes {
     tp match {
     case tp: NamedType => // default case, inlined for speed
       val isPatternBoundTypeRef = tp.isInstanceOf[TypeRef] && tp.symbol.isPatternBound
+      val isImplicitTermRef = tp.isInstanceOf[TermRef] && tp.symbol.maybeOwner.isAnonymousFunction && tp.symbol.isParamOrAccessor && tp.symbol.is(Flags.Given) && containsTypeParamRef(tp.superType)
       if (isPatternBoundTypeRef) WildcardType(tp.underlying.bounds)
+      else if (isImplicitTermRef) wildApprox(tp.underlying, theMap, seen, internal)
       else if (tp.symbol.isStatic || (tp.prefix `eq` NoPrefix)) tp
       else tp.derivedSelect(wildApprox(tp.prefix, theMap, seen, internal))
     case tp @ AppliedType(tycon, args) =>

--- a/tests/neg/i25500.scala
+++ b/tests/neg/i25500.scala
@@ -1,0 +1,7 @@
+trait A[B[_]]:
+  type C
+
+def apply[D[_]](other: (a: A[D]) ?=> a.C): Any = ???
+
+def main =
+  apply(()) // error

--- a/tests/pos/i25500.scala
+++ b/tests/pos/i25500.scala
@@ -1,0 +1,13 @@
+trait A[B[_]]:
+  type C
+
+object A:
+  given A[Option]:
+    type C = Option[Int]
+
+  def apply[E[_], F](e: E[F])(using a: A[E]): a.C = ???
+
+def apply[D[_]](other: (a: A[D]) ?=> a.C): Any = ???
+
+def main =
+  apply(A(Option(5)))


### PR DESCRIPTION
Backports #25530 to the 3.3.8.

PR submitted by the release tooling.
[skip ci]