### PR TITLE
Backport "Remove redundant mapOver in fixThisTypeModuleClassReferences" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/inlines/Inlines.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inlines.scala
@@ -550,12 +550,11 @@ object Inlines:
         TreeTypeMap(
           typeMap = new TypeMap:
             override def stopAt = StopAt.Package
-            def apply(t: Type) = mapOver {
+            def apply(t: Type) =
               t match
                 case ThisType(tref @ TypeRef(prefix, _)) if tref.symbol.flags.is(Module) && !owners.contains(tref.symbol) =>
                   TermRef(apply(prefix), tref.symbol.companionModule)
                 case _ => mapOver(t)
-            }
         ).typeMap(tpe)
 
       if !hasOpaqueProxies && !hasOpaquesInResultFromCallWithTransparentContext then inlined

--- a/tests/pos/i25362/Macro_1.scala
+++ b/tests/pos/i25362/Macro_1.scala
@@ -1,0 +1,15 @@
+package example
+import scala.deriving.Mirror
+import scala.quoted.*
+
+class TC[A] {
+  type Out
+}
+
+object TC {
+  transparent inline def derived[Left: Mirror.ProductOf as m]: TC[Left] =
+    ${ derivedImpl[Left, m.MirroredElemTypes] }
+
+  private def derivedImpl[Left: Type, LeftTypes: Type](using Quotes): Expr[TC[Left]] =
+    '{ new TC[Left] { type Out = LeftTypes } }
+}

--- a/tests/pos/i25362/Test_2.scala
+++ b/tests/pos/i25362/Test_2.scala
@@ -1,0 +1,14 @@
+package example
+
+opaque type BigTuple <: Repr = Repr
+final case class Repr(
+  f1: Int, f2: Int, f3: Int, f4: Int, f5: Int,
+  f6: Int, f7: Int, f8: Int, f9: Int, f10: Int,
+  f11: Int, f12: Int, f13: Int, f14: Int, f15: Int,
+  f16: Int, f17: Int, f18: Int, f19: Int, f20: Int,
+  f21: Int, f22: Int, f23: Int, f24: Int, f25: Int,
+)
+
+class test {
+  val merger = TC.derived[BigTuple]
+}


### PR DESCRIPTION
Backports #25440 to the 3.3.8.

PR submitted by the release tooling.
[skip ci]