### PR TITLE
Backport "Bump Scala CLI to 1.12.5 (was 1.12.4) and Coursier to 2.1.25-M24 (was 2.1.25-M23" to 3.3 LTS

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -801,5 +801,5 @@ jobs:
         with:
           fetch-depth: 0
       - uses: coursier/cache-action@v8
-      - uses: VirtusLab/scala-cli-setup@v1.12.4
+      - uses: VirtusLab/scala-cli-setup@v1.12.5
       - run: scala-cli format --check


### PR DESCRIPTION
Backports #25592 to the 3.3.8.

PR submitted by the release tooling.
[skip ci]