### PR TITLE
Backport "Don't lookahead from interpolation" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/tasty/TastyPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TastyPrinter.scala
@@ -11,14 +11,9 @@ import TastyUnpickler.*
 import util.Spans.offsetToInt
 import dotty.tools.tasty.TastyFormat.{ASTsSection, PositionsSection, CommentsSection}
 import java.nio.file.{Files, Paths}
-import dotty.tools.io.{JarArchive, Path}
+import dotty.tools.io.{AbstractFile, JarArchive, Path}
 import dotty.tools.tasty.TastyFormat.header
 
-import java.nio.file.{Files, Paths}
-import dotty.tools.io.{JarArchive, Path, PlainFile}
-import dotty.tools.tasty.TastyFormat.header
-
-import scala.collection.immutable.BitSet
 import scala.compiletime.uninitialized
 import dotty.tools.tasty.TastyBuffer.Addr
 
@@ -55,8 +50,11 @@ object TastyPrinter:
           System.exit(1)
       else if arg.endsWith(".jar") then
         val jar = JarArchive.open(Path(arg), create = false)
+        def tastyFiles(file: AbstractFile): Iterator[AbstractFile] =
+          if file.isDirectory then file.iterator().flatMap(tastyFiles)
+          else Iterator.single(file).filter(_.name.endsWith(".tasty"))
         try
-          for file <- jar.allFileNames().map(f => new PlainFile(Path(f))) if file.name.endsWith(".tasty") do
+          for file <- tastyFiles(jar) do
             printTasty(s"$arg ${file.path}", file.toByteArray)
         finally jar.close()
       else

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -3461,7 +3461,7 @@ object Parsers {
                 syntaxError(em"`using` expected")
               val (firstParamMod, isParams) =
                 var mods = EmptyModifiers
-                if in.lookahead.isColon then
+                if in.token != INTERPOLATIONID && in.lookahead.isColon then
                   (mods, true)
                 else
                   if isErased then mods = addModifier(mods)

--- a/compiler/test/dotty/tools/dotc/core/tasty/TastyUnpickerTest.scala
+++ b/compiler/test/dotty/tools/dotc/core/tasty/TastyUnpickerTest.scala
@@ -13,11 +13,7 @@ class TastyUnpickerTest {
     val base = new ContextBase
     given Context = base.initialCtx.fresh
     val bytesArray = bytes.map(_.toByte).toArray
-    val dotty = new DottyUnpickler(
-      tastyFile = new VirtualFile("bytes.tasty", bytesArray),
-      bytes = bytesArray,
-      isBestEffortTasty = false
-    )
+    val dotty = new DottyUnpickler(bytes = bytesArray)
     dotty.enter(roots = Set.empty)
     dotty.rootTrees.foreach(t => t.foreachSubTree(identity))
 

--- a/tests/neg/i25717.scala
+++ b/tests/neg/i25717.scala
@@ -1,0 +1,9 @@
+import scala.quoted.*
+
+object Crash {
+  def macroImpl(using Quotes)(q"a: String"): Expr[Boolean] = ??? // error
+
+  def f(s"a: String") = ??? // error
+
+  def softie(into q"a: String") = ??? // error
+}

--- a/tests/old-tasty-interpreter-prototype/Test.scala
+++ b/tests/old-tasty-interpreter-prototype/Test.scala
@@ -17,7 +17,7 @@ object Test {
     // Artefact of the current test infrastructure
     // TODO improve infrastructure to avoid needing this code on each test
     val classpath = dotty.tools.dotc.util.ClasspathFromClassloader(this.getClass.getClassLoader).split(java.io.File.pathSeparator).find(_.contains("runWithCompiler")).get
-    val allTastyFiles = dotty.tools.io.Path(classpath).walkFilter(_.ext == dotty.tools.io.FileExtension.Tasty).map(_.toString).toList
+    val allTastyFiles = dotty.tools.io.Path(classpath).walkFilter(_.extension == "tasty").map(_.toString).toList
 
     val actualOutput = interpret(allTastyFiles.filter(x => x.contains("IntepretedMain") || x.contains("InterpretedBar")))
     val expectedOutput =
@@ -96,7 +96,7 @@ object Test {
 
     // Artefact of the current test infrastructure
     // TODO improve infrastructure to avoid needing this code on each test
-    val allTastyFiles = dotty.tools.io.Path(out).walkFilter(_.ext == dotty.tools.io.FileExtension.Tasty).map(_.toString).toList
+    val allTastyFiles = dotty.tools.io.Path(out).walkFilter(_.extension == "tasty").map(_.toString).toList
 
     val actualOutput = interpret(allTastyFiles.filter(_.endsWith("Test.tasty")))
 

--- a/tests/run-tasty-inspector/i10359.scala
+++ b/tests/run-tasty-inspector/i10359.scala
@@ -25,7 +25,7 @@ object Test {
     // Artefact of the current test infrastructure
     // TODO improve infrastructure to avoid needing this code on each test
     val classpath = dotty.tools.dotc.util.ClasspathFromClassloader(this.getClass.getClassLoader).split(java.io.File.pathSeparator).find(_.contains("runWithCompiler")).get
-    val allTastyFiles = dotty.tools.io.Path(classpath).walkFilter(_.ext == dotty.tools.io.FileExtension.Tasty).map(_.toString).toList
+    val allTastyFiles = dotty.tools.io.Path(classpath).walkFilter(_.extension == "tasty").map(_.toString).toList
     val tastyFiles = allTastyFiles.filter(_.contains("TraitParams"))
 
     val inspect = new TestInspector()

--- a/tests/run-tasty-inspector/i13352.scala
+++ b/tests/run-tasty-inspector/i13352.scala
@@ -5,7 +5,7 @@ import scala.tasty.inspector.*
   // Artefact of the current test infrastructure
   // TODO improve infrastructure to avoid needing this code on each test
   val classpath = dotty.tools.dotc.util.ClasspathFromClassloader(this.getClass.getClassLoader).split(java.io.File.pathSeparator).find(_.contains("runWithCompiler")).get
-  val allTastyFiles = dotty.tools.io.Path(classpath).walkFilter(_.ext == dotty.tools.io.FileExtension.Tasty).map(_.toString).toList
+  val allTastyFiles = dotty.tools.io.Path(classpath).walkFilter(_.extension == "tasty").map(_.toString).toList
   val tastyFiles = allTastyFiles.filter(_.contains("CanEqual2"))
 
   TastyInspector.inspectTastyFiles(tastyFiles)(new MyInspector)

--- a/tests/run-tasty-inspector/i14027.scala
+++ b/tests/run-tasty-inspector/i14027.scala
@@ -18,7 +18,7 @@ object Test {
     // Artefact of the current test infrastructure
     // TODO improve infrastructure to avoid needing this code on each test
     val classpath = dotty.tools.dotc.util.ClasspathFromClassloader(this.getClass.getClassLoader).split(java.io.File.pathSeparator).find(_.contains("runWithCompiler")).get
-    val allTastyFiles = dotty.tools.io.Path(classpath).walkFilter(_.ext == dotty.tools.io.FileExtension.Tasty).map(_.toString).toList
+    val allTastyFiles = dotty.tools.io.Path(classpath).walkFilter(_.extension == "tasty").map(_.toString).toList
     val tastyFiles = allTastyFiles.filter(_.contains("MyTest"))
 
     val inspect = new TestInspector()

--- a/tests/run-tasty-inspector/i14788.scala
+++ b/tests/run-tasty-inspector/i14788.scala
@@ -12,7 +12,7 @@ import scala.tasty.inspector.*
   // Artefact of the current test infrastructure
   // TODO improve infrastructure to avoid needing this code on each test
   val classpath = dotty.tools.dotc.util.ClasspathFromClassloader(this.getClass.getClassLoader).split(java.io.File.pathSeparator).find(_.contains("runWithCompiler")).get
-  val allTastyFiles = dotty.tools.io.Path(classpath).walkFilter(_.ext == dotty.tools.io.FileExtension.Tasty).map(_.toString).toList
+  val allTastyFiles = dotty.tools.io.Path(classpath).walkFilter(_.extension == "tasty").map(_.toString).toList
   val tastyFiles = allTastyFiles.filter(_.contains("MySeq"))
 
   TastyInspector.inspectTastyFiles(tastyFiles)(new MyInspector)

--- a/tests/run-tasty-inspector/i14789.scala
+++ b/tests/run-tasty-inspector/i14789.scala
@@ -5,7 +5,7 @@ import scala.tasty.inspector.*
   // Artefact of the current test infrastructure
   // TODO improve infrastructure to avoid needing this code on each test
   val classpath = dotty.tools.dotc.util.ClasspathFromClassloader(this.getClass.getClassLoader).split(java.io.File.pathSeparator).find(_.contains("runWithCompiler")).get
-  val allTastyFiles = dotty.tools.io.Path(classpath).walkFilter(_.ext == dotty.tools.io.FileExtension.Tasty).map(_.toString).toList
+  val allTastyFiles = dotty.tools.io.Path(classpath).walkFilter(_.extension == "tasty").map(_.toString).toList
   val tastyFiles = allTastyFiles.filter(_.contains("App"))
 
   // in dotty-example-project

--- a/tests/run-tasty-inspector/i8163.scala
+++ b/tests/run-tasty-inspector/i8163.scala
@@ -13,7 +13,7 @@ object Test {
     // Artefact of the current test infrastructure
     // TODO improve infrastructure to avoid needing this code on each test
     val classpath = dotty.tools.dotc.util.ClasspathFromClassloader(this.getClass.getClassLoader).split(java.io.File.pathSeparator).find(_.contains("runWithCompiler")).get
-    val allTastyFiles = dotty.tools.io.Path(classpath).walkFilter(_.ext == dotty.tools.io.FileExtension.Tasty).map(_.toString).toList
+    val allTastyFiles = dotty.tools.io.Path(classpath).walkFilter(_.extension == "tasty").map(_.toString).toList
     val tastyFiles = allTastyFiles.filter(_.contains("I8163"))
 
     TastyInspector.inspectTastyFiles(tastyFiles)(new TestInspector())

--- a/tests/run-tasty-inspector/i8389.scala
+++ b/tests/run-tasty-inspector/i8389.scala
@@ -5,7 +5,7 @@ import scala.tasty.inspector.*
   // Artefact of the current test infrastructure
   // TODO improve infrastructure to avoid needing this code on each test
   val classpath = dotty.tools.dotc.util.ClasspathFromClassloader(this.getClass.getClassLoader).split(java.io.File.pathSeparator).find(_.contains("runWithCompiler")).get
-  val allTastyFiles = dotty.tools.io.Path(classpath).walkFilter(_.ext == dotty.tools.io.FileExtension.Tasty).map(_.toString).toList
+  val allTastyFiles = dotty.tools.io.Path(classpath).walkFilter(_.extension == "tasty").map(_.toString).toList
   val tastyFiles = allTastyFiles.filter(_.contains("TraitParams"))
 
   // in dotty-example-project

--- a/tests/run-tasty-inspector/i8460.scala
+++ b/tests/run-tasty-inspector/i8460.scala
@@ -18,7 +18,7 @@ object Test {
     // Artefact of the current test infrastructure
     // TODO improve infrastructure to avoid needing this code on each test
     val classpath = dotty.tools.dotc.util.ClasspathFromClassloader(this.getClass.getClassLoader).split(java.io.File.pathSeparator).find(_.contains("runWithCompiler")).get
-    val allTastyFiles = dotty.tools.io.Path(classpath).walkFilter(_.ext == dotty.tools.io.FileExtension.Tasty).map(_.toString).toList
+    val allTastyFiles = dotty.tools.io.Path(classpath).walkFilter(_.extension == "tasty").map(_.toString).toList
     val tastyFiles = allTastyFiles.filter(_.contains("TraitParams"))
 
     // Tasty Scala Class

--- a/tests/run-tasty-inspector/i9970.scala
+++ b/tests/run-tasty-inspector/i9970.scala
@@ -37,7 +37,7 @@ object Test {
     // Artefact of the current test infrastructure
     // TODO improve infrastructure to avoid needing this code on each test
     val classpath = dotty.tools.dotc.util.ClasspathFromClassloader(this.getClass.getClassLoader).split(java.io.File.pathSeparator).find(_.contains("runWithCompiler")).get
-    val allTastyFiles = dotty.tools.io.Path(classpath).walkFilter(_.ext == dotty.tools.io.FileExtension.Tasty).map(_.toString).toList
+    val allTastyFiles = dotty.tools.io.Path(classpath).walkFilter(_.extension == "tasty").map(_.toString).toList
     val tastyFiles = allTastyFiles.filter(_.contains("I9970"))
 
     TastyInspector.inspectTastyFiles(tastyFiles)(new TestInspector())

--- a/tests/run-tasty-inspector/tasty-documentation-inspector/Test.scala
+++ b/tests/run-tasty-inspector/tasty-documentation-inspector/Test.scala
@@ -6,7 +6,7 @@ object Test {
       // Artefact of the current test infrastructure
     // TODO improve infrastructure to avoid needing this code on each test
     val classpath = dotty.tools.dotc.util.ClasspathFromClassloader(this.getClass.getClassLoader).split(java.io.File.pathSeparator).find(_.contains("runWithCompiler")).get
-    val allTastyFiles = dotty.tools.io.Path(classpath).walkFilter(_.ext == dotty.tools.io.FileExtension.Tasty).map(_.toString).toList
+    val allTastyFiles = dotty.tools.io.Path(classpath).walkFilter(_.extension == "tasty").map(_.toString).toList
     val tastyFiles = allTastyFiles.filter(_.contains("Foo"))
 
     TastyInspector.inspectTastyFiles(tastyFiles)(new DocumentationInspector())

--- a/tests/run-tasty-inspector/tasty-inspector/Test.scala
+++ b/tests/run-tasty-inspector/tasty-inspector/Test.scala
@@ -6,7 +6,7 @@ object Test {
     // Artefact of the current test infrastructure
     // TODO improve infrastructure to avoid needing this code on each test
     val classpath = dotty.tools.dotc.util.ClasspathFromClassloader(this.getClass.getClassLoader).split(java.io.File.pathSeparator).find(_.contains("runWithCompiler")).get
-    val allTastyFiles = dotty.tools.io.Path(classpath).walkFilter(_.ext == dotty.tools.io.FileExtension.Tasty).map(_.toString).toList
+    val allTastyFiles = dotty.tools.io.Path(classpath).walkFilter(_.extension == "tasty").map(_.toString).toList
     val tastyFiles = allTastyFiles.filter(_.contains("Foo"))
 
     TastyInspector.inspectTastyFiles(tastyFiles)(new DBInspector())

--- a/tests/run-tasty-inspector/tastyPaths.scala
+++ b/tests/run-tasty-inspector/tastyPaths.scala
@@ -15,7 +15,7 @@ object Test {
     // Artefact of the current test infrastructure
     // TODO improve infrastructure to avoid needing this code on each test
     val classpath = dotty.tools.dotc.util.ClasspathFromClassloader(this.getClass.getClassLoader).split(java.io.File.pathSeparator).find(_.contains("runWithCompiler")).get
-    val allTastyFiles = dotty.tools.io.Path(classpath).walkFilter(_.ext == dotty.tools.io.FileExtension.Tasty).map(_.toString).toList
+    val allTastyFiles = dotty.tools.io.Path(classpath).walkFilter(_.extension == "tasty").map(_.toString).toList
     val tastyFiles = allTastyFiles.filter(_.contains("I8163"))
 
     TastyInspector.inspectTastyFiles(tastyFiles)(new TestInspector())


### PR DESCRIPTION
Backports #25834 to the 3.3.8.

PR submitted by the release tooling.