### PR TITLE
Backport "Fix main build: use vcBoxing instead of unboxedVCs" to 3.3 LTS

### DIFF
--- a/tests/run/value-class-array-signature.scala
+++ b/tests/run/value-class-array-signature.scala
@@ -1,3 +1,6 @@
+// scalajs: --skip
+// (this is a JVM-only test)
+
 trait A
 class VC(val self: A) extends AnyVal
 class Z {


### PR DESCRIPTION
Backports #25710 to the 3.3.8.

PR submitted by the release tooling.
[skip ci]