### PR TITLE
Backport "Error mentions bad _1 selector" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -2404,6 +2404,12 @@ extends NamingMsg(DoubleDefinitionID):
             i"have the same$nameAnd type $erasedType after erasure.$hint"
         }
       }
+      else if decl.is(CaseAccessor) || previousDecl.is(CaseAccessor) then
+        val selector = """_(\d+)""".r
+        decl.name.toString match
+          case selector(n) =>
+            s"${decl.name} is a case element selector and must name the ${n}th element"
+          case _ => ""
       else ""
     def symLocation(sym: Symbol) = {
       val lineDesc =

--- a/tests/neg/i4520.check
+++ b/tests/neg/i4520.check
@@ -1,0 +1,9 @@
+-- [E120] Naming Error: tests/neg/i4520.scala:6:46 ---------------------------------------------------------------------
+6 |case class LabeledEdge[T, U](_1: T, label: U, _2: T) extends EdgeLike[T] // error
+  |                                              ^
+  |                                              Conflicting definitions:
+  |                                              def _2: U in class LabeledEdge at line 6 and
+  |                                              val _2: T in class LabeledEdge at line 6
+  |                                              _2 is a case element selector and must name the 2th element
+  |
+  | longer explanation available when compiling with `-explain`

--- a/tests/neg/i4520.scala
+++ b/tests/neg/i4520.scala
@@ -1,0 +1,6 @@
+trait EdgeLike[T] {
+  def _1: T
+  def _2: T
+}
+
+case class LabeledEdge[T, U](_1: T, label: U, _2: T) extends EdgeLike[T] // error


### PR DESCRIPTION
Backports #25616 to the 3.3.8.

PR submitted by the release tooling.
[skip ci]