### PR TITLE
Backport "Be honest about the nullability of ConsoleReporter.reader and SourcePosition.outer." to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/ConsoleReporter.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/ConsoleReporter.scala
@@ -10,7 +10,7 @@ import Diagnostic.Error
   * This class implements a Reporter that displays messages on a text console
   */
 class ConsoleReporter(
-  reader: BufferedReader = Console.in,
+  reader: BufferedReader | Null = Console.in,
   writer: PrintWriter = new PrintWriter(Console.err, true),
   echoer: PrintWriter = new PrintWriter(Console.out, true)
 ) extends ConsoleReporter.AbstractConsoleReporter {

--- a/compiler/src/dotty/tools/dotc/reporting/Reporter.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/Reporter.scala
@@ -2,8 +2,6 @@ package dotty.tools
 package dotc
 package reporting
 
-import scala.language.unsafeNulls
-
 import dotty.tools.dotc.core.Contexts.*
 import dotty.tools.dotc.core.Mode
 import dotty.tools.dotc.core.Symbols.{NoSymbol, Symbol}
@@ -41,7 +39,7 @@ object Reporter {
     (mc, ctx) => ctx.reporter.report(mc)(using ctx)
 
   /** Show prompt if `-Xprompt` is passed as a flag to the compiler */
-  def displayPrompt(reader: BufferedReader, writer: PrintWriter): Unit = {
+  def displayPrompt(reader: BufferedReader | Null, writer: PrintWriter): Unit = {
     writer.println()
     writer.print("a)bort, s)tack, r)esume: ")
     writer.flush()

--- a/compiler/src/dotty/tools/dotc/util/SourcePosition.scala
+++ b/compiler/src/dotty/tools/dotc/util/SourcePosition.scala
@@ -2,7 +2,7 @@ package dotty.tools
 package dotc
 package util
 
-import scala.language.unsafeNulls
+import scala.annotation.tailrec
 
 import printing.{Showable, Printer}
 import printing.Texts.*
@@ -11,7 +11,7 @@ import Spans.{Span, NoSpan}
 import scala.annotation.internal.sharable
 
 /** A source position is comprised of a span and a source file */
-case class SourcePosition(source: SourceFile, span: Span, outer: SourcePosition = NoSourcePosition)
+case class SourcePosition(source: SourceFile, span: Span, outer: SourcePosition | Null  = NoSourcePosition)
 extends SrcPos, interfaces.SourcePosition, Showable {
 
   def sourcePos(using Context) = this
@@ -66,8 +66,8 @@ extends SrcPos, interfaces.SourcePosition, Showable {
   def focus   : SourcePosition = withSpan(span.focus)
   def toSynthetic: SourcePosition = withSpan(span.toSynthetic)
 
-  def outermost: SourcePosition =
-    if outer == null || outer == NoSourcePosition then this else outer.outermost
+  @tailrec final def outermost: SourcePosition =
+    if outer == null then this else outer.outermost
 
   /** Inner most position that is contained within the `outermost` position.
    *  Most precise position that comes from the call site.
@@ -75,7 +75,7 @@ extends SrcPos, interfaces.SourcePosition, Showable {
   def nonInlined: SourcePosition = {
     val om = outermost
     def rec(self: SourcePosition): SourcePosition =
-      if om.contains(self) then self else rec(self.outer)
+      if om.contains(self) || self.outer == null then self else rec(self.outer)
     rec(this)
   }
 

--- a/compiler/test/dotty/tools/dotc/reporting/TestReporter.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/TestReporter.scala
@@ -42,7 +42,7 @@ extends Reporter with UniqueMessagePositions with HideNonSensicalMessages with M
 
   protected final def inlineInfo(pos: SourcePosition)(using Context): String =
     if (pos.exists) {
-      if (pos.outer.exists)
+      if (pos.outer != null)
         i"\ninlined at ${pos.outer}:\n" + inlineInfo(pos.outer)
       else ""
     }

--- a/compiler/test/dotty/tools/dotc/reporting/TestReporter.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/TestReporter.scala
@@ -17,13 +17,6 @@ import Diagnostic.*
 
 import scala.collection.mutable
 import scala.jdk.CollectionConverters.*
-import util.SourcePosition
-import core.Contexts.*
-import Diagnostic.*
-import dotty.Properties
-import interfaces.Diagnostic.{ERROR, WARNING}
-
-import scala.io.Codec
 
 class TestReporter protected (outWriter: PrintWriter, logLevel: Int)
 extends Reporter with UniqueMessagePositions with HideNonSensicalMessages with MessageRendering {


### PR DESCRIPTION
Backports #25561 to the 3.3.8.

PR submitted by the release tooling.
[skip ci]