### PR TITLE
Backport "Regression test" to 3.3 LTS

### DIFF
--- a/tests/pos/i15881/J.java
+++ b/tests/pos/i15881/J.java
@@ -1,0 +1,3 @@
+public abstract class J {
+        public abstract int f(int i);
+}

--- a/tests/pos/i15881/K.java
+++ b/tests/pos/i15881/K.java
@@ -1,0 +1,3 @@
+public interface K {
+        int f(int i);
+}

--- a/tests/pos/i15881/s.scala
+++ b/tests/pos/i15881/s.scala
@@ -1,0 +1,14 @@
+class C {
+  def f(j: J): Int = j.f(42)
+  def g(k: K): Int = k.f(17)
+}
+object Test extends App {
+  def bump(i: Int): Int = i + 1
+  val c = new C
+  println {(
+    c.f((i: Int) => i + 1),
+    c.g((i: Int) => i + 1),
+    c.f(bump),
+    c.g(bump),
+  )}
+}


### PR DESCRIPTION
Backports #25685 to the 3.3.8.

PR submitted by the release tooling.
[skip ci]