### PR TITLE
Backport "Fixes #25482: Ensure package transformation properly handles language imports in InstrumentCoverage" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/InstrumentCoverage.scala
+++ b/compiler/src/dotty/tools/dotc/transform/InstrumentCoverage.scala
@@ -400,8 +400,10 @@ class InstrumentCoverage extends MacroTransform with IdentityDenotTransformer:
 
           case tree: PackageDef =>
             if isFileIncluded(tree.srcPos.sourcePos.source) && isClassIncluded(tree.symbol) then
-              // only transform the statements of the package
-              cpy.PackageDef(tree)(tree.pid, transform(tree.stats))
+              // Use transformStats (not transform) to process statements with updated context.
+              // This ensures language imports like `scala.language.unsafeNulls` are properly
+              // processed for subsequent statements in the package.
+              cpy.PackageDef(tree)(tree.pid, transformStats(tree.stats, tree.symbol))
             else
               tree
 

--- a/tests/coverage/pos/i25482.scala
+++ b/tests/coverage/pos/i25482.scala
@@ -1,0 +1,12 @@
+//> using options -Yexplicit-nulls
+
+import scala.language.unsafeNulls
+
+object Lookup:
+
+  abstract class AbstractFile2:
+    def lookupName(name: String, directory: Boolean): AbstractFile2 | Null
+
+  private final def lookupPath2(base: AbstractFile2, pathParts: Seq[String]): AbstractFile2 | Null =
+    var file: AbstractFile2 | Null = base
+    file.lookupName(pathParts.last, true)

--- a/tests/coverage/pos/i25482.scoverage.check
+++ b/tests/coverage/pos/i25482.scoverage.check
@@ -1,0 +1,88 @@
+# Coverage data, format version: 3.0
+# Statement data:
+# - id
+# - source path
+# - package name
+# - class name
+# - class type (Class, Object or Trait)
+# - full class name
+# - method name
+# - start offset
+# - end offset
+# - line number
+# - symbol name
+# - tree name
+# - is branch
+# - invocations count
+# - is ignored
+# - description (can be multi-line)
+# '' sign
+# ------------------------------------------
+0
+i25482.scala
+<empty>
+Lookup
+Object
+<empty>.Lookup
+lookupPath2
+342
+379
+12
+lookupName
+Apply
+false
+0
+false
+file.lookupName(pathParts.last, true)
+
+1
+i25482.scala
+<empty>
+Lookup
+Object
+<empty>.Lookup
+lookupPath2
+358
+372
+12
+last
+Select
+false
+0
+false
+pathParts.last
+
+2
+i25482.scala
+<empty>
+Lookup
+Object
+<empty>.Lookup
+lookupPath2
+374
+378
+12
+<none>
+Literal
+false
+0
+false
+true
+
+3
+i25482.scala
+<empty>
+Lookup
+Object
+<empty>.Lookup
+lookupPath2
+197
+226
+10
+lookupPath2
+DefDef
+false
+0
+false
+private final def lookupPath2
+


### PR DESCRIPTION
Backports #25546 to the 3.3.8.

PR submitted by the release tooling.
[skip ci]