### PR TITLE
Backport "bugfix: Fix issues with Scala JS and the presentation compiler" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/backend/sjs/JSDefinitions.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSDefinitions.scala
@@ -19,7 +19,13 @@ object JSDefinitions {
     ctx.platform.asInstanceOf[SJSPlatform].jsDefinitions
 }
 
-final class JSDefinitions()(using Context) {
+final class JSDefinitions() {
+
+  private var initCtx: Context = uninitialized
+  private given currentContext[Dummy_so_its_a_def]: Context = initCtx
+
+  def init()(using Context): Unit =
+    this.initCtx = ctx
 
   @threadUnsafe lazy val InlineAnnotType: TypeRef = requiredClassRef("scala.inline")
   def InlineAnnot(using Context) = InlineAnnotType.symbol.asClass

--- a/compiler/src/dotty/tools/dotc/config/Platform.scala
+++ b/compiler/src/dotty/tools/dotc/config/Platform.scala
@@ -12,6 +12,11 @@ import core.Flags.Module
  */
 abstract class Platform {
 
+  /** Initialize platform-specific definitions for the current run.
+   *  Called at the start of each compilation run.
+   */
+  def init()(using Context): Unit = ()
+
   /** The root symbol loader. */
   def rootLoader(root: TermSymbol)(using Context): SymbolLoader
 

--- a/compiler/src/dotty/tools/dotc/config/SJSPlatform.scala
+++ b/compiler/src/dotty/tools/dotc/config/SJSPlatform.scala
@@ -12,10 +12,13 @@ object SJSPlatform {
     ctx.platform.asInstanceOf[SJSPlatform]
 }
 
-class SJSPlatform()(using Context) extends JavaPlatform {
+class SJSPlatform extends JavaPlatform {
 
   /** Scala.js-specific definitions. */
   val jsDefinitions: JSDefinitions = new JSDefinitions()
+
+  override def init()(using Context): Unit =
+    jsDefinitions.init()
 
   /** Is the SAMType `cls` also a SAM under the rules of the Scala.js back-end? */
   override def isSam(cls: ClassSymbol)(using Context): Boolean =

--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -908,6 +908,7 @@ object Contexts {
      */
     def initialize()(using Context): Unit = {
       _platform = newPlatform
+      platform.init()
       definitions.init()
     }
 

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/ScalaJSCompletionsSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/ScalaJSCompletionsSuite.scala
@@ -53,4 +53,20 @@ class ScalaJSCompletionsSuite extends BaseCompletionSuite {
         |onbeforeunload: scala.scalajs.js.Function1[BeforeUnloadEvent, ?]
         |""".stripMargin
     )
+
+  @Test def union =
+    check(
+      """
+        |
+        |import org.scalajs.dom
+        |import org.scalajs.dom.WebSocket
+        |
+        |object ChatApp:
+        |  val foo: String | Unit = "blah"
+        |  foo@@
+        |""".stripMargin,
+      """
+        |foo: String | Unit
+        |""".stripMargin
+    )
 }


### PR DESCRIPTION
Backports #25550 to the 3.3.8.

PR submitted by the release tooling.
[skip ci]