### PR TITLE
Backport "Context bound always has a span" to 3.3 LTS

### DIFF
--- a/tests/neg/i25456.check
+++ b/tests/neg/i25456.check
@@ -1,0 +1,22 @@
+-- [E040] Syntax Error: tests/neg/i25456.scala:6:41 --------------------------------------------------------------------
+6 |  def generate[F[_]: { ApplicativeError[_[?], ?] }]: Int = 1 // error // error // error // nopos-error
+  |                                         ^
+  |                                         ']' expected, but '[' found
+-- [E035] Syntax Error: tests/neg/i25456.scala:6:46 --------------------------------------------------------------------
+6 |  def generate[F[_]: { ApplicativeError[_[?], ?] }]: Int = 1 // error // error // error // nopos-error
+  |                                              ^
+  |                                              Unbound wildcard type
+  |
+  | longer explanation available when compiling with `-explain`
+-- [E019] Syntax Error: tests/neg/i25456.scala:6:48 --------------------------------------------------------------------
+6 |  def generate[F[_]: { ApplicativeError[_[?], ?] }]: Int = 1 // error // error // error // nopos-error
+  |                                                ^
+  |                                                Missing return type
+  |
+  | longer explanation available when compiling with `-explain`
+-- Warning: tests/neg/i25456.scala:6:40 --------------------------------------------------------------------------------
+6 |  def generate[F[_]: { ApplicativeError[_[?], ?] }]: Int = 1 // error // error // error // nopos-error
+  |                                        ^
+  |                               `_` is deprecated for wildcard arguments of types: use `?` instead
+  |                               This construct can be rewritten automatically under -rewrite -source 3.4-migration.
+No warnings can be incurred under -Werror

--- a/tests/neg/i25716.scala
+++ b/tests/neg/i25716.scala
@@ -1,0 +1,8 @@
+def g[@inline x: _](y: x): Unit = () // error: Unbound wildcard type
+
+trait F[A]
+trait G[A]
+def ok[A: {F, G}](a: A): Unit = () // error
+def f0[A: {F, _}](a: A): Unit = () // error
+def f1[A: {_, G}](a: A): Unit = () // error
+def f2[A: {_, _}](a: A): Unit = () // error


### PR DESCRIPTION
Backports #25809 to the 3.3.8.

PR submitted by the release tooling.
[skip ci]