### PR TITLE
Backport "fix: import resolution for Java" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -308,8 +308,17 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
         imp.importSym.info match
           case ImportType(expr) =>
             val pre = expr.tpe
-            val denot0 = pre.memberBasedOnFlags(name, required, excluded)
-              .accessibleFrom(pre)(using refctx)
+            def findMember(excluded: FlagSet) =
+              if ctx.isJava then
+                ctx.javaFindMember(name, pre, lookInCompanion = true, required, excluded)
+              else
+                pre.memberBasedOnFlags(name, required, excluded)
+                 .accessibleFrom(pre)(using refctx)
+            val denot0 = findMember(excluded)
+            var accessibleDenot = denot0.accessibleFrom(pre)(using refctx)
+            if !accessibleDenot.exists && denot0.hasAltWith(_.symbol.is(Private)) then
+              accessibleDenot =
+                findMember(excluded | Private).accessibleFrom(pre)(using refctx)
             // Pass refctx so that any errors are reported in the context of the
             // reference instead of the context of the import scope
             if denot0.exists then

--- a/tests/pos/i18530/Code.java
+++ b/tests/pos/i18530/Code.java
@@ -1,0 +1,11 @@
+package bug.code;
+
+import bug.actions.Smart.Action;
+
+import java.util.ArrayDeque;
+
+public class Code {
+    public static class Variable {
+        public ArrayDeque<Action> actions = new ArrayDeque<Action>();
+    }
+}

--- a/tests/pos/i18530/Smart.java
+++ b/tests/pos/i18530/Smart.java
@@ -1,0 +1,7 @@
+package bug.actions;
+
+public class Smart {
+    public abstract class Action {
+
+    }
+}

--- a/tests/pos/i18530/Test.scala
+++ b/tests/pos/i18530/Test.scala
@@ -1,0 +1,3 @@
+object Test {
+  val v = new bug.code.Code.Variable()
+}

--- a/tests/pos/i18531/Code.java
+++ b/tests/pos/i18531/Code.java
@@ -1,0 +1,8 @@
+package bug.code;
+
+import static bug.code.Symbol.*;
+
+public class Code {
+    public void constant(LoadableConstant c) {
+    }
+}

--- a/tests/pos/i18531/Constant.java
+++ b/tests/pos/i18531/Constant.java
@@ -1,0 +1,6 @@
+package bug.code;
+
+public interface Constant {
+    interface LoadableConstant extends Constant {
+    }
+}

--- a/tests/pos/i18531/Symbol.java
+++ b/tests/pos/i18531/Symbol.java
@@ -1,0 +1,4 @@
+package bug.code;
+
+public abstract class Symbol implements Constant {
+}

--- a/tests/pos/i18531/Test.scala
+++ b/tests/pos/i18531/Test.scala
@@ -1,0 +1,3 @@
+object Test {
+  val c = new bug.code.Code()
+}


### PR DESCRIPTION
Backports #25537 to the 3.3.8.

PR submitted by the release tooling.
[skip ci]