### PR TITLE
Backport "Fix Java signatures for arrays of value classes" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/GenericSignatures.scala
+++ b/compiler/src/dotty/tools/dotc/transform/GenericSignatures.scala
@@ -5,7 +5,6 @@ package transform
 import core.Annotations.*
 import core.Contexts.*
 import core.Phases.*
-import core.Decorators.*
 import core.Definitions
 import core.Flags.*
 import core.Names.Name
@@ -15,8 +14,6 @@ import core.TypeErasure.{erasedGlb, erasure, fullErasure, isGenericArrayElement,
 import core.Types.*
 import core.classfile.ClassfileConstants
 
-import config.Printers.transforms
-import reporting.trace
 import java.lang.StringBuilder
 
 import scala.collection.mutable.ListBuffer
@@ -64,11 +61,11 @@ object GenericSignatures {
       ps.foreach(boxedSig)
     }
 
-    def boxedSig(tp: Type): Unit = jsig(tp.widenDealias, unboxedVCs = false)
+    def boxedSig(tp: Type): Unit = jsig(tp.widenDealias, vcBoxing = ValueClassBoxing.Box)
 
     /** The signature of the upper-bound of a type parameter.
      *
-     *  @pre none of the bounds are themselves type parameters.
+     *  @note precondition: none of the bounds are themselves type parameters.
      *       TODO: Remove this restriction so we can support things like:
      *
      *           class Foo[A]:
@@ -174,6 +171,7 @@ object GenericSignatures {
     }
 
     def classSig(sym: Symbol, pre: Type = NoType, args: List[Type] = Nil): Unit = {
+      @tailrec
       def argSig(tp: Type): Unit =
         tp match {
           case bounds: TypeBounds =>
@@ -231,20 +229,23 @@ object GenericSignatures {
       builder.append(';')
     }
 
+    enum ValueClassBoxing:
+      case Box, Unbox, UnboxOnlyPrimitives
+
     @noinline
-    def jsig(tp0: Type, toplevel: Boolean = false, unboxedVCs: Boolean = true): Unit = {
-      inline def jsig1(tp0: Type): Unit = jsig(tp0, toplevel = false, unboxedVCs = true)
+    def jsig(tp0: Type, toplevel: Boolean = false, vcBoxing: ValueClassBoxing = ValueClassBoxing.Unbox): Unit = {
+      inline def jsig1(tp0: Type): Unit = jsig(tp0)
 
       val tp = tp0.dealias
       tp match {
         case RefinedType(parent, _, _) =>
-          jsig(parent, toplevel = toplevel, unboxedVCs = unboxedVCs)
+          jsig(parent, toplevel = toplevel, vcBoxing = vcBoxing)
 
         case ref @ TypeParamRef(_: PolyType, _) =>
           val erasedUnderlying = fullErasure(ref.underlying.bounds.hi)
           // don't emit type param name if the param is upper-bounded by a primitive type (including via a value class)
           if erasedUnderlying.isPrimitiveValueType then
-            jsig(erasedUnderlying, toplevel = toplevel, unboxedVCs = unboxedVCs)
+            jsig(erasedUnderlying, toplevel = toplevel, vcBoxing = vcBoxing)
           else typeParamSig(ref.paramName.lastPart)
 
         case ref: TermRef if ref.symbol.isGetter =>
@@ -255,7 +256,7 @@ object GenericSignatures {
           // Since the TermRef originally intended to capture the underlying type of a `val`,
           // we recover that information by directly checking the resultType of the getter.
           // See `tests/run/i24553.scala` for an example
-          jsig(ref.info.resultType, toplevel = toplevel, unboxedVCs = unboxedVCs)
+          jsig(ref.info.resultType, toplevel = toplevel, vcBoxing = vcBoxing)
 
         case defn.ArrayOf(elemtp) =>
           if (isGenericArrayElement(elemtp, isScala2 = false))
@@ -264,7 +265,10 @@ object GenericSignatures {
             builder.append(ClassfileConstants.ARRAY_TAG)
             elemtp match
               case TypeBounds(lo, hi) => jsig1(hi.widenDealias)
-              case _ => jsig1(elemtp)
+              // derived VCs are not unboxed inside arrays,
+              // i.e., `Array[VC]` where `class VC(n: X) extends AnyVal`
+              // is `[LVC;`, not `[LX;`
+              case _ => jsig(elemtp, vcBoxing = ValueClassBoxing.UnboxOnlyPrimitives)
 
         case RefOrAppliedType(sym, pre, args) =>
           if (sym == defn.PairClass && tupleArity(tp) > Definitions.MaxTupleArity)
@@ -282,13 +286,15 @@ object GenericSignatures {
           else if (sym == defn.NullClass)
             builder.append("Lscala/runtime/Null$;")
           else if (sym.isPrimitiveValueClass)
-            if (!unboxedVCs) jsig1(defn.ObjectType)
+            // TODO, but a few tests need fixing / disabling until a newer scalac is ingested,
+            // replace the next 2 lines with: if (vcBoxing == ValueClassBoxing.Box || sym == defn.UnitClass) jsig1(defn.boxedClass(sym).typeRef)
+            if (vcBoxing == ValueClassBoxing.Box) jsig1(defn.ObjectType)
             else if (sym == defn.UnitClass) jsig1(defn.BoxedUnitClass.typeRef)
             else builder.append(defn.typeTag(sym.info))
           else if (sym.isDerivedValueClass) {
-            if (unboxedVCs) {
+            if (vcBoxing == ValueClassBoxing.Unbox) {
               val erasedUnderlying = fullErasure(tp)
-              jsig(erasedUnderlying, toplevel = toplevel, unboxedVCs = true)
+              jsig(erasedUnderlying, toplevel = toplevel)
             } else classSig(sym, pre, args)
           }
           else if (defn.isSyntheticFunctionClass(sym)) {
@@ -298,7 +304,7 @@ object GenericSignatures {
           else if sym.isClass then
             classSig(sym, pre, args)
           else
-            jsig(erasure(tp), toplevel = toplevel, unboxedVCs = unboxedVCs)
+            jsig(erasure(tp), toplevel = toplevel, vcBoxing = vcBoxing)
 
         case ExprType(restpe) if toplevel =>
           builder.append("()")
@@ -341,7 +347,7 @@ object GenericSignatures {
         case tp: AndType =>
           // Only intersections appearing as the upper-bound of a type parameter
           // can be preserved in generic signatures and those are already
-          // handled by `boundsSig`, so here we fallback to picking a parent of
+          // handled by `boundsSig`, so here we fall back to picking a parent of
           // the intersection to determine its overall signature. We must pick a
           // parent whose erasure matches the erasure of the intersection
           // because javac relies on the generic signature to determine the
@@ -351,7 +357,7 @@ object GenericSignatures {
           val (reprParents, _) = splitIntersection(parents)
           val repr =
             reprParents.find(_.typeSymbol.is(TypeParam)).getOrElse(reprParents.head)
-          jsig(repr, toplevel = false, unboxedVCs = unboxedVCs)
+          jsig(repr, toplevel = false, vcBoxing = vcBoxing)
 
         case ci: ClassInfo =>
           val tParams = tp.typeParams
@@ -359,15 +365,15 @@ object GenericSignatures {
           superSig(ci.typeSymbol, ci.parents)
 
         case AnnotatedType(atp, _) =>
-          jsig(atp, toplevel, unboxedVCs)
+          jsig(atp, toplevel, vcBoxing)
 
         case hktl: HKTypeLambda =>
-          jsig(hktl.finalResultType, toplevel, unboxedVCs)
+          jsig(hktl.finalResultType, toplevel, vcBoxing)
 
         case _ =>
           val etp = erasure(tp)
           if (etp eq tp) throw new UnknownSig
-          else jsig(etp, toplevel, unboxedVCs)
+          else jsig(etp, toplevel, vcBoxing)
       }
     }
     val throwsArgs = sym0.annotations flatMap ThrownException.unapply

--- a/tests/run/value-class-array-signature.check
+++ b/tests/run/value-class-array-signature.check
@@ -1,2 +1,2 @@
 public void Z.vcARRAY(VC[])
-class [LA;
+class [LVC;

--- a/tests/run/value-class-array-signature.check
+++ b/tests/run/value-class-array-signature.check
@@ -1,0 +1,2 @@
+public void Z.vcARRAY(VC[])
+class [LA;

--- a/tests/run/value-class-array-signature.scala
+++ b/tests/run/value-class-array-signature.scala
@@ -1,0 +1,12 @@
+trait A
+class VC(val self: A) extends AnyVal
+class Z {
+  def vcARRAY(x: Array[VC]): Unit = {}
+}
+
+object Test:
+  def main(args: Array[String]): Unit =
+    classOf[Z].getDeclaredMethods.foreach(m =>
+      println(m)
+      println(m.getGenericParameterTypes().mkString(","))
+    )

--- a/tests/run/value-class-array-signature.scala
+++ b/tests/run/value-class-array-signature.scala
@@ -1,3 +1,6 @@
+// scalajs: --skip
+// (this is a JVM-only test)
+
 trait A
 class VC(val self: A) extends AnyVal
 class Z {


### PR DESCRIPTION
Backports #25631 to the 3.3.8.

PR submitted by the release tooling.
[skip ci]