### PR TITLE
Backport "Fix typo in `transparent`" to 3.3 LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -859,7 +859,7 @@ object desugar {
         }
       }
       if mods.isAllOf(Given | Inline | Transparent) then
-        report.error("inline given instances cannot be trasparent", cdef)
+        report.error("inline given instances cannot be transparent", cdef)
       val classMods = if mods.is(Given) then mods &~ (Inline | Transparent) | Synthetic else mods
       cpy.TypeDef(cdef: TypeDef)(
         name = className,

--- a/compiler/src/dotty/tools/dotc/transform/GenericSignatures.scala
+++ b/compiler/src/dotty/tools/dotc/transform/GenericSignatures.scala
@@ -17,6 +17,7 @@ import core.classfile.ClassfileConstants
 import java.lang.StringBuilder
 
 import scala.collection.mutable.ListBuffer
+import scala.annotation.tailrec
 
 /** Helper object to generate generic java signatures, as defined in
  *  the Java Virtual Machine Specification, §4.3.4


### PR DESCRIPTION
Backports #25753 to the 3.3.8.

PR submitted by the release tooling.