### PR TITLE
Backport "Normalize tuple types when typing patterns" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1752,7 +1752,7 @@ trait Applications extends Compatibility {
         for (argType <- argTypes) assert(!isBounds(argType), unapplyApp.tpe.show)
         val bunchedArgs = argTypes match {
           case argType :: Nil =>
-            if (args.lengthCompare(1) > 0 && Feature.autoTuplingEnabled && defn.isTupleNType(argType)) untpd.Tuple(args) :: Nil
+            if (args.lengthCompare(1) > 0 && Feature.autoTuplingEnabled && defn.isTupleNType(argType.normalizedTupleType)) untpd.Tuple(args) :: Nil
             else args
           case _ => args
         }

--- a/tests/pos/i22923.scala
+++ b/tests/pos/i22923.scala
@@ -1,0 +1,10 @@
+object Test {
+  object E1 {
+    def unapply(x: Int): Some[Tuple.Map[(Int, Int), Option]] = ???
+  }
+
+  val s: Int = ???
+  s match {
+    case E1(x, y) => x
+  }
+}

--- a/tests/pos/i23155b.scala
+++ b/tests/pos/i23155b.scala
@@ -1,0 +1,6 @@
+object Unpack_T {
+  (1, 2) match {
+    case Unpack_T(first, _) => first
+  }
+  def unapply(e: (Int, Int)): Some[Int *: Int *: EmptyTuple] = ???
+}


### PR DESCRIPTION
Backports #25335 to the 3.3.8.

PR submitted by the release tooling.
[skip ci]