### PR TITLE
Backport "Propagate expected types when rechecking match return expressions" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/Recheck.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Recheck.scala
@@ -351,9 +351,6 @@ abstract class Recheck extends Phase, SymTransformer:
         def toAvoid(tp: NamedType) =
            tp.symbol.is(Case) && tp.symbol.owner.isContainedIn(ctx.owner)
 
-      val rawType = recheck(tree.expr)
-      val ownType = avoidMap(rawType)
-
       // The pattern matching translation, which runs before this phase
       // sometimes instantiates return types with singleton type alternatives
       // but the returned expression is widened. We compensate by widening the expected
@@ -366,7 +363,10 @@ abstract class Recheck extends Phase, SymTransformer:
         case tp: AndOrType => tp.derivedAndOrType(widened(tp.tp1), widened(tp.tp2))
         case tp @ AnnotatedType(tp1, ann) => tp.derivedAnnotatedType(widened(tp1), ann)
         case _ => tp
-      checkConforms(ownType, widened(tree.from.symbol.returnProto), tree)
+      val expected = widened(tree.from.symbol.returnProto)
+      val rawType = recheck(tree.expr, expected)
+      val ownType = avoidMap(rawType)
+      checkConforms(ownType, expected, tree)
       defn.NothingType
     end recheckReturn
 
@@ -575,5 +575,3 @@ class TestRecheck extends Recheck:
   def phaseName: String = "recheck"
   override def isEnabled(using Context) = ctx.settings.YrecheckTest.value
   def newRechecker()(using Context): Rechecker = Rechecker(ctx)
-
-

--- a/tests/neg-custom-args/captures/i25320a.check
+++ b/tests/neg-custom-args/captures/i25320a.check
@@ -1,0 +1,11 @@
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/i25320a.scala:6:9 ----------------------------------------
+6 |    case Box(y) => y  // error
+  |         ^^^^^^^^^^^
+  |         Found:    A^{y, any}
+  |         Required: A
+  |
+  |         Note that capability `y` cannot flow into capture set {}.
+  |
+  |         where:    any is a root capability in the type of value x7
+  |
+  | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/i25320a.scala
+++ b/tests/neg-custom-args/captures/i25320a.scala
@@ -1,0 +1,6 @@
+import language.experimental.captureChecking
+sealed trait AbstractBox[A]
+case class Box[A](x: A) extends AbstractBox[A]
+def leak[A](x: Box[A^]): A =
+  x match
+    case Box(y) => y  // error

--- a/tests/neg-custom-args/captures/i25320b.check
+++ b/tests/neg-custom-args/captures/i25320b.check
@@ -1,0 +1,9 @@
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/i25320b.scala:6:16 ---------------------------------------
+6 |    case Box(y) => Box(y)  // error
+  |                ^^^^^^^^^
+  |                Found:    Box[Foo]^'s1
+  |                Required: Box[Foo^{y}]^'s2
+  |
+  |                Note that capability `y` cannot flow into capture set {}.
+  |
+  | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/i25320b.scala
+++ b/tests/neg-custom-args/captures/i25320b.scala
@@ -1,0 +1,8 @@
+import language.experimental.captureChecking
+case class Foo()
+case class Box[A](x: A)
+def fooLeak(x: Box[Foo^]): Box[Foo] = {
+  x match {
+    case Box(y) => Box(y)  // error
+  }
+}

--- a/tests/neg-custom-args/captures/match-return-avoid.check
+++ b/tests/neg-custom-args/captures/match-return-avoid.check
@@ -1,0 +1,9 @@
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/match-return-avoid.scala:8:11 ----------------------------
+8 |    case y => Box(y) // error
+  |           ^^^^^^^^^
+  |           Found:    Box[Foo]^'s1
+  |           Required: Box[Foo^{y}]^'s2
+  |
+  |           Note that capability `y` cannot flow into capture set {}.
+  |
+  | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/match-return-avoid.scala
+++ b/tests/neg-custom-args/captures/match-return-avoid.scala
@@ -1,0 +1,8 @@
+import language.experimental.captureChecking
+
+case class Foo()
+case class Box[A](x: A)
+
+def f(x: Foo^): Box[Foo^{}] =
+  x match
+    case y => Box(y) // error


### PR DESCRIPTION
Backports #25580 to the 3.3.8.

PR submitted by the release tooling.