### PR TITLE
Backport "Do not simplify isInstanceOf if unrelated types might be subtypes at run-time" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/JavaPlatform.scala
+++ b/compiler/src/dotty/tools/dotc/config/JavaPlatform.scala
@@ -76,4 +76,8 @@ class JavaPlatform extends Platform {
 
   def newClassLoader(bin: AbstractFile)(using Context): SymbolLoader =
     new ClassfileLoader(bin)
+
+  def typeMightBeSubtypeAtRuntime(c: Symbol, potentialSuperClass: Symbol)(using Context): Boolean =
+    // On the JVM, we add an implementation of Serializable to everything
+    potentialSuperClass == defn.JavaSerializableClass
 }

--- a/compiler/src/dotty/tools/dotc/config/Platform.scala
+++ b/compiler/src/dotty/tools/dotc/config/Platform.scala
@@ -51,4 +51,12 @@ abstract class Platform {
   final def hasMainMethod(sym: Symbol)(using Context): Boolean =
     sym.info.member(nme.main).hasAltWith(d =>
       isMainMethod(d.symbol) && (sym.is(Module) || d.symbol.isStatic))
+
+  /**
+   * Whether instances of the class represented by the class symbol `c` **might** be a subtype of
+   * the class represented by the class symbol `potentialSuperClass` at runtime on this platform.
+   * This does not imply that they always will be,
+   * only that the compiler cannot fold `x.isInstanceOf[potentialSuperClass]` to false for for `x: c`
+   */
+  def typeMightBeSubtypeAtRuntime(c: Symbol, potentialSuperClass: Symbol)(using Context): Boolean
 }

--- a/compiler/src/dotty/tools/dotc/config/SJSPlatform.scala
+++ b/compiler/src/dotty/tools/dotc/config/SJSPlatform.scala
@@ -35,4 +35,10 @@ class SJSPlatform extends JavaPlatform {
    */
   override def shouldReceiveJavaSerializationMethods(sym: ClassSymbol)(using Context): Boolean =
     !sym.isSubClass(jsDefinitions.JSAnyClass)
+
+  override def typeMightBeSubtypeAtRuntime(c: Symbol, potentialSuperClass: Symbol)(using Context): Boolean =
+    // because we deal with primitive types, we also have to deal with the boxed version,
+    // otherwise the compiler will error with, e.g., "cannot test if scala.Double is a subtype of java.lang.Integer"
+    (defn.ScalaNumericValueClasses()(c) || defn.ScalaNumericBoxedClasses()(c)) &&
+      (defn.ScalaNumericValueClasses()(potentialSuperClass) || defn.ScalaNumericBoxedClasses()(potentialSuperClass))
 }

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -2049,8 +2049,11 @@ class Definitions {
   val ScalaNumericValueClasses: PerRun[collection.Set[Symbol]] = new PerRun(ScalaNumericValueTypes.map(_.symbol))
   val ScalaValueClasses: PerRun[collection.Set[Symbol]]        = new PerRun(ScalaValueTypes.map(_.symbol))
 
+  val ScalaNumericBoxedClasses: PerRun[collection.Set[Symbol]] = new PerRun(
+    Set(BoxedByteClass, BoxedShortClass, BoxedCharClass, BoxedIntClass, BoxedLongClass, BoxedFloatClass, BoxedDoubleClass)
+  )
   val ScalaBoxedClasses: PerRun[collection.Set[Symbol]] = new PerRun(
-    Set(BoxedByteClass, BoxedShortClass, BoxedCharClass, BoxedIntClass, BoxedLongClass, BoxedFloatClass, BoxedDoubleClass, BoxedUnitClass, BoxedBooleanClass)
+    ScalaNumericBoxedClasses() `union` Set(BoxedUnitClass, BoxedBooleanClass)
   )
 
   private val valueTypeEnc = mutable.Map[TypeName, PrimitiveClassEnc]()

--- a/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
@@ -218,8 +218,9 @@ object TypeTestsCasts {
             !(!testCls.isPrimitiveValueClass && foundCls.isPrimitiveValueClass) &&
                // foundCls can be `Boolean`, while testCls is `Integer`
                // it can happen in `(3: Boolean | Int).isInstanceOf[Int]`
-            !foundCls.isDerivedValueClass && !testCls.isDerivedValueClass
+            !foundCls.isDerivedValueClass && !testCls.isDerivedValueClass &&
                // we don't have the logic to handle derived value classes
+            !ctx.platform.typeMightBeSubtypeAtRuntime(foundCls, testCls)
 
           /** Check whether a runtime test that a value of `foundCls` can be a `testCls`
            *  can be true in some cases. Issues a warning or an error otherwise.
@@ -242,12 +243,7 @@ object TypeTestsCasts {
               else true
             end check
 
-            val foundEffectiveClass = effectiveClass(expr.tpe.widen)
-
-            if foundEffectiveClass.isPrimitiveValueClass && !testCls.isPrimitiveValueClass then
-              report.error(em"cannot test if value of $exprType is a reference of $testCls", tree.srcPos)
-              false
-            else foundClasses.exists(check)
+            foundClasses.exists(check)
           end checkSensical
 
           val tp = if expr.tpe.isPrimitiveValueType then defn.boxedType(expr.tpe) else expr.tpe
@@ -266,7 +262,7 @@ object TypeTestsCasts {
             }
             else if (testCls.isPrimitiveValueClass)
               foundClsSyms match
-                case List(cls) if cls.isPrimitiveValueClass =>
+                case List(cls) if cls.isPrimitiveValueClass && !ctx.platform.typeMightBeSubtypeAtRuntime(testCls, cls) =>
                   constant(expr, Literal(Constant(foundClsSyms.head == testCls)))
                 case _ =>
                   transformIsInstanceOf(
@@ -362,7 +358,7 @@ object TypeTestsCasts {
           val isTrusted = tree.hasAttachment(PatternMatcher.TrustedTypeTestKey)
           checkTypePattern(expr.tpe, argType, expr.srcPos, isTrusted)
           transformTypeTest(expr, argType,
-            flagUnrelated = enclosingInlineds.isEmpty) // if test comes from inlined code, dont't flag it even if it always false
+            flagUnrelated = enclosingInlineds.isEmpty) // if test comes from inlined code, don't flag it even if it always false
         }
         else if (sym.isTypeCast)
           transformAsInstanceOf(erasure(tree.args.head.tpe))

--- a/tests/neg/typetest.scala
+++ b/tests/neg/typetest.scala
@@ -1,7 +1,0 @@
-object Test {
-
-  val i: Int = 1
-
-  println(i.isInstanceOf[Object])                     // error
-}
-

--- a/tests/run/i1354b.check
+++ b/tests/run/i1354b.check
@@ -1,0 +1,6 @@
+0
+false
+5
+1
+true
+true

--- a/tests/run/i1354b.scala
+++ b/tests/run/i1354b.scala
@@ -1,15 +1,14 @@
-// scalajs: --skip
-// (because scala.js has special semantics for numbers)
+// special version if i1354 that applies to Scala.js as well
 
 object Test {
   def foo(a: Int | Double) = a match {
-    case a: (Float | Boolean) => 1
+    case a: (Char | Boolean) => 1
     case _ => 0
   }
 
-  def typeTest(a: Int | Double) = a.isInstanceOf[Float | Boolean] // false
+  def typeTest(a: Int | Double) = a.isInstanceOf[Char | Boolean] // false
 
-  def typeCast(a: Int | Double) = a.asInstanceOf[Float | Boolean] // no error
+  def typeCast(a: Int | Double) = a.asInstanceOf[Char | Boolean] // no error
 
   def main(args: Array[String]): Unit = {
     println(foo(4))

--- a/tests/run/instanceof-serializable.check
+++ b/tests/run/instanceof-serializable.check
@@ -1,0 +1,2 @@
+true
+true

--- a/tests/run/instanceof-serializable.scala
+++ b/tests/run/instanceof-serializable.scala
@@ -1,0 +1,10 @@
+// scalajs: --skip
+// (this special case is JVM-only)
+
+object Foo
+def foo: Any = Foo
+
+object Test:
+  def main(args: Array[String]): Unit =
+    println(Foo.isInstanceOf[Serializable]) // should not be constant-folded to false, at runtime it is on the JVM
+    println(foo.isInstanceOf[Serializable])

--- a/tests/run/typetest.check
+++ b/tests/run/typetest.check
@@ -1,0 +1,2 @@
+true
+true

--- a/tests/run/typetest.scala
+++ b/tests/run/typetest.scala
@@ -1,0 +1,6 @@
+object Test:
+  def main(args: Array[String]): Unit =
+    val i: Int = 1
+    println(i.isInstanceOf[Object])
+    println(1.isInstanceOf[Object])
+

--- a/tests/sjs-junit/test/org/scalajs/testsuite/compiler/RegressionTestScala3.scala
+++ b/tests/sjs-junit/test/org/scalajs/testsuite/compiler/RegressionTestScala3.scala
@@ -156,6 +156,46 @@ class RegressionTestScala3 {
     val c = Array.ofDim[Unit](0, 0)
     assertSame(classOf[Array[Array[Unit]]], c.getClass())
   }
+
+  @Test def issue25097(): Unit = {
+    val foo: Any = 1.0
+    assertTrue(foo.isInstanceOf[Int])
+
+    // should not get constant-folded incorrectly earlier in the pipeline:
+    // (which is why we cannot use fancier asserts here, having the specific 'constant.isInstanceOf[Number]' shape is the point)
+
+    assertTrue("1.0 instanceof Byte", 1.0.isInstanceOf[Byte])
+    assertTrue("1.0 instanceof Short", 1.0.isInstanceOf[Short])
+    assertTrue("1.0 instanceof Int", 1.0.isInstanceOf[Int])
+    assertTrue("1.0 instanceof Float", 1.0.isInstanceOf[Float])
+    assertTrue("1.0 instanceof Double", 1.0.isInstanceOf[Double])
+
+    assertFalse("128 instanceof Byte", 128.isInstanceOf[Byte])
+    assertTrue("128 instanceof Short", 128.isInstanceOf[Short])
+    assertTrue("128 instanceof Int", 128.isInstanceOf[Int])
+    assertTrue("128 instanceof Float", 128.isInstanceOf[Float])
+    assertTrue("128 instanceof Double", 128.isInstanceOf[Double])
+
+    assertFalse("32768 instanceof Byte", 32768.isInstanceOf[Byte])
+    assertFalse("32768 instanceof Short", 32768.isInstanceOf[Short])
+    assertTrue("32768 instanceof Int", 32768.isInstanceOf[Int])
+    assertTrue("32768 instanceof Float", 32768.isInstanceOf[Float])
+    assertTrue("32768 instanceof Double", 32768.isInstanceOf[Double])
+
+    assertFalse("2147483647 instanceof Byte", 2147483647.isInstanceOf[Byte])
+    assertFalse("2147483647 instanceof Short", 2147483647.isInstanceOf[Short])
+    assertTrue("2147483647 instanceof Int", 2147483647.isInstanceOf[Int])
+    assertFalse("2147483647 instanceof Float", 2147483647.isInstanceOf[Float]) // cannot be represented exactly as a float
+    assertTrue("2147483647 instanceof Double", 2147483647.isInstanceOf[Double])
+
+    assertFalse("2147483648.0 instanceof Byte", 2147483648.0.isInstanceOf[Byte])
+    assertFalse("2147483648.0 instanceof Short", 2147483648.0.isInstanceOf[Short])
+    assertFalse("2147483648.0 instanceof Int", 2147483648.0.isInstanceOf[Int])
+    assertTrue("2147483648.0 instanceof Float", 2147483648.0.isInstanceOf[Float])
+    assertTrue("2147483648.0 instanceof Double", 2147483648.0.isInstanceOf[Double])
+
+    assertTrue("1: jl.Integer instanceof jl.Double", (1: java.lang.Integer).isInstanceOf[java.lang.Double]) // ensure the target being boxed also works
+  }
 }
 
 object RegressionTestScala3 {


### PR DESCRIPTION
Backports #25535 to the 3.3.8.

PR submitted by the release tooling.
[skip ci]