### PR TITLE
Backport "Don't pop outermost region when skipping" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -367,7 +367,7 @@ object Scanners {
         }
       case OUTDENT =>
         currentRegion match
-          case r: Indented => currentRegion = r.enclosing
+          case r: Indented if !r.isOutermost => currentRegion = r.enclosing
           case _ =>
       case STRINGLIT =>
         currentRegion match {

--- a/tests/neg/i25683.scala
+++ b/tests/neg/i25683.scala
@@ -1,0 +1,9 @@
+object OptionExample {
+  def f(x: Any) = ()
+  def example = {
+    f(
+      if (
+        false
+      )
+    ) // error
+    val someVal // error


### PR DESCRIPTION
Backports #25738 to the 3.3.8.

PR submitted by the release tooling.
[skip ci]