### PR TITLE
Backport "Use `<sup>` tags for exponents in Scaladoc comments" to 3.3 LTS

### DIFF
--- a/scaladoc-testcases/src/tests/i25517.scala
+++ b/scaladoc-testcases/src/tests/i25517.scala
@@ -1,0 +1,27 @@
+package tests.i25517
+
+/** 2<sup>29</sup> 2<sup>30</sup> */
+class SupDefault
+
+/** 2<sup>29</sup> 2<sup>30</sup>
+ * @syntax wiki
+ */
+class SupWiki
+
+/** 2<sup>29</sup> 2<sup>30</sup>
+ * @syntax markdown
+ */
+class SupMarkdown
+
+/** 2^29 2^30 */
+class CaretDefault
+
+/** 2^29 2^30
+ * @syntax wiki
+ */
+class CaretWiki
+
+/** 2^29^ 2^30^
+ * @syntax wiki
+ */
+class PairedCaretWiki

--- a/scaladoc/src/dotty/tools/scaladoc/renderers/DocRenderer.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/renderers/DocRenderer.scala
@@ -83,8 +83,8 @@ class DocRender(signatureRenderer: SignatureRenderer)(using DocContext):
     case Underline(text) => span(cls:="underline")(renderElement(text))
     case Bold(text) => strong(renderElement(text))
     case Monospace(text) => code(renderElement(text))
-    case Superscript(text) => span(cls:="superscript")(renderElement(text))  // TODO implement style
-    case Subscript(text) => span(cls:="subscript")(renderElement(text))  // TODO implement style
+    case Superscript(text) => sup(renderElement(text))
+    case Subscript(text) => sub(renderElement(text))
     case Link(target, body) =>
       renderLink(target, default => body.fold[TagArg](default)(renderElement))
     case Text(text) => raw(text.escapeReservedTokens)

--- a/scaladoc/src/dotty/tools/scaladoc/util/html.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/util/html.scala
@@ -91,6 +91,8 @@ object HTML:
   val tr = Tag("tr")
   val td = Tag("td")
   val section = Tag("section")
+  val sup = Tag("sup")
+  val sub = Tag("sub")
 
   val cls = Attr("class")
   val href = Attr("href")

--- a/scaladoc/test/dotty/tools/scaladoc/tasty/comments/CaretTest.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/tasty/comments/CaretTest.scala
@@ -1,0 +1,50 @@
+package dotty.tools.scaladoc
+package tasty
+package comments
+
+import org.junit.Test
+import org.junit.Assert._
+import java.nio.file.Files
+
+/** Test that `<sup>` tags render correctly in both wiki and markdown modes,
+  * and that `^` in wiki mode creates a `<span class="superscript">`.
+  *
+  * See https://github.com/scala/scala3/issues/25517
+  */
+class CaretTest extends BaseHtmlTest:
+
+  private def docHtml(cls: String, syntax: String = "markdown"): String =
+    val dest = Files.createTempDirectory("test-doc").toFile
+    try
+      val args = Scaladoc.Args(
+        name = projectName,
+        tastyFiles = tastyFiles("i25517"),
+        output = dest,
+        projectVersion = Some(projectVersion),
+        defaultSyntax = List(syntax),
+      )
+      Scaladoc.run(args)(using testContext)
+      val path = dest.toPath.resolve(s"tests/i25517/$cls.html")
+      val doc = org.jsoup.Jsoup.parse(dotty.tools.scaladoc.util.IO.read(path))
+      doc.select(".doc").html()
+    finally dotty.tools.scaladoc.util.IO.delete(dest)
+
+  @Test def supTagsInMarkdown(): Unit =
+    val html = docHtml("SupDefault", "markdown")
+    assertEquals("<p>2<sup>29</sup> 2<sup>30</sup></p>", html)
+
+  @Test def supTagsInWiki(): Unit =
+    val html = docHtml("SupWiki", "wiki")
+    assertTrue(html.contains("2<sup>29</sup>"))
+    assertTrue(html.contains("2<sup>30</sup>"))
+    assertFalse("no broken superscript span", html.contains("superscript"))
+
+  @Test def bareCaretBrokenInWiki(): Unit =
+    val html = docHtml("CaretWiki", "wiki")
+    assertTrue("bare ^ in wiki should create broken superscript",
+      html.contains("<span class=\"superscript\">"))
+
+  @Test def pairedCaretInWiki(): Unit =
+    val html = docHtml("PairedCaretWiki", "wiki")
+    assertTrue(html.contains("2<span class=\"superscript\">29</span>"))
+    assertTrue(html.contains("2<span class=\"superscript\">30</span>"))

--- a/scaladoc/test/dotty/tools/scaladoc/tasty/comments/CaretTest.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/tasty/comments/CaretTest.scala
@@ -7,7 +7,7 @@ import org.junit.Assert._
 import java.nio.file.Files
 
 /** Test that `<sup>` tags render correctly in both wiki and markdown modes,
-  * and that `^` in wiki mode creates a `<span class="superscript">`.
+  * and that `^...^` in wiki mode creates a `<sup>...</sup>`.
   *
   * See https://github.com/scala/scala3/issues/25517
   */
@@ -37,14 +37,12 @@ class CaretTest extends BaseHtmlTest:
     val html = docHtml("SupWiki", "wiki")
     assertTrue(html.contains("2<sup>29</sup>"))
     assertTrue(html.contains("2<sup>30</sup>"))
-    assertFalse("no broken superscript span", html.contains("superscript"))
 
   @Test def bareCaretBrokenInWiki(): Unit =
     val html = docHtml("CaretWiki", "wiki")
-    assertTrue("bare ^ in wiki should create broken superscript",
-      html.contains("<span class=\"superscript\">"))
+    assertTrue(html.contains("<sup>"))
 
   @Test def pairedCaretInWiki(): Unit =
     val html = docHtml("PairedCaretWiki", "wiki")
-    assertTrue(html.contains("2<span class=\"superscript\">29</span>"))
-    assertTrue(html.contains("2<span class=\"superscript\">30</span>"))
+    assertTrue(html.contains("2<sup>29</sup>"))
+    assertTrue(html.contains("2<sup>30</sup>"))


### PR DESCRIPTION
Backports #25645 to the 3.3.8.

PR submitted by the release tooling.
[skip ci]