### PR TITLE
Backport "bugfix: Don't add square braces in context bounds" to 3.3 LTS

### DIFF
--- a/presentation-compiler/src/main/dotty/tools/pc/completions/Completions.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/Completions.scala
@@ -86,6 +86,11 @@ class Completions(
       case Ident(_) :: (templ: untpd.DerivingTemplate) :: _ =>
         val pos = completionPos.toSourcePosition
         !templ.derived.exists(_.sourcePos.contains(pos))
+        /* In case of `def demo[F[_]: TC@@]` or `def demo[F[_]: {TC1, TC@@}]`
+         * we shouldn't add `[]` as we are in a context bound position.
+         */
+      case Ident(_) :: (_: untpd.ContextBounds) :: _ => false
+      case Ident(_) :: (_: untpd.AppliedTypeTree) :: (_: untpd.ContextBounds) :: _ => false
       case _ => true)
 
   private lazy val isNew: Boolean = Completion.isInNewContext(adjustedPath)

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
@@ -1938,8 +1938,8 @@ class CompletionSuite extends BaseCompletionSuite:
         |  extension [T: Orde@@]
         |}
         |""".stripMargin,
-      """Ordered[T] scala.math
-        |Ordering[T] scala.math
+      """Ordered scala.math
+        |Ordering scala.math
         |""".stripMargin,
       topLines = Some(2)
     )
@@ -1951,8 +1951,8 @@ class CompletionSuite extends BaseCompletionSuite:
         |  extension [T: Ordering: Orde@@]
         |}
         |""".stripMargin,
-      """Ordered[T] scala.math
-        |Ordering[T] scala.math
+      """Ordered scala.math
+        |Ordering scala.math
         |""".stripMargin,
       topLines = Some(2)
     )
@@ -2251,4 +2251,14 @@ class CompletionSuite extends BaseCompletionSuite:
         |case class Miau(y: Int) derives Ordering, CanEqu@@
         |""".stripMargin,
       "CanEqual scala"
+    )
+
+  @Test def `context-bound-no-square-brackets` =
+    check(
+      """|trait Applicative[F[_]]
+         |trait Monadic[F[_]]
+         |
+         |def demo[F[_]: Applicative: Mona@@]: Unit = ???
+         |""".stripMargin,
+      "Monadic test"
     )


### PR DESCRIPTION
Backports #25798 to the 3.3.8.

PR submitted by the release tooling.
[skip ci]