### PR TITLE
Backport "Regression test for #3403" to 3.3 LTS

### DIFF
--- a/tests/pos/3403/NamedImpl_2.java
+++ b/tests/pos/3403/NamedImpl_2.java
@@ -1,0 +1,11 @@
+package bug;
+
+import java.io.Serializable;
+import java.lang.annotation.Annotation;
+
+public class NamedImpl_2 implements Named_1 {
+
+    public Class<? extends Annotation> annotationType() {
+        return null;
+    }
+}

--- a/tests/pos/3403/Named_1.java
+++ b/tests/pos/3403/Named_1.java
@@ -1,0 +1,3 @@
+package bug;
+
+public @interface Named_1 {}

--- a/tests/pos/3403/test_3.scala
+++ b/tests/pos/3403/test_3.scala
@@ -1,0 +1,3 @@
+class C {
+  new bug.NamedImpl_2
+}


### PR DESCRIPTION
Backports #25521 to the 3.3.8.

PR submitted by the release tooling.
[skip ci]