### PR TITLE
Backport "Restore test" to 3.3 LTS

### DIFF
--- a/tests/disabled/neg/i8984.check
+++ b/tests/disabled/neg/i8984.check
@@ -1,9 +1,0 @@
--- [E007] Type Mismatch Error: tests/neg/i8984.scala:36:52 -------------------------------------------------------------
-36 |            case Cat(_, "red", rest) => dropRedCats(rest)  // error
-   |                                                    ^^^^
-   |                               Found:    (rest : Any)
-   |                               Required: Fix.T[F]
-   |
-   |                               where:    F is a type in method dropRedCats with bounds >: Cat and <: [a] =>> Any
-   |
-   | longer explanation available when compiling with `-explain`

--- a/tests/neg/i8984.scala
+++ b/tests/neg/i8984.scala
@@ -1,8 +1,7 @@
-import scala.annotation.tailrec
 type |@[F[+_], G[+_]] = [a] =>> F[a] | G[a]
 
-object Fix: // error
-  opaque type T[+F[+_]] = ApplyFix.T[F]
+object Fix: // error Cyclic reference involving type T
+  opaque type T[+F[+_]] = ApplyFix.T[F] // error
 
   def apply[F[+_]](f: F[Fix[F]]): T[F] = ApplyFix(f) // error // error
 


### PR DESCRIPTION
Backports #25671 to the 3.3.8.

PR submitted by the release tooling.
[skip ci]