### PR TITLE
Backport "Ensure mistakes in CI inputs are caught early" to 3.3 LTS

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -702,7 +702,7 @@ jobs:
 
       # Extract the release tag
       - name: Extract the release tag
-        run : echo "RELEASE_TAG=${GITHUB_REF#*refs/tags/}" >> $GITHUB_ENV
+        run : echo "RELEASE_TAG='${GITHUB_REF#*refs/tags/}'" >> $GITHUB_ENV
 
       - name: Check compiler version
         shell: bash

--- a/.github/workflows/publish-chocolatey.yml
+++ b/.github/workflows/publish-chocolatey.yml
@@ -35,4 +35,7 @@ jobs:
         with:
           name: scala.nupkg
       - name: Publish the package to Chocolatey
-        run: choco push scala.${{inputs.version}}.nupkg --source https://push.chocolatey.org/ --api-key ${{ secrets.API-KEY }}
+        env:
+          VERSION: ${{ inputs.version }}
+          KEY: ${{ secrets.API-KEY }}
+        run: choco push "scala.$VERSION.nupkg" --source https://push.chocolatey.org/ --api-key "$KEY"

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -56,8 +56,10 @@ jobs:
     steps:
       - name: Compute the SHA256 of scala3-${{ inputs.version }}.zip in GitHub Release
         id: digest
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
-          curl -o artifact.zip -L https://github.com/scala/scala3/releases/download/${{ inputs.version }}/scala3-${{ inputs.version }}.zip
+          curl -o artifact.zip -L "https://github.com/scala/scala3/releases/download/$VERSION/scala3-$VERSION.zip"
           echo "digest=$(sha256sum artifact.zip | cut -d " " -f 1)" >> "$GITHUB_OUTPUT"
 
   build-chocolatey:


### PR DESCRIPTION
Backports #25677 to the 3.3.8.

PR submitted by the release tooling.
[skip ci]