### PR TITLE
Backport "Use `dealiasKeepRefiningAnnots` in `AvoidMap`" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -475,7 +475,7 @@ object TypeOps:
       try
         tp match
           case tp: TermRef if toAvoid(tp) =>
-            tp.info.widenExpr.dealias match {
+            tp.info.widenExpr.dealiasKeepRefiningAnnots match {
               case info: SingletonType => apply(info)
               case info => range(defn.NothingType, apply(info))
             }

--- a/tests/pos/annot-refining-avoid.scala
+++ b/tests/pos/annot-refining-avoid.scala
@@ -1,0 +1,11 @@
+import scala.annotation.RefiningAnnotation
+
+class myAnnot extends RefiningAnnotation
+
+type Refined = Int @myAnnot
+
+def test =
+  val result =
+    val tmp: Refined = ???
+    tmp
+  result: Refined


### PR DESCRIPTION
Backports #25609 to the 3.3.8.

PR submitted by the release tooling.
[skip ci]