### PR TITLE
Backport "Fix "Scala 3.8.3 compiling covariant overrides with separate compilation causes AbstractMethodError at runtime"" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/Bridges.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Bridges.scala
@@ -90,12 +90,15 @@ class Bridges(root: ClassSymbol, thisPhase: DenotTransformer)(using Context) {
       // A bridge might introduce a classcast exception.
       // Example where this was observed: run/i12828a.scala and MapView in stdlib213
       report.log(i"suppress bridge in $root for ${member} in ${member.owner} and ${other.showLocated} since member infos ${site.memberInfo(member)} and ${site.memberInfo(other)} do not match")
-    else if !member.isPublic(using preErasureCtx) && !member.is(Protected) // opt: public or protected are obviously accessible
+    else if member.is(JavaDefined)
+        && !member.isPublic(using preErasureCtx) && !member.is(Protected) // opt: public or protected are obviously accessible
         && !member.isAccessibleFrom(root.thisType)(using preErasureCtx)
     then
       // Don't generate a bridge that would call an inaccessible method.
-      // This can typically happen with Java package-private methods
+      // This can happen with Java package-private methods
       // when a Scala class in a different package extends the Java class.
+      // Scala's private[pkg] methods are compiled as public at the JVM level,
+      // so they don't have this problem (see #25291).
       report.log(i"suppress bridge in $root for inaccessible method ${member.showLocated}")
     else if !bridgeExists then
       addBridge(member, other)

--- a/tests/run/i25291/App_2.scala
+++ b/tests/run/i25291/App_2.scala
@@ -1,0 +1,3 @@
+package other
+
+class App extends pkg.Middle

--- a/tests/run/i25291/Helper_2.scala
+++ b/tests/run/i25291/Helper_2.scala
@@ -1,0 +1,4 @@
+package pkg
+
+object Helper:
+  def callFoo(b: Base): Base = b.foo

--- a/tests/run/i25291/Lib_1.scala
+++ b/tests/run/i25291/Lib_1.scala
@@ -1,0 +1,7 @@
+package pkg
+
+trait Base:
+  private[pkg] def foo: Base
+
+trait Middle extends Base:
+  override private[pkg] def foo: Middle = this

--- a/tests/run/i25291/Test_2.scala
+++ b/tests/run/i25291/Test_2.scala
@@ -1,0 +1,8 @@
+object Test:
+  def main(args: Array[String]): Unit =
+    val app = new other.App
+    // This would throw AbstractMethodError before the fix
+    // because the bridge from Base.foo():Base to Middle.foo():Middle was missing
+    val result = pkg.Helper.callFoo(app)
+    println(s"result eq app: ${result eq app}")
+    assert(result eq app, s"expected app instance but got $result")


### PR DESCRIPTION
Backports #25659 to the 3.3.8.

PR submitted by the release tooling.
[skip ci]