### PR TITLE
Backport "Detect `InsertedApply` on `Apply` to break synthetic apply loops, not just `Select`" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -114,7 +114,7 @@ object Typer {
    *  apply of a function class?
    */
   private[typer] def isSyntheticApply(tree: tpd.Tree): Boolean = tree match {
-    case tree: tpd.Select => tree.hasAttachment(InsertedApply)
+    case _: (tpd.Select | tpd.Apply) => tree.hasAttachment(InsertedApply)
     case TypeApply(fn, targs) => isSyntheticApply(fn) && targs.forall(_.isInstanceOf[tpd.InferredTypeTree])
     case _ => false
   }

--- a/tests/neg/24782.check
+++ b/tests/neg/24782.check
@@ -1,0 +1,6 @@
+-- [E050] Type Error: tests/neg/24782.scala:4:28 -----------------------------------------------------------------------
+4 |  def f(using pure: Pure) = S(s => pure(s)) // error (but no compiler crash / stack overflow)
+  |                            ^
+  |                            expression does not take more parameters
+  |
+  | longer explanation available when compiling with `-explain`

--- a/tests/neg/24782.scala
+++ b/tests/neg/24782.scala
@@ -1,0 +1,5 @@
+object S {
+  trait F[A]
+  type Pure = [a] => a => F[a]
+  def f(using pure: Pure) = S(s => pure(s)) // error (but no compiler crash / stack overflow)
+}

--- a/tests/pos/i14907.scala
+++ b/tests/pos/i14907.scala
@@ -5,7 +5,7 @@ object Module {
     case 1 => Any *: Fill[0]
   }
   extension[N <: Int] (f: Fun[N])
-    def apply: Fill[N] => Any = ???
+    def apply(): Fill[N] => Any = ???
 
-  Fun[1]()(???)
+  Fun[1]()()(???)
 }


### PR DESCRIPTION
Backports #25463 to the 3.3.8.

PR submitted by the release tooling.
[skip ci]