### PR TITLE
Backport "Tweak -Wconf:help for correctness" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -267,12 +267,13 @@ private sealed trait WarningSettings:
          |
          |The default configuration is empty.
          |
-         |User-defined configurations are added to the left. The leftmost rule matching
-         |a warning message defines the action.
+         |The last matching configuration for a diagnostic, in definition order,
+         |determines the action for that diagnostic message.
          |
          |Examples:
          |  - change every warning into an error: -Wconf:any:error
          |  - silence deprecations: -Wconf:cat=deprecation:s
+         |  - error but silence deprecations: -Wall -Wconf:any:e,cat=deprecation:s
          |  - silence a deprecation: -Wconf:origin=java\.lang\.Thread\.getId:s
          |  - silence warnings in src_managed directory: -Wconf:src=src_managed/.*:s
          |


### PR DESCRIPTION
Backports #25615 to the 3.3.8.

PR submitted by the release tooling.
[skip ci]