### PR TITLE
Backport "Regression tests for #25" to 3.3 LTS

### DIFF
--- a/compiler/test/dotc/run-test-pickling.excludelist
+++ b/compiler/test/dotc/run-test-pickling.excludelist
@@ -46,6 +46,8 @@ i12656.scala
 trait-static-forwarder
 i17255
 named-tuples-strawman-2.scala
+25-1
+25-2
 
 # typecheckErrors method unpickling
 typeCheckErrors.scala

--- a/tests/run/25-1/StringSearch.scala
+++ b/tests/run/25-1/StringSearch.scala
@@ -1,0 +1,5 @@
+package p
+
+trait C[T]
+trait Search[M] { def search(input: M): C[Int] = null }
+object StringSearch extends Search[String] { }

--- a/tests/run/25-1/Test.java
+++ b/tests/run/25-1/Test.java
@@ -1,0 +1,7 @@
+// scalajs: --skip
+
+public class Test {
+  public static void main(String[] args) {
+    p.StringSearch.search("test");
+  }
+}

--- a/tests/run/25-2/Bar.scala
+++ b/tests/run/25-2/Bar.scala
@@ -1,0 +1,7 @@
+package p
+
+abstract class Foo {
+  type T
+  def f(x: T): List[T] = List()
+}
+object Bar extends Foo { type T = String }

--- a/tests/run/25-2/Test.java
+++ b/tests/run/25-2/Test.java
@@ -1,0 +1,7 @@
+// scalajs: --skip
+
+public class Test {
+  public static void main(String[] args) {
+    p.Bar.f("");
+  }
+}


### PR DESCRIPTION
Backports #25536 to the 3.3.8.

PR submitted by the release tooling.
[skip ci]