### PR TITLE
Backport "Use dollar-free param names in stub implementations" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -705,7 +705,7 @@ object RefChecks {
 
         for (member <- missingMethods) {
           def showDclAndLocation(sym: Symbol) =
-            s"${sym.showDcl} in ${sym.owner.showLocated}"
+            s"${sym.mapInfo(replaceSyntheticParamNames).showDcl} in ${sym.owner.showLocated}"
           def undefined(msg: String) =
             abstractClassError(false, s"${showDclAndLocation(member)} is not defined $msg")
           val underlying = member.underlyingSymbol

--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -660,11 +660,27 @@ object RefChecks {
               .distinctBy(_.signature) // Avoid duplication for similar definitions (#19731)
         }
 
+        /** Replace synthetic parameter names (x$0, x$1, ...) with
+         *  dollar-free versions (x0, x1, ...) so that stub implementations
+         *  are directly usable as valid Scala identifiers.
+         */
+        def replaceSyntheticParamNames(tp: Type): Type = tp match
+          case mt: MethodType if mt.allParamNamesSynthetic =>
+            val newNames = mt.paramNames.zipWithIndex.map((_, i) => termName("x" + i))
+            mt.derivedLambdaType(newNames, mt.paramInfos, replaceSyntheticParamNames(mt.resType))
+          case mt: MethodType =>
+            mt.derivedLambdaType(mt.paramNames, mt.paramInfos, replaceSyntheticParamNames(mt.resType))
+          case pt: PolyType =>
+            pt.derivedLambdaType(pt.paramNames, pt.paramInfos, replaceSyntheticParamNames(pt.resType))
+          case _ => tp
+
         def stubImplementations: List[String] = {
           // Grouping missing methods by the declaring class
           val regrouped = missingMethods.groupBy(_.owner).toList
           def membersStrings(members: List[Symbol]) =
-            members.sortBy(_.name.toString).map(_.asSeenFrom(clazz.thisType).showDcl + " = ???")
+            members.sortBy(_.name.toString).map: sym =>
+              val denot = sym.asSeenFrom(clazz.thisType)
+              denot.mapInfo(replaceSyntheticParamNames).showDcl + " = ???"
 
           if (regrouped.tail.isEmpty)
             membersStrings(regrouped.head._2)

--- a/tests/neg/i25531.check
+++ b/tests/neg/i25531.check
@@ -1,0 +1,13 @@
+-- Error: tests/neg/i25531.scala:3:6 -----------------------------------------------------------------------------------
+3 |class Walker extends FileVisitor[Path] {} // error
+  |      ^^^^^^
+  |class Walker needs to be abstract, since:
+  |it has 4 unimplemented members.
+  |/** As seen from class Walker, the missing signatures are as follows.
+  | *  For convenience, these are usable as stub implementations.
+  | */
+  |  def postVisitDirectory(x0: java.nio.file.Path, x1: java.io.IOException): java.nio.file.FileVisitResult = ???
+  |  def preVisitDirectory
+  |  (x0: java.nio.file.Path, x1: java.nio.file.attribute.BasicFileAttributes): java.nio.file.FileVisitResult = ???
+  |  def visitFile(x0: java.nio.file.Path, x1: java.nio.file.attribute.BasicFileAttributes): java.nio.file.FileVisitResult = ???
+  |  def visitFileFailed(x0: java.nio.file.Path, x1: java.io.IOException): java.nio.file.FileVisitResult = ???

--- a/tests/neg/i25531.scala
+++ b/tests/neg/i25531.scala
@@ -1,0 +1,3 @@
+import java.nio.file.*
+
+class Walker extends FileVisitor[Path] {} // error

--- a/tests/neg/i25531b.check
+++ b/tests/neg/i25531b.check
@@ -1,0 +1,4 @@
+-- Error: tests/neg/i25531b.scala:1:6 ----------------------------------------------------------------------------------
+1 |class Rble extends Readable // error
+  |      ^^^^
+  |class Rble needs to be abstract, since def read(x0: java.nio.CharBuffer): Int in trait Readable in package java.lang is not defined 

--- a/tests/neg/i25531b.scala
+++ b/tests/neg/i25531b.scala
@@ -1,0 +1,1 @@
+class Rble extends Readable // error


### PR DESCRIPTION
Backports #25646 to the 3.3.8.

PR submitted by the release tooling.
[skip ci]